### PR TITLE
Add CI, benchmark artifacts, and documentation for performance tracking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,49 @@
+name: Benchmarks
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - fix/test-suite-and-perf-baseline
+      - ci-artifacts-benchmarks
+    paths:
+      - 'Cargo.toml'
+      - 'crates/ghostlink-core/Cargo.toml'
+      - 'crates/ghostlink-core/src/**'
+      - 'benches/**'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  criterion:
+    name: Run Criterion benchmarks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Criterion benchmarks
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cargo bench -p ghostlink-core --bench criterion -- --warm-up-time 1 --measurement-time 1 | tee artifacts/criterion.log
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-benchmarks
+          path: |
+            artifacts/criterion.log
+            target/criterion
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - fix/test-suite-and-perf-baseline
+      - ci-artifacts-benchmarks
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Format, lint, and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Run workspace tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cargo test --workspace -- --nocapture | tee artifacts/test.log
+
+      - name: Upload test log artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-test-log
+          path: artifacts/test.log
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to Ghost-Link will be documented in this file.
+
+## Unreleased
+
+- Added GitHub Actions CI for formatting, linting, and workspace tests.
+- Added a Criterion benchmark workflow with uploaded benchmark artifacts.
+- Updated the README with CI and benchmark badges plus the latest Criterion results.
+- Added a shared node snapshot cache and cached total VRAM fast path in `ClusterState`.
+- Switched hot readers to the shared snapshot API to reduce read-path overhead.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ghost-Link 🚀
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/ci.yml)
+[![Benchmarks](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/benchmarks.yml/badge.svg?branch=main)](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/benchmarks.yml)
 [![Rust](https://img.shields.io/badge/Rust-1.70+-orange.svg)](https://www.rust-lang.org)
 
 Ghost-Link is an open-source, zero-config LAN fabric that turns spare local GPUs into a shared execution surface for large-model inference and training. The system moves tensors directly over the local wire without forcing workloads through heavy orchestration layers or cloud subscriptions.
@@ -150,37 +152,40 @@ cargo tarpaulin --workspace
 
 ## Performance Baseline
 
-Measured on `x86_64` with `cargo bench` (release profile, optimized). Results from `benches/baseline.rs`:
+Measured on `x86_64` with Criterion (`cargo bench -p ghostlink-core --bench criterion -- --warm-up-time 1 --measurement-time 1`). GitHub Actions uploads the raw benchmark logs and Criterion report directory as artifacts.
+
+### Latest Criterion Run
 
 | Benchmark | Latency | Throughput |
 |---|---|---|
-| Ring buffer push+pop round-trip (ST) | ~6 ns | ~165 M ops/s |
-| Ring buffer push only (ST, full=drain) | ~3 ns | ~323 M ops/s |
-| Ring buffer SPSC cross-thread (10k items) | ~1 250 ns | ~800 K ops/s |
-| Protocol: `DiscoveryFrame` encode | ~137 ns | ~7.3 M ops/s |
-| Protocol: `DiscoveryFrame` decode | ~131 ns | ~7.6 M ops/s |
-| Protocol: encode + decode round-trip | ~233 ns | ~4.3 M ops/s |
-| Planning: 33 layers across 2 nodes | ~169 ns | ~5.9 M ops/s |
-| Planning: 80 layers across 8 nodes | ~344 ns | ~2.9 M ops/s |
-| Cluster: `register` node (update path) | ~195 ns | ~5.1 M ops/s |
-| Cluster: `nodes()` snapshot (10 nodes) | ~680 ns | ~1.5 M ops/s |
-| Cluster: `total_vram_gb()` (10 nodes) | ~13 ns | ~79 M ops/s |
+| Ring buffer push+pop round-trip (ST) | ~2.89-3.03 ns | ~330 M ops/s |
+| Ring buffer push only (ST, full=drain) | ~1.89-1.98 ns | ~518 M ops/s |
+| Protocol: `DiscoveryFrame` encode | ~100.04-103.54 ns | ~9.7 M ops/s |
+| Protocol: `DiscoveryFrame` decode | ~102.50-103.81 ns | ~9.7 M ops/s |
+| Protocol: encode + decode round-trip | ~210.21-219.03 ns | ~4.6 M ops/s |
+| Planning: 33 layers across 2 nodes | ~164.90-170.18 ns | ~5.9 M ops/s |
+| Planning: 80 layers across 8 nodes | ~344.28-354.76 ns | ~2.9 M ops/s |
+| Cluster: `register` node (update path) | ~179.57-186.40 ns | ~5.4 M ops/s |
+| Cluster: `nodes_snapshot()` (10 nodes) | ~9.78-10.28 ns | ~97 M ops/s |
+| Cluster: `total_vram_gb()` (10 nodes) | ~1.59-1.77 ns | ~600 M ops/s |
 
 Run the baseline yourself:
 
 ```bash
-# Build and run bench binary directly (avoids long-running unit tests)
-cargo rustc --release -p ghostlink-core --bench baseline
-./target/release/deps/baseline-*
+# Build and run the Criterion benchmark harness
+cargo bench -p ghostlink-core --bench criterion -- --warm-up-time 1 --measurement-time 1
 ```
 
-> **Note**: The SPSC cross-thread figure includes OS scheduling overhead from `yield_now`. Raw ring buffer latency for the single-threaded path is sub-10 ns.
+> **Note**: The SPSC cross-thread figure includes OS scheduling overhead from `yield_now`. Raw ring buffer latency for the single-threaded path remains sub-3 ns.
+
+Benchmark artifacts are captured automatically in GitHub Actions under the `Benchmarks` workflow.
 
 ## Dependencies
 
 ### Core Dependencies
 - `pin-utils` - Zero-copy pinned allocations
 - `crc32fast` - Fast CRC32 checksums
+- `arc-swap` - Shared, lock-free snapshot reads
 - `thiserror` - Error types
 - `tokio` - Async runtime (for health monitoring)
 - `ratatui` - Terminal UI
@@ -188,6 +193,7 @@ cargo rustc --release -p ghostlink-core --bench baseline
 
 ### Dev Dependencies
 - `tokio-test` - Tokio testing utilities
+- `criterion` - Benchmark harness for hot-path regression tracking
 
 ## Platform Support
 

--- a/benches/baseline.rs
+++ b/benches/baseline.rs
@@ -1,20 +1,23 @@
-/// Performance Baseline for Ghost-Link Primitives
-
-use std::time::Instant;
 use std::sync::Arc;
 use std::thread;
+/// Performance Baseline for Ghost-Link Primitives
+use std::time::Instant;
 
 use ghostlink_core::{
-    ring::{SpscRingBuffer, RingConfig},
-    protocol::{DiscoveryFrame, FrameKind, NodeResources},
     cluster::ClusterState,
     planning::{assign_layers_sequentially, LayerSpec},
+    protocol::{DiscoveryFrame, FrameKind, NodeResources},
+    ring::{RingConfig, SpscRingBuffer},
 };
 
 fn bench(name: &str, iters: u64, mut f: impl FnMut()) -> f64 {
-    for _ in 0..1000_u64.min(iters / 10) { f(); }
+    for _ in 0..1000_u64.min(iters / 10) {
+        f();
+    }
     let start = Instant::now();
-    for _ in 0..iters { f(); }
+    for _ in 0..iters {
+        f();
+    }
     let elapsed = start.elapsed();
     let ns = elapsed.as_nanos() as f64 / iters as f64;
     let ops = 1_000_000_000.0 / ns;
@@ -25,7 +28,10 @@ fn bench(name: &str, iters: u64, mut f: impl FnMut()) -> f64 {
 fn main() {
     println!("\nGhost-Link Performance Baseline");
     println!("================================");
-    println!("{:<52} {:>10}       {:>14}", "Benchmark", "Latency", "Throughput");
+    println!(
+        "{:<52} {:>10}       {:>14}",
+        "Benchmark", "Latency", "Throughput"
+    );
     println!("{}", "-".repeat(82));
 
     // ─── Ring Buffer (single-threaded) ────────────────────────────────────────
@@ -42,7 +48,9 @@ fn main() {
     {
         let ring = SpscRingBuffer::<u64>::new(RingConfig::default());
         bench("ring_buffer: push only (ST, full=drain)", 1_000_000, || {
-            if ring.push(42u64).is_err() { ring.pop(); }
+            if ring.push(42u64).is_err() {
+                ring.pop();
+            }
         });
     }
 
@@ -56,7 +64,9 @@ fn main() {
         let producer = thread::spawn(move || {
             for i in 0..iters {
                 loop {
-                    if prod.push(i).is_ok() { break; }
+                    if prod.push(i).is_ok() {
+                        break;
+                    }
                     thread::yield_now();
                 }
             }
@@ -64,7 +74,11 @@ fn main() {
         let consumer = thread::spawn(move || {
             let mut n = 0u64;
             while n < iters {
-                if cons.pop().is_some() { n += 1; } else { thread::yield_now(); }
+                if cons.pop().is_some() {
+                    n += 1;
+                } else {
+                    thread::yield_now();
+                }
             }
         });
         producer.join().unwrap();
@@ -72,13 +86,18 @@ fn main() {
         let elapsed = start.elapsed();
         let ns = elapsed.as_nanos() as f64 / iters as f64;
         let ops = 1_000_000_000.0 / ns;
-        println!("{:<52} {:>10.2} ns/op  {:>14.0} ops/sec",
-            "ring_buffer: SPSC cross-thread (10k items)", ns, ops);
+        println!(
+            "{:<52} {:>10.2} ns/op  {:>14.0} ops/sec",
+            "ring_buffer: SPSC cross-thread (10k items)", ns, ops
+        );
     }
 
     // ─── Protocol ────────────────────────────────────────────────────────────
     let node = NodeResources::new("bench-node", 24.0, 64.0, "8.9", None);
-    let frame = DiscoveryFrame { kind: FrameKind::Discovery, node };
+    let frame = DiscoveryFrame {
+        kind: FrameKind::Discovery,
+        node,
+    };
 
     bench("protocol: DiscoveryFrame encode", 500_000, || {
         let _ = frame.encode();
@@ -95,22 +114,30 @@ fn main() {
     });
 
     // ─── Layer Assignment Planning ───────────────────────────────────────────
-    let nodes_2: Vec<_> = (0..2).map(|i| {
-        NodeResources::new(format!("node-{}", i), 24.0, 64.0, "8.9", None)
-    }).collect();
-    let layers_33: Vec<LayerSpec> = (0..33).map(|i| LayerSpec {
-        index: i, vram_gb: 1.0, num_weights: 0
-    }).collect();
+    let nodes_2: Vec<_> = (0..2)
+        .map(|i| NodeResources::new(format!("node-{}", i), 24.0, 64.0, "8.9", None))
+        .collect();
+    let layers_33: Vec<LayerSpec> = (0..33)
+        .map(|i| LayerSpec {
+            index: i,
+            vram_gb: 1.0,
+            num_weights: 0,
+        })
+        .collect();
     bench("planning: 33 layers across 2 nodes", 100_000, || {
         let _ = assign_layers_sequentially(&nodes_2, &layers_33);
     });
 
-    let nodes_8: Vec<_> = (0..8).map(|i| {
-        NodeResources::new(format!("node-{}", i), 48.0, 128.0, "9.0", None)
-    }).collect();
-    let layers_80: Vec<LayerSpec> = (0..80).map(|i| LayerSpec {
-        index: i, vram_gb: 1.0, num_weights: 0
-    }).collect();
+    let nodes_8: Vec<_> = (0..8)
+        .map(|i| NodeResources::new(format!("node-{}", i), 48.0, 128.0, "9.0", None))
+        .collect();
+    let layers_80: Vec<LayerSpec> = (0..80)
+        .map(|i| LayerSpec {
+            index: i,
+            vram_gb: 1.0,
+            num_weights: 0,
+        })
+        .collect();
     bench("planning: 80 layers across 8 nodes", 100_000, || {
         let _ = assign_layers_sequentially(&nodes_8, &layers_80);
     });
@@ -124,7 +151,12 @@ fn main() {
     let cluster2 = ClusterState::new();
     for i in 0..10 {
         cluster2.register(NodeResources::new(
-            format!("node-{}", i), 24.0, 64.0, "8.9", None));
+            format!("node-{}", i),
+            24.0,
+            64.0,
+            "8.9",
+            None,
+        ));
     }
     bench("cluster: nodes() snapshot (10 nodes)", 200_000, || {
         let _ = cluster2.nodes();
@@ -134,6 +166,8 @@ fn main() {
     });
 
     println!("{}", "-".repeat(82));
-    println!("\nPlatform: {} | Profile: release (optimized)\n",
-        std::env::consts::ARCH);
+    println!(
+        "\nPlatform: {} | Profile: release (optimized)\n",
+        std::env::consts::ARCH
+    );
 }

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -83,10 +83,20 @@ fn bench_planning(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("planning");
     group.bench_function("33_layers_2_nodes", |b| {
-        b.iter(|| black_box(assign_layers_sequentially(black_box(&nodes_2), black_box(&layers_33))));
+        b.iter(|| {
+            black_box(assign_layers_sequentially(
+                black_box(&nodes_2),
+                black_box(&layers_33),
+            ))
+        });
     });
     group.bench_function("80_layers_8_nodes", |b| {
-        b.iter(|| black_box(assign_layers_sequentially(black_box(&nodes_8), black_box(&layers_80))));
+        b.iter(|| {
+            black_box(assign_layers_sequentially(
+                black_box(&nodes_8),
+                black_box(&layers_80),
+            ))
+        });
     });
     group.finish();
 }

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -1,0 +1,132 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use ghostlink_core::{
+    cluster::ClusterState,
+    planning::{assign_layers_sequentially, LayerSpec},
+    protocol::{DiscoveryFrame, FrameKind, NodeResources},
+    ring::{RingConfig, SpscRingBuffer},
+};
+
+fn bench_ring(c: &mut Criterion) {
+    let ring = SpscRingBuffer::<u64>::new(RingConfig::default());
+    let mut group = c.benchmark_group("ring");
+
+    group.bench_function(BenchmarkId::new("push_pop_round_trip", "st"), |b| {
+        let mut counter = 0u64;
+        b.iter(|| {
+            black_box(ring.push(black_box(counter))).ok();
+            black_box(ring.pop());
+            counter = counter.wrapping_add(1);
+        });
+    });
+
+    group.bench_function(BenchmarkId::new("push_only", "st"), |b| {
+        b.iter(|| {
+            if black_box(ring.push(black_box(42u64))).is_err() {
+                black_box(ring.pop());
+            }
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_protocol(c: &mut Criterion) {
+    let node = NodeResources::new("bench-node", 24.0, 64.0, "8.9", None);
+    let frame = DiscoveryFrame {
+        kind: FrameKind::Discovery,
+        node,
+    };
+    let encoded = frame.encode();
+
+    let mut group = c.benchmark_group("protocol");
+    group.bench_function("encode", |b| {
+        b.iter(|| black_box(frame.encode()));
+    });
+    group.bench_function("decode", |b| {
+        b.iter(|| {
+            let _ = black_box(DiscoveryFrame::decode(black_box(&encoded)));
+        });
+    });
+    group.bench_function("round_trip", |b| {
+        b.iter(|| {
+            let encoded = black_box(frame.encode());
+            let _ = black_box(DiscoveryFrame::decode(&encoded));
+        });
+    });
+    group.finish();
+}
+
+fn bench_planning(c: &mut Criterion) {
+    let nodes_2: Vec<_> = (0..2)
+        .map(|i| NodeResources::new(format!("node-{i}"), 24.0, 64.0, "8.9", None))
+        .collect();
+    let layers_33: Vec<_> = (0..33)
+        .map(|i| LayerSpec {
+            index: i,
+            vram_gb: 1.0,
+            num_weights: 0,
+        })
+        .collect();
+
+    let nodes_8: Vec<_> = (0..8)
+        .map(|i| NodeResources::new(format!("node-{i}"), 48.0, 128.0, "9.0", None))
+        .collect();
+    let layers_80: Vec<_> = (0..80)
+        .map(|i| LayerSpec {
+            index: i,
+            vram_gb: 1.0,
+            num_weights: 0,
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("planning");
+    group.bench_function("33_layers_2_nodes", |b| {
+        b.iter(|| black_box(assign_layers_sequentially(black_box(&nodes_2), black_box(&layers_33))));
+    });
+    group.bench_function("80_layers_8_nodes", |b| {
+        b.iter(|| black_box(assign_layers_sequentially(black_box(&nodes_8), black_box(&layers_80))));
+    });
+    group.finish();
+}
+
+fn bench_cluster(c: &mut Criterion) {
+    let cluster = ClusterState::new();
+    let snapshot_cluster = ClusterState::new();
+    for i in 0..10 {
+        snapshot_cluster.register(NodeResources::new(
+            format!("node-{i}"),
+            24.0,
+            64.0,
+            "8.9",
+            None,
+        ));
+    }
+
+    let mut group = c.benchmark_group("cluster");
+    group.bench_function("register_update", |b| {
+        b.iter_batched(
+            || NodeResources::new("bench", 24.0, 64.0, "8.9", None),
+            |node| cluster.register(node),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("nodes_snapshot_10", |b| {
+        b.iter(|| black_box(snapshot_cluster.nodes_snapshot()));
+    });
+    group.bench_function("total_vram_10", |b| {
+        b.iter(|| black_box(snapshot_cluster.total_vram_gb()));
+    });
+    group.finish();
+}
+
+fn criterion_benches(c: &mut Criterion) {
+    bench_ring(c);
+    bench_protocol(c);
+    bench_planning(c);
+    bench_cluster(c);
+}
+
+criterion_group!(benches, criterion_benches);
+criterion_main!(benches);

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -7,8 +7,8 @@
 
 use anyhow::Result;
 use ghostlink_core::cluster::{ClusterState, NodeMetrics};
+use ghostlink_core::dashboard::Dashboard;
 use ghostlink_core::protocol::NodeResources;
-use ghostlink_core::dashboard::{Dashboard, AsciiDashboard};
 use ghostlink_core::planning::{assign_layers_sequentially, select_quantization_mode, LayerSpec};
 use ghostlink_core::protocol::{DiscoveryFrame, FrameKind};
 
@@ -159,7 +159,7 @@ fn print_dashboard() -> Result<()> {
     });
 
     // Collect nodes metrics for display
-    let nodes_metrics: Vec<NodeMetrics> = cluster.nodes()
+    let nodes_metrics: Vec<NodeMetrics> = cluster.nodes_snapshot()
         .iter()
         .filter_map(|n| cluster.get_metrics(&n.id))
         .collect();
@@ -179,5 +179,5 @@ fn print_dashboard() -> Result<()> {
 
 // Re-export protocol module for use in main.rs
 mod protocol {
-    pub use ghostlink_core::protocol::{GHOSTLINK_ETHERTYPE, PROTOCOL_VERSION};
+    pub use ghostlink_core::protocol::GHOSTLINK_ETHERTYPE;
 }

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1,5 +1,5 @@
 //! Ghost-Link CLI Demo
-//! 
+//!
 //! Command-line interface for demonstrating Ghost-Link primitives:
 //! - `plan` - Generate layer placement plan
 //! - `join` - Broadcast discovery frame to join cluster
@@ -8,8 +8,8 @@
 use anyhow::Result;
 use ghostlink_core::cluster::{ClusterState, NodeMetrics};
 use ghostlink_core::dashboard::Dashboard;
-use ghostlink_core::protocol::NodeResources;
 use ghostlink_core::planning::{assign_layers_sequentially, select_quantization_mode, LayerSpec};
+use ghostlink_core::protocol::NodeResources;
 use ghostlink_core::protocol::{DiscoveryFrame, FrameKind};
 
 fn main() -> Result<()> {
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
     tracing_subscriber::fmt().init();
 
     let mut args = std::env::args().skip(1);
-    
+
     match args.next().as_deref() {
         Some("plan") => print_plan()?,
         Some("join") => print_join(args.next().as_deref().unwrap_or("node-01"))?,
@@ -63,16 +63,16 @@ fn print_plan() -> Result<()> {
 
     // Create sample layers (Llama-7B has ~33 layers)
     let layers: Vec<LayerSpec> = (0..33)
-        .map(|index| LayerSpec { 
-            index, 
+        .map(|index| LayerSpec {
+            index,
             vram_gb: 1.0,
-            num_weights: 0, 
+            num_weights: 0,
         })
         .collect();
 
     // Assign layers sequentially
-    let assignments = assign_layers_sequentially(&nodes, &layers)
-        .map_err(|e| anyhow::anyhow!(e))?;
+    let assignments =
+        assign_layers_sequentially(&nodes, &layers).map_err(|e| anyhow::anyhow!(e))?;
 
     println!("Ghost-Link Layer Placement Plan\n");
     println!("================================\n");
@@ -103,18 +103,11 @@ fn print_join(node_id: &str) -> Result<()> {
     // Create discovery frame with node resources
     let frame = DiscoveryFrame {
         kind: FrameKind::Join,
-        node: NodeResources::new(
-            node_id, 
-            12.0, 
-            32.0, 
-            "8.6".to_string(),
-            None,
-        ),
+        node: NodeResources::new(node_id, 12.0, 32.0, "8.6".to_string(), None),
     };
 
     let encoded = frame.encode();
-    let decoded = DiscoveryFrame::decode(&encoded)
-        .map_err(|e| anyhow::anyhow!(e))?;
+    let decoded = DiscoveryFrame::decode(&encoded).map_err(|e| anyhow::anyhow!(e))?;
 
     println!("Broadcasting Ghost-Link Join Frame\n");
     println!("====================================\n");
@@ -143,8 +136,20 @@ fn print_join(node_id: &str) -> Result<()> {
 fn print_dashboard() -> Result<()> {
     // Create sample cluster state
     let cluster = ClusterState::new();
-    cluster.register(NodeResources::new("NODE-01", 24.0, 64.0, "8.9", Some("RTX4090".to_string())));
-    cluster.register(NodeResources::new("NODE-02", 12.0, 32.0, "8.6", Some("RTX3080".to_string())));
+    cluster.register(NodeResources::new(
+        "NODE-01",
+        24.0,
+        64.0,
+        "8.9",
+        Some("RTX4090".to_string()),
+    ));
+    cluster.register(NodeResources::new(
+        "NODE-02",
+        12.0,
+        32.0,
+        "8.6",
+        Some("RTX3080".to_string()),
+    ));
 
     // Update metrics for each node
     cluster.get_metrics_mut("NODE-01", |metrics| {
@@ -159,18 +164,14 @@ fn print_dashboard() -> Result<()> {
     });
 
     // Collect nodes metrics for display
-    let nodes_metrics: Vec<NodeMetrics> = cluster.nodes_snapshot()
+    let nodes_metrics: Vec<NodeMetrics> = cluster
+        .nodes_snapshot()
         .iter()
         .filter_map(|n| cluster.get_metrics(&n.id))
         .collect();
 
     // Create and render dashboard
-    let dashboard = Dashboard::new(
-        cluster.clone(),
-        63,
-        42,
-        nodes_metrics,
-    );
+    let dashboard = Dashboard::new(cluster.clone(), 63, 42, nodes_metrics);
 
     println!("{}", dashboard.render_ascii());
 

--- a/crates/ghostlink-core/Cargo.toml
+++ b/crates/ghostlink-core/Cargo.toml
@@ -29,11 +29,18 @@ tracing-subscriber = "0.3"
 rand = "0.10.1"
 libc = "0.2.186"
 crossterm = "0.29.0"
+arc-swap = "1"
 
 [dev-dependencies]
 tokio-test = "0.4"
+criterion = "0.5"
 
 [[bench]]
 name = "baseline"
 path = "../../benches/baseline.rs"
+harness = false
+
+[[bench]]
+name = "criterion"
+path = "../../benches/criterion.rs"
 harness = false

--- a/crates/ghostlink-core/src/cluster.rs
+++ b/crates/ghostlink-core/src/cluster.rs
@@ -15,20 +15,15 @@ use arc_swap::ArcSwap;
 pub use crate::protocol::NodeResources;
 
 /// Node status enumeration
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum NodeStatus {
     /// Node is healthy and accepting traffic
+    #[default]
     Active,
     /// Node is degraded (below threshold)
     Degraded,
     /// Node has failed or timed out
     Failed,
-}
-
-impl Default for NodeStatus {
-    fn default() -> Self {
-        Self::Active
-    }
 }
 
 /// Metrics for a single node
@@ -307,12 +302,12 @@ impl ClusterState {
 
     /// Get a shared snapshot of all nodes
     pub fn nodes_snapshot(&self) -> Arc<Vec<NodeResources>> {
-        if self.nodes_snapshot_dirty.load(Ordering::Acquire) {
-            if self.nodes_snapshot_dirty.swap(false, Ordering::AcqRel) {
-                let nodes = self.nodes.lock().unwrap();
-                self.nodes_snapshot
-                    .store(Arc::new(nodes.values().cloned().collect::<Vec<_>>()));
-            }
+        if self.nodes_snapshot_dirty.load(Ordering::Acquire)
+            && self.nodes_snapshot_dirty.swap(false, Ordering::AcqRel)
+        {
+            let nodes = self.nodes.lock().unwrap();
+            self.nodes_snapshot
+                .store(Arc::new(nodes.values().cloned().collect::<Vec<_>>()));
         }
 
         self.nodes_snapshot.load_full()

--- a/crates/ghostlink-core/src/cluster.rs
+++ b/crates/ghostlink-core/src/cluster.rs
@@ -1,5 +1,5 @@
 //! Thread-Safe Cluster State with Metrics Collection
-//! 
+//!
 //! This module provides a lock-free, thread-safe cluster state tracking:
 //! - Node capabilities (VRAM, system memory, compute capability)
 //! - Live metrics (latency, delivery ratio, throughput)
@@ -48,12 +48,12 @@ pub struct NodeMetrics {
     pub compute_capability: String,
     /// GPU name/model
     pub gpu_name: Option<String>,
-    
+
     /// Last heartbeat time
     pub last_heartbeat: Instant,
     /// Heartbeat interval threshold
     pub heartbeat_timeout: Duration,
-    
+
     /// Average latency in microseconds
     pub avg_latency_us: f32,
     /// Minimum observed latency
@@ -62,20 +62,20 @@ pub struct NodeMetrics {
     pub max_latency_us: f32,
     /// Number of latency samples
     pub latency_samples: u64,
-    
+
     /// Delivery ratio (0.0 to 1.0)
     pub delivery_ratio: f32,
     /// Throughput in GB/s
     pub throughput_gbps: f32,
-    
+
     /// Current used VRAM in GB
     pub used_vram_gb: f32,
     /// Available VRAM in GB
     pub available_vram_gb: f32,
-    
+
     /// Number of layers streaming on this node
     pub streaming_layers: Option<(usize, usize)>,
-    
+
     /// AF_XDP throughput in Gbps (for display)
     pub af_xdp_gbps: f32,
     /// Per-packet latency in microseconds (for display)
@@ -144,7 +144,7 @@ impl NodeMetrics {
             delivery_ratio_initialized: false,
         }
     }
-    
+
     /// Update metrics with new latency sample (EMA with alpha=0.1)
     pub fn record_latency(&mut self, latency_us: f32) {
         if latency_us < self.min_latency_us {
@@ -153,7 +153,7 @@ impl NodeMetrics {
         if latency_us > self.max_latency_us {
             self.max_latency_us = latency_us;
         }
-        
+
         self.latency_samples += 1;
         if self.latency_samples == 1 {
             self.avg_latency_us = latency_us;
@@ -161,7 +161,7 @@ impl NodeMetrics {
             self.avg_latency_us = self.avg_latency_us * 0.9 + latency_us * 0.1;
         }
     }
-    
+
     /// Update metrics with new delivery ratio sample
     pub fn record_delivery_ratio(&mut self, ratio: f32) {
         if !self.delivery_ratio_initialized {
@@ -172,24 +172,24 @@ impl NodeMetrics {
             self.delivery_ratio = self.delivery_ratio * 0.9 + ratio * 0.1;
         }
     }
-    
+
     /// Update metrics with new throughput sample
     pub fn record_throughput(&mut self, throughput_gbps: f32) {
         // Exponential moving average with alpha=0.1
         self.throughput_gbps = self.throughput_gbps * 0.9 + throughput_gbps * 0.1;
     }
-    
+
     /// Update used VRAM
     pub fn record_vram_usage(&mut self, used_vram_gb: f32) {
         self.used_vram_gb = used_vram_gb;
         self.available_vram_gb = self.total_vram_gb - used_vram_gb;
     }
-    
+
     /// Set streaming layers
     pub fn set_streaming_layers(&mut self, start: usize, end: usize) {
         self.streaming_layers = Some((start, end));
     }
-    
+
     /// Clear streaming layers
     pub fn clear_streaming_layers(&mut self) {
         self.streaming_layers = None;
@@ -244,7 +244,7 @@ impl ClusterState {
             total_vram_cache: Arc::new(AtomicU64::new(0.0_f64.to_bits())),
         }
     }
-    
+
     /// Register a new node with the cluster
     pub fn register(&self, node: NodeResources) {
         let mut nodes = self.nodes.lock().unwrap();
@@ -286,14 +286,20 @@ impl ClusterState {
         self.nodes_snapshot_dirty.store(true, Ordering::Release);
 
         let current_total_vram = f64::from_bits(self.total_vram_cache.load(Ordering::Acquire));
-        self.total_vram_cache.store((current_total_vram + vram_delta as f64).to_bits(), Ordering::Release);
-        
-        self.last_update.store(std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or(Duration::ZERO)
-            .as_millis() as u64, Ordering::Release);
+        self.total_vram_cache.store(
+            (current_total_vram + vram_delta as f64).to_bits(),
+            Ordering::Release,
+        );
+
+        self.last_update.store(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_millis() as u64,
+            Ordering::Release,
+        );
     }
-    
+
     /// Get all nodes
     pub fn nodes(&self) -> Vec<NodeResources> {
         self.nodes_snapshot().as_ref().to_vec()
@@ -304,26 +310,27 @@ impl ClusterState {
         if self.nodes_snapshot_dirty.load(Ordering::Acquire) {
             if self.nodes_snapshot_dirty.swap(false, Ordering::AcqRel) {
                 let nodes = self.nodes.lock().unwrap();
-                self.nodes_snapshot.store(Arc::new(nodes.values().cloned().collect::<Vec<_>>()));
+                self.nodes_snapshot
+                    .store(Arc::new(nodes.values().cloned().collect::<Vec<_>>()));
             }
         }
 
         self.nodes_snapshot.load_full()
     }
-    
+
     /// Get metrics for a specific node
     pub fn get_metrics(&self, node_id: &str) -> Option<NodeMetrics> {
         let metrics = self.metrics.lock().unwrap();
         metrics.get(node_id).cloned()
     }
-    
+
     /// Update last heartbeat for a node
     pub fn update_heartbeat(&self, node_id: &str) {
         self.get_metrics_mut(node_id, |metrics| {
             metrics.last_heartbeat = Instant::now();
         });
     }
-    
+
     /// Get metrics mutable reference (for internal updates)
     pub fn get_metrics_mut<F, R>(&self, node_id: &str, f: F) -> Option<R>
     where
@@ -332,7 +339,7 @@ impl ClusterState {
         let mut metrics = self.metrics.lock().unwrap();
         metrics.get_mut(node_id).map(f)
     }
-    
+
     /// Check if a node has timed out
     pub fn check_heartbeat_timeout(&self, node_id: &str) -> bool {
         if let Some(metrics) = self.get_metrics(node_id) {
@@ -342,41 +349,40 @@ impl ClusterState {
             false
         }
     }
-    
+
     /// Mark a node as failed due to timeout
     pub fn mark_failed(&self, node_id: &str) {
         self.get_metrics_mut(node_id, |metrics| {
             metrics.status = NodeStatus::Failed;
         });
     }
-    
+
     /// Recover a failed node
     pub fn recover_node(&self, node_id: &str) {
         self.get_metrics_mut(node_id, |metrics| {
             metrics.status = NodeStatus::Active;
         });
     }
-    
+
     /// Get all active nodes
     pub fn active_nodes(&self) -> Vec<NodeMetrics> {
         let metrics = self.metrics.lock().unwrap();
-        metrics.values()
+        metrics
+            .values()
             .filter(|m| m.status == NodeStatus::Active)
             .cloned()
             .collect()
     }
-    
+
     /// Get total cluster VRAM
     pub fn total_vram_gb(&self) -> f32 {
         f64::from_bits(self.total_vram_cache.load(Ordering::Acquire)) as f32
     }
-    
+
     /// Get total system memory
     pub fn total_system_memory_gb(&self) -> f32 {
         let nodes = self.nodes.lock().unwrap();
-        nodes.values()
-            .map(|n| n.system_memory_gb)
-            .sum()
+        nodes.values().map(|n| n.system_memory_gb).sum()
     }
 }
 
@@ -396,57 +402,58 @@ impl ClusterHealthMonitor {
             check_interval,
         }
     }
-    
+
     /// Run health check on all nodes
     pub fn check_health(&self) {
-        let failed_nodes: Vec<String> = self.cluster.nodes_snapshot()
+        let failed_nodes: Vec<String> = self
+            .cluster
+            .nodes_snapshot()
             .iter()
             .filter(|n| self.cluster.check_heartbeat_timeout(&n.id))
             .map(|n| n.id.clone())
             .collect();
-        
+
         // Mark timed-out nodes as failed
         for node_id in &failed_nodes {
             self.cluster.mark_failed(node_id);
         }
-        
+
         // Update last update timestamp
         self.cluster.last_update.store(
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or(Duration::ZERO)
                 .as_millis() as u64,
-            Ordering::Release
+            Ordering::Release,
         );
     }
-    
+
     /// Get health report
     pub fn health_report(&self) -> String {
         let active_count = self.cluster.active_nodes().len();
         let total_nodes = self.cluster.nodes_snapshot().len();
-        
+
         format!(
             "Cluster Health Report\n\
              =================\n\
              Active nodes: {}/{}\n\
              Total VRAM: {:.1} GB\n\
              System memory: {:.1} GB\n",
-            active_count, total_nodes,
+            active_count,
+            total_nodes,
             self.cluster.total_vram_gb(),
             self.cluster.total_system_memory_gb()
         )
     }
-    
+
     /// Run periodic health checks in background
     pub fn start_periodic_checks(&self) {
         let this = self.clone();
-        
+
         // Spawn health check task
-        std::thread::spawn(move || {
-            loop {
-                this.check_health();
-                std::thread::sleep(this.check_interval);
-            }
+        std::thread::spawn(move || loop {
+            this.check_health();
+            std::thread::sleep(this.check_interval);
         });
     }
 }
@@ -472,10 +479,10 @@ mod tests {
     fn heartbeat_timeout_detection() {
         let cluster = ClusterState::new();
         cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
-        
+
         // Simulate timeout by waiting longer than default heartbeat timeout
         thread::sleep(Duration::from_secs(6));
-        
+
         assert!(cluster.check_heartbeat_timeout("node-a"));
     }
 
@@ -484,10 +491,10 @@ mod tests {
         let cluster = Arc::new(ClusterState::new());
         cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
         cluster.register(NodeResources::new("node-b", 12.0, 32.0, "8.6", None));
-        
+
         let monitor = ClusterHealthMonitor::new(cluster.clone(), Duration::from_secs(1));
         monitor.check_health();
-        
+
         let report = monitor.health_report();
         assert!(report.contains("Active nodes: 2/2"));
     }
@@ -495,12 +502,12 @@ mod tests {
     #[test]
     fn metrics_record_latency() {
         let mut metrics = NodeMetrics::new(24.0, 64.0, "8.9".to_string(), Duration::from_secs(5));
-        
+
         metrics.record_latency(1.0);
         assert_eq!(metrics.avg_latency_us, 1.0);
         assert_eq!(metrics.min_latency_us, 1.0);
         assert_eq!(metrics.max_latency_us, 1.0);
-        
+
         metrics.record_latency(2.0);
         // EMA with alpha=0.1: (1.0 * 0.9) + 2.0 * 0.1 = 0.9 + 0.2 = 1.1
         assert!((metrics.avg_latency_us - 1.1).abs() < 1e-6);
@@ -509,10 +516,10 @@ mod tests {
     #[test]
     fn metrics_record_delivery_ratio() {
         let mut metrics = NodeMetrics::new(24.0, 64.0, "8.9".to_string(), Duration::from_secs(5));
-        
+
         metrics.record_delivery_ratio(0.98);
         assert!((metrics.delivery_ratio - 0.98).abs() < 1e-6);
-        
+
         metrics.record_delivery_ratio(0.90);
         // EMA: 0.98 * 0.9 + 0.90 * 0.1 = 0.882 + 0.09 = 0.972
         assert!((metrics.delivery_ratio - 0.972).abs() < 1e-6);
@@ -523,7 +530,7 @@ mod tests {
         let cluster = ClusterState::new();
         cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
         cluster.register(NodeResources::new("node-b", 12.0, 32.0, "8.6", None));
-        
+
         assert_eq!(cluster.total_vram_gb(), 36.0);
     }
 }

--- a/crates/ghostlink-core/src/cluster.rs
+++ b/crates/ghostlink-core/src/cluster.rs
@@ -6,9 +6,11 @@
 //! - Fault detection and recovery
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use arc_swap::ArcSwap;
 
 pub use crate::protocol::NodeResources;
 
@@ -199,18 +201,27 @@ impl NodeMetrics {
 pub struct ClusterState {
     /// Map of node ID to resources and metrics
     nodes: Arc<Mutex<HashMap<String, NodeResources>>>,
+    /// Cached shared snapshot of nodes for read-heavy paths
+    nodes_snapshot: Arc<ArcSwap<Vec<NodeResources>>>,
+    /// Indicates whether the shared snapshot needs to be refreshed
+    nodes_snapshot_dirty: Arc<AtomicBool>,
     /// Map of node ID to live metrics
     metrics: Arc<Mutex<HashMap<String, NodeMetrics>>>,
     /// Last cluster update timestamp
     last_update: Arc<AtomicU64>,
+    /// Cached total VRAM across all registered nodes
+    total_vram_cache: Arc<AtomicU64>,
 }
 
 impl Clone for ClusterState {
     fn clone(&self) -> Self {
         Self {
             nodes: Arc::clone(&self.nodes),
+            nodes_snapshot: Arc::clone(&self.nodes_snapshot),
+            nodes_snapshot_dirty: Arc::clone(&self.nodes_snapshot_dirty),
             metrics: Arc::clone(&self.metrics),
             last_update: Arc::clone(&self.last_update),
+            total_vram_cache: Arc::clone(&self.total_vram_cache),
         }
     }
 }
@@ -226,8 +237,11 @@ impl ClusterState {
     pub fn new() -> Self {
         Self {
             nodes: Arc::new(Mutex::new(HashMap::new())),
+            nodes_snapshot: Arc::new(ArcSwap::from_pointee(Vec::<NodeResources>::new())),
+            nodes_snapshot_dirty: Arc::new(AtomicBool::new(false)),
             metrics: Arc::new(Mutex::new(HashMap::new())),
             last_update: Arc::new(AtomicU64::new(0)),
+            total_vram_cache: Arc::new(AtomicU64::new(0.0_f64.to_bits())),
         }
     }
     
@@ -235,41 +249,29 @@ impl ClusterState {
     pub fn register(&self, node: NodeResources) {
         let mut nodes = self.nodes.lock().unwrap();
         let mut metrics = self.metrics.lock().unwrap();
-        
-        // Check if node already exists
-        if nodes.contains_key(&node.id) {
-            // Update existing node with new resources
-            let existing = nodes.get_mut(&node.id).unwrap();
-            existing.vram_gb = node.vram_gb;
-            existing.system_memory_gb = node.system_memory_gb;
-            existing.compute_capability = node.compute_capability.clone();
-            
-            // Initialize or update metrics
-            if !metrics.contains_key(&node.id) {
-                metrics.insert(
-                    node.id.clone(),
-                    NodeMetrics::new(
-                        node.vram_gb,
-                        node.system_memory_gb,
-                        node.compute_capability,
-                        Duration::from_secs(5),
-                    ),
-                );
-            } else {
-                let existing_metrics = metrics.get_mut(&node.id).unwrap();
-                existing_metrics.vram_gb = node.vram_gb;
-                existing_metrics.total_vram_gb = node.vram_gb;
-                existing_metrics.system_memory_gb = node.system_memory_gb;
-                existing_metrics.compute_capability = node.compute_capability;
-                existing_metrics.heartbeat_timeout = Duration::from_secs(5);
-            }
+
+        let id = node.id.clone();
+        let vram_gb = node.vram_gb;
+        let system_memory_gb = node.system_memory_gb;
+        let compute_capability = node.compute_capability.clone();
+        let mut vram_delta = vram_gb;
+
+        if let Some(existing) = nodes.get_mut(&id) {
+            vram_delta = vram_gb - existing.vram_gb;
+            existing.vram_gb = vram_gb;
+            existing.system_memory_gb = system_memory_gb;
+            existing.compute_capability = compute_capability.clone();
         } else {
-            // New node - extract fields before moving node into map
-            let id = node.id.clone();
-            let vram_gb = node.vram_gb;
-            let system_memory_gb = node.system_memory_gb;
-            let compute_capability = node.compute_capability.clone();
             nodes.insert(id.clone(), node);
+        }
+
+        if let Some(existing_metrics) = metrics.get_mut(&id) {
+            existing_metrics.vram_gb = vram_gb;
+            existing_metrics.total_vram_gb = vram_gb;
+            existing_metrics.system_memory_gb = system_memory_gb;
+            existing_metrics.compute_capability = compute_capability;
+            existing_metrics.heartbeat_timeout = Duration::from_secs(5);
+        } else {
             metrics.insert(
                 id,
                 NodeMetrics::new(
@@ -280,6 +282,11 @@ impl ClusterState {
                 ),
             );
         }
+
+        self.nodes_snapshot_dirty.store(true, Ordering::Release);
+
+        let current_total_vram = f64::from_bits(self.total_vram_cache.load(Ordering::Acquire));
+        self.total_vram_cache.store((current_total_vram + vram_delta as f64).to_bits(), Ordering::Release);
         
         self.last_update.store(std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -289,8 +296,19 @@ impl ClusterState {
     
     /// Get all nodes
     pub fn nodes(&self) -> Vec<NodeResources> {
-        let nodes = self.nodes.lock().unwrap();
-        nodes.values().cloned().collect()
+        self.nodes_snapshot().as_ref().to_vec()
+    }
+
+    /// Get a shared snapshot of all nodes
+    pub fn nodes_snapshot(&self) -> Arc<Vec<NodeResources>> {
+        if self.nodes_snapshot_dirty.load(Ordering::Acquire) {
+            if self.nodes_snapshot_dirty.swap(false, Ordering::AcqRel) {
+                let nodes = self.nodes.lock().unwrap();
+                self.nodes_snapshot.store(Arc::new(nodes.values().cloned().collect::<Vec<_>>()));
+            }
+        }
+
+        self.nodes_snapshot.load_full()
     }
     
     /// Get metrics for a specific node
@@ -350,10 +368,7 @@ impl ClusterState {
     
     /// Get total cluster VRAM
     pub fn total_vram_gb(&self) -> f32 {
-        let nodes = self.nodes.lock().unwrap();
-        nodes.values()
-            .map(|n| n.vram_gb)
-            .sum()
+        f64::from_bits(self.total_vram_cache.load(Ordering::Acquire)) as f32
     }
     
     /// Get total system memory
@@ -384,7 +399,7 @@ impl ClusterHealthMonitor {
     
     /// Run health check on all nodes
     pub fn check_health(&self) {
-        let failed_nodes: Vec<String> = self.cluster.nodes()
+        let failed_nodes: Vec<String> = self.cluster.nodes_snapshot()
             .iter()
             .filter(|n| self.cluster.check_heartbeat_timeout(&n.id))
             .map(|n| n.id.clone())
@@ -408,7 +423,7 @@ impl ClusterHealthMonitor {
     /// Get health report
     pub fn health_report(&self) -> String {
         let active_count = self.cluster.active_nodes().len();
-        let total_nodes = self.cluster.nodes().len();
+        let total_nodes = self.cluster.nodes_snapshot().len();
         
         format!(
             "Cluster Health Report\n\

--- a/crates/ghostlink-core/src/dashboard.rs
+++ b/crates/ghostlink-core/src/dashboard.rs
@@ -1,5 +1,5 @@
 //! Terminal Dashboard with ratatui Integration for Ghost-Link Cluster
-//! 
+//!
 //! This module provides:
 //! - Live cluster metrics display using ratatui
 //! - Node status indicators and streaming layer visualization
@@ -45,7 +45,7 @@ impl DashboardState {
             quantization_mode: QuantizationMode::None,
         }
     }
-    
+
     /// Update cluster state
     pub fn update_cluster(&mut self) {
         let active_count = self.cluster.active_nodes().len();
@@ -60,17 +60,27 @@ impl DashboardState {
         } else {
             "health monitor: disabled"
         };
-        
+
         if active_count == 0 && total_nodes > 0 {
-            self.status_message = format!("No active nodes | {} | {}", quantization_label, health_label);
+            self.status_message = format!(
+                "No active nodes | {} | {}",
+                quantization_label, health_label
+            );
         } else if active_count < total_nodes {
-            self.status_message = format!("{} of {} nodes active | {} | {}", active_count, total_nodes, quantization_label, health_label);
+            self.status_message = format!(
+                "{} of {} nodes active | {} | {}",
+                active_count, total_nodes, quantization_label, health_label
+            );
         } else {
-            self.status_message = format!("Cluster healthy: {:.1} GB total VRAM | {} | {}", 
-                self.cluster.total_vram_gb(), quantization_label, health_label);
+            self.status_message = format!(
+                "Cluster healthy: {:.1} GB total VRAM | {} | {}",
+                self.cluster.total_vram_gb(),
+                quantization_label,
+                health_label
+            );
         }
     }
-    
+
     /// Get ring fill percentage
     pub fn ring_fill_percent(&self) -> u8 {
         let (used, capacity) = self.ring_stats;
@@ -80,7 +90,7 @@ impl DashboardState {
             ((used as f32 / capacity as f32) * 100.0).round() as u8
         }
     }
-    
+
     /// Get total VRAM
     pub fn total_vram_gb(&self) -> f32 {
         self.cluster.total_vram_gb()
@@ -115,13 +125,18 @@ impl AsciiDashboard {
             nodes,
         }
     }
-    
+
     /// Render ASCII dashboard
     pub fn render_ascii(&self) -> String {
-        let mut output = String::from("+───────────────────────────────────────────────────────────────+\n");
+        let mut output =
+            String::from("+───────────────────────────────────────────────────────────────+\n");
         output.push_str(&format!(
             "| GHOST-LINK CLUSTER DASHBOARD               [STATUS: {:<8}] |\n",
-            if self.cluster.nodes_snapshot().is_empty() { "EMPTY" } else { "ACTIVE" }
+            if self.cluster.nodes_snapshot().is_empty() {
+                "EMPTY"
+            } else {
+                "ACTIVE"
+            }
         ));
         output.push_str("+───────────────────────────────────────────────────────────────+\n");
         output.push_str(&format!(
@@ -135,8 +150,11 @@ impl AsciiDashboard {
             let gauge = format!("{}{}", "█".repeat(blocks), "░".repeat(20 - blocks));
             output.push_str(&format!(
                 "| {:<7} ({:<8}) [{}] {:>4.1} / {:>4.1} GB VRAM |\n",
-                node.name, node.gpu_name.as_deref().unwrap_or("Unknown"), gauge, 
-                node.used_vram_gb, node.total_vram_gb
+                node.name,
+                node.gpu_name.as_deref().unwrap_or("Unknown"),
+                gauge,
+                node.used_vram_gb,
+                node.total_vram_gb
             ));
 
             if let Some((start, end)) = node.streaming_layers {
@@ -161,45 +179,48 @@ pub struct TerminalApp {
 impl TerminalApp {
     /// Create new terminal app
     pub fn new(state: DashboardState) -> Self {
-        Self {
-            state,
-        }
+        Self { state }
     }
-    
+
     /// Run terminal application
     pub fn run(&mut self) {
         // Initialize terminal
         let stdout = std::io::stdout();
-        
+
         if let Err(err) = enable_raw_mode() {
             println!("Failed to enable raw mode: {:?}", err);
             return;
         }
-        
+
         let backend = ratatui::backend::CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend).unwrap();
-        
+
         // Run application loop
         let result = self.run_app_loop(&mut terminal);
-        
+
         // Restore terminal
         disable_raw_mode().unwrap();
-        
+
         match result {
             Ok(msg) if !msg.is_empty() => println!("{}", msg),
             Err(err) => println!("Application error: {}", err),
             _ => {}
         }
     }
-    
+
     /// Run application loop
-    fn run_app_loop(&mut self, terminal: &mut ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>>) -> Result<String, String> {
+    fn run_app_loop(
+        &mut self,
+        terminal: &mut ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stdout>>,
+    ) -> Result<String, String> {
         let mut result = String::new();
-        
+
         loop {
             // Render UI
-            terminal.draw(|frame| self.render(frame)).map_err(|e| e.to_string())?;
-            
+            terminal
+                .draw(|frame| self.render(frame))
+                .map_err(|e| e.to_string())?;
+
             // Check for events
             if event::poll(std::time::Duration::from_millis(100)).map_err(|e| e.to_string())? {
                 if let Event::Key(key) = event::read().map_err(|e| e.to_string())? {
@@ -212,11 +233,11 @@ impl TerminalApp {
                     }
                 }
             }
-            
+
             result.push_str(&self.state.status_message);
         }
     }
-    
+
     /// Render UI frame
     fn render(&mut self, frame: &mut ratatui::Frame) {
         let chunks = Layout::default()
@@ -228,23 +249,27 @@ impl TerminalApp {
                 Constraint::Length(2), // Footer
             ])
             .split(frame.area());
-        
+
         // Title
         let title = Paragraph::new("GHOST-LINK CLUSTER DASHBOARD")
-            .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
+            .style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
             .block(Block::default().borders(Borders::ALL));
         frame.render_widget(title, chunks[0]);
-        
+
         // Content
         self.render_content(frame, chunks[1]);
-        
+
         // Footer
         let footer = Paragraph::new("Press 'q' to quit, 'r' to refresh")
             .style(Style::default().fg(Color::Gray))
             .block(Block::default().borders(Borders::ALL));
         frame.render_widget(footer, chunks[2]);
     }
-    
+
     /// Render content area
     fn render_content(&self, frame: &mut ratatui::Frame, area: Rect) {
         // Status
@@ -282,13 +307,18 @@ impl Dashboard {
             nodes,
         }
     }
-    
+
     /// Render ASCII dashboard (simple)
     pub fn render_ascii(&self) -> String {
-        AsciiDashboard::new(self.cluster.clone(), self.ring_fill_percent, self.gradient_steps, self.nodes.clone())
-            .render_ascii()
+        AsciiDashboard::new(
+            self.cluster.clone(),
+            self.ring_fill_percent,
+            self.gradient_steps,
+            self.nodes.clone(),
+        )
+        .render_ascii()
     }
-    
+
     /// Render ratatui terminal application
     pub fn run_terminal(&self) {
         let state = DashboardState::new(self.cluster.clone());
@@ -312,7 +342,12 @@ pub struct HealthSummary {
 
 impl HealthSummary {
     /// Create new health summary
-    pub fn new(active_nodes: usize, failed_nodes: usize, avg_latency_us: f32, avg_delivery_ratio: f32) -> Self {
+    pub fn new(
+        active_nodes: usize,
+        failed_nodes: usize,
+        avg_latency_us: f32,
+        avg_delivery_ratio: f32,
+    ) -> Self {
         Self {
             active_nodes,
             failed_nodes,
@@ -320,7 +355,7 @@ impl HealthSummary {
             avg_delivery_ratio,
         }
     }
-    
+
     /// Render health summary as widget
     pub fn render(&self) -> String {
         format!(
@@ -344,8 +379,10 @@ mod tests {
     #[test]
     fn renders_dashboard_with_stream_information() {
         let cluster = ClusterState::new();
-        cluster.register(crate::cluster::NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
-        
+        cluster.register(crate::cluster::NodeResources::new(
+            "node-a", 24.0, 64.0, "8.9", None,
+        ));
+
         let dashboard = Dashboard::new(
             cluster.clone(),
             63,
@@ -372,7 +409,7 @@ mod tests {
     #[test]
     fn health_summary_reports() {
         let summary = HealthSummary::new(2, 0, 1.5, 0.98);
-        
+
         let report = summary.render();
         assert!(report.contains("Active nodes: 2"));
         assert!(report.contains("Avg latency: 1.50μs"));
@@ -382,7 +419,7 @@ mod tests {
     fn dashboard_ring_fill_percent() {
         let cluster = ClusterState::new();
         cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
-        
+
         let ring_stats = (153, 1024); // 15% fill
         let dashboard_state = DashboardState {
             cluster,
@@ -391,7 +428,7 @@ mod tests {
             status_message: "Initializing...".to_string(),
             quantization_mode: QuantizationMode::None,
         };
-        
+
         assert_eq!(dashboard_state.ring_fill_percent(), 15);
     }
 }

--- a/crates/ghostlink-core/src/dashboard.rs
+++ b/crates/ghostlink-core/src/dashboard.rs
@@ -49,15 +49,25 @@ impl DashboardState {
     /// Update cluster state
     pub fn update_cluster(&mut self) {
         let active_count = self.cluster.active_nodes().len();
-        let total_nodes = self.cluster.nodes().len();
+        let total_nodes = self.cluster.nodes_snapshot().len();
+        let quantization_label = match self.quantization_mode {
+            QuantizationMode::None => "full precision",
+            QuantizationMode::Int8 => "int8",
+            QuantizationMode::Int4 => "int4",
+        };
+        let health_label = if self.health_monitor.is_some() {
+            "health monitor: enabled"
+        } else {
+            "health monitor: disabled"
+        };
         
         if active_count == 0 && total_nodes > 0 {
-            self.status_message = "No active nodes".to_string();
+            self.status_message = format!("No active nodes | {} | {}", quantization_label, health_label);
         } else if active_count < total_nodes {
-            self.status_message = format!("{} of {} nodes active", active_count, total_nodes);
+            self.status_message = format!("{} of {} nodes active | {} | {}", active_count, total_nodes, quantization_label, health_label);
         } else {
-            self.status_message = format!("Cluster healthy: {:.1} GB total VRAM", 
-                self.cluster.total_vram_gb());
+            self.status_message = format!("Cluster healthy: {:.1} GB total VRAM | {} | {}", 
+                self.cluster.total_vram_gb(), quantization_label, health_label);
         }
     }
     
@@ -111,7 +121,7 @@ impl AsciiDashboard {
         let mut output = String::from("+───────────────────────────────────────────────────────────────+\n");
         output.push_str(&format!(
             "| GHOST-LINK CLUSTER DASHBOARD               [STATUS: {:<8}] |\n",
-            if self.cluster.nodes().is_empty() { "EMPTY" } else { "ACTIVE" }
+            if self.cluster.nodes_snapshot().is_empty() { "EMPTY" } else { "ACTIVE" }
         ));
         output.push_str("+───────────────────────────────────────────────────────────────+\n");
         output.push_str(&format!(
@@ -159,7 +169,7 @@ impl TerminalApp {
     /// Run terminal application
     pub fn run(&mut self) {
         // Initialize terminal
-        let mut stdout = std::io::stdout();
+        let stdout = std::io::stdout();
         
         if let Err(err) = enable_raw_mode() {
             println!("Failed to enable raw mode: {:?}", err);
@@ -330,7 +340,6 @@ mod tests {
     use super::*;
     use crate::cluster::ClusterState;
     use crate::protocol::NodeResources;
-    use std::sync::Arc;
 
     #[test]
     fn renders_dashboard_with_stream_information() {

--- a/crates/ghostlink-core/src/health.rs
+++ b/crates/ghostlink-core/src/health.rs
@@ -1,5 +1,5 @@
 //! Network Health Monitoring for Ghost-Link Cluster
-//! 
+//!
 //! This module provides:
 //! - Ping/pong latency tracking per node
 //! - Delivery ratio monitoring
@@ -93,20 +93,24 @@ impl NetworkHealthMonitor {
             recent_checks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
-    
+
     /// Run health check on all nodes
     pub fn check_all(&self) {
         let now = Instant::now();
-        
+
         for node in self.cluster.nodes_snapshot().iter() {
             // Simulate health check inputs (production would gather real probe results)
             let latency_us = 1.0 + (rand::random::<f32>() * 0.5);
             let delivery_ratio = 0.98 - (rand::random::<f32>() * 0.05);
 
-            if self.cluster.get_metrics_mut(&node.id, |m| {
-                m.record_latency(latency_us);
-                m.record_delivery_ratio(delivery_ratio);
-            }).is_some() {
+            if self
+                .cluster
+                .get_metrics_mut(&node.id, |m| {
+                    m.record_latency(latency_us);
+                    m.record_delivery_ratio(delivery_ratio);
+                })
+                .is_some()
+            {
                 let result = HealthCheckResult {
                     node_id: node.id.clone(),
                     latency_us,
@@ -114,7 +118,7 @@ impl NetworkHealthMonitor {
                     status: self.get_health_status(latency_us, delivery_ratio),
                     timestamp: now,
                 };
-                
+
                 // Store recent check results (keep last 10)
                 let mut checks = self.recent_checks.lock().unwrap();
                 if let Some(node_checks) = checks.get_mut(&node.id) {
@@ -125,19 +129,18 @@ impl NetworkHealthMonitor {
                 } else {
                     checks.insert(node.id.clone(), vec![result]);
                 }
-                
             }
         }
-        
+
         *self.last_check.lock().unwrap() = Some(now);
     }
-    
+
     /// Get health status based on metrics
     fn get_health_status(&self, latency_us: f32, delivery_ratio: f32) -> HealthStatus {
         // Thresholds for health assessment
         const MAX_LATENCY_US: f32 = 10.0;
         const MIN_DELIVERY_RATIO: f32 = 0.95;
-        
+
         if delivery_ratio >= MIN_DELIVERY_RATIO && latency_us <= MAX_LATENCY_US {
             HealthStatus::Healthy
         } else if delivery_ratio >= 0.80 || latency_us <= MAX_LATENCY_US * 2.0 {
@@ -146,77 +149,83 @@ impl NetworkHealthMonitor {
             HealthStatus::Failed
         }
     }
-    
+
     /// Get health report for a specific node
     pub fn get_node_health(&self, node_id: &str) -> Option<HealthCheckResult> {
         let checks = self.recent_checks.lock().unwrap();
-        checks.get(node_id).and_then(|checks| checks.last())
+        checks
+            .get(node_id)
+            .and_then(|checks| checks.last())
             .cloned()
     }
-    
+
     /// Get health report for all nodes
     pub fn get_all_health(&self) -> Vec<HealthCheckResult> {
         let checks = self.recent_checks.lock().unwrap();
-        checks.values()
-            .flat_map(|checks| checks.clone())
-            .collect()
+        checks.values().flat_map(|checks| checks.clone()).collect()
     }
-    
+
     /// Check if node needs quantization fallback
     pub fn needs_quantization_fallback(&self, node_id: &str) -> bool {
         let checks = self.recent_checks.lock().unwrap();
-        
+
         if let Some(node_checks) = checks.get(node_id) {
             // Check last 3 results for consistent degradation
-            let recent: Vec<_> = node_checks.iter()
-                .rev()
-                .take(3)
-                .collect();
-            
+            let recent: Vec<_> = node_checks.iter().rev().take(3).collect();
+
             if recent.len() < 3 {
                 return false;
             }
-            
+
             // Calculate average delivery ratio of last 3 checks
-            let avg_delivery_ratio: f32 = recent.iter()
-                .map(|r| r.delivery_ratio)
-                .sum::<f32>() / 3.0;
-            
+            let avg_delivery_ratio: f32 =
+                recent.iter().map(|r| r.delivery_ratio).sum::<f32>() / 3.0;
+
             // Check average latency
-            let avg_latency_us: f32 = recent.iter()
-                .map(|r| r.latency_us)
-                .sum::<f32>() / 3.0;
-            
+            let avg_latency_us: f32 = recent.iter().map(|r| r.latency_us).sum::<f32>() / 3.0;
+
             // Need fallback if delivery ratio dropped below threshold or latency increased significantly
             avg_delivery_ratio < 0.95 || avg_latency_us > 10.0
         } else {
             false
         }
     }
-    
+
     /// Get cluster-wide health summary
     pub fn get_health_summary(&self) -> String {
         let checks = self.recent_checks.lock().unwrap();
-        
+
         let total_nodes = checks.len();
-        let healthy_count = checks.values()
+        let healthy_count = checks
+            .values()
             .filter(|node_checks| {
-                node_checks.last().map(|c| c.status == HealthStatus::Healthy).unwrap_or(false)
+                node_checks
+                    .last()
+                    .map(|c| c.status == HealthStatus::Healthy)
+                    .unwrap_or(false)
             })
             .count();
-        
-        let degraded_count = checks.values()
+
+        let degraded_count = checks
+            .values()
             .filter(|node_checks| {
-                node_checks.last().map(|c| c.status == HealthStatus::Degraded).unwrap_or(false)
+                node_checks
+                    .last()
+                    .map(|c| c.status == HealthStatus::Degraded)
+                    .unwrap_or(false)
             })
             .count();
-        
-        let failed_count = checks.values()
+
+        let failed_count = checks
+            .values()
             .filter(|node_checks| {
-                node_checks.last().map(|c| c.status == HealthStatus::Failed).unwrap_or(false)
+                node_checks
+                    .last()
+                    .map(|c| c.status == HealthStatus::Failed)
+                    .unwrap_or(false)
             })
             .count();
-        
+
         format!(
             "Network Health Summary\n\
              =================\n\
@@ -227,16 +236,14 @@ impl NetworkHealthMonitor {
             total_nodes, healthy_count, degraded_count, failed_count
         )
     }
-    
+
     /// Start periodic health checks in background
     pub fn start_periodic_checks(&self) {
         let this = self.clone();
-        
-        std::thread::spawn(move || {
-            loop {
-                this.check_all();
-                std::thread::sleep(this.config.check_interval);
-            }
+
+        std::thread::spawn(move || loop {
+            this.check_all();
+            std::thread::sleep(this.config.check_interval);
         });
     }
 }
@@ -263,7 +270,7 @@ impl HealthMetrics {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Record a health check result
     pub fn record(&mut self, latency_us: f32, delivery_ratio: f32) {
         if self.sample_count == 0 {
@@ -281,7 +288,7 @@ impl HealthMetrics {
                 self.min_delivery_ratio = delivery_ratio;
             }
         }
-        
+
         // Running mean
         let n = self.sample_count as f32;
         self.avg_latency_us = (self.avg_latency_us * n + latency_us) / (n + 1.0);
@@ -289,13 +296,13 @@ impl HealthMetrics {
 
         self.sample_count += 1;
     }
-    
+
     /// Get health status recommendation
     pub fn get_recommendation(&self) -> String {
         if self.sample_count == 0 {
             return "No data available".to_string();
         }
-        
+
         match (self.avg_delivery_ratio, self.min_latency_us) {
             (ratio, latency) if ratio >= 0.95 && latency <= 10.0 => {
                 "Cluster is healthy. No action needed.".to_string()
@@ -306,9 +313,7 @@ impl HealthMetrics {
             (ratio, latency) if ratio >= 0.80 && latency <= 50.0 => {
                 "Cluster performance is poor. Recommend quantization fallback.".to_string()
             }
-            _ => {
-                "Cluster has failed nodes. Investigate and recover.".to_string()
-            }
+            _ => "Cluster has failed nodes. Investigate and recover.".to_string(),
         }
     }
 }
@@ -330,11 +335,11 @@ impl FaultDetector {
             detection_interval,
         }
     }
-    
+
     /// Detect failed nodes based on heartbeat timeouts
     pub fn detect_failures(&self) -> Vec<String> {
         let mut failed_nodes: Vec<String> = Vec::new();
-        
+
         for node in self.cluster.nodes_snapshot().iter() {
             if self.cluster.check_heartbeat_timeout(&node.id) {
                 if let Some(metrics) = self.cluster.get_metrics(&node.id) {
@@ -350,16 +355,16 @@ impl FaultDetector {
                 }
             }
         }
-        
+
         failed_nodes
     }
-    
+
     /// Recover a failed node
     pub fn recover_node(&self, node_id: &str) {
         self.cluster.get_metrics_mut(node_id, |metrics| {
             metrics.status = NodeStatus::Active;
             metrics.last_heartbeat = Instant::now();
-            
+
             // Reset metrics
             metrics.avg_latency_us = 0.0;
             metrics.min_latency_us = f32::MAX;
@@ -369,22 +374,21 @@ impl FaultDetector {
             metrics.throughput_gbps = 0.0;
         });
     }
-    
+
     /// Start periodic fault detection in background
     pub fn start_periodic_detection(&self) {
         let this = self.clone();
-        
-        std::thread::spawn(move || {
-            loop {
-                let failed = this.detect_failures();
-                if !failed.is_empty() {
-                    tracing::warn!("Detected {} failed nodes: {:?}", 
-                        failed.len(), 
-                        failed.iter().map(|s| s.as_str()).collect::<Vec<_>>()
-                    );
-                }
-                std::thread::sleep(this.detection_interval);
+
+        std::thread::spawn(move || loop {
+            let failed = this.detect_failures();
+            if !failed.is_empty() {
+                tracing::warn!(
+                    "Detected {} failed nodes: {:?}",
+                    failed.len(),
+                    failed.iter().map(|s| s.as_str()).collect::<Vec<_>>()
+                );
             }
+            std::thread::sleep(this.detection_interval);
         });
     }
 }
@@ -402,10 +406,10 @@ mod tests {
         let cluster = Arc::new(ClusterState::new());
         cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
         cluster.register(NodeResources::new("node-b", 12.0, 32.0, "8.6", None));
-        
+
         let monitor = NetworkHealthMonitor::new(cluster.clone(), HealthConfig::default());
         monitor.check_all();
-        
+
         let summary = monitor.get_health_summary();
         assert!(summary.contains("Total nodes: 2"));
     }
@@ -414,9 +418,9 @@ mod tests {
     fn health_monitor_detects_degraded_nodes() {
         let cluster = Arc::new(ClusterState::new());
         cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
-        
+
         let monitor = NetworkHealthMonitor::new(cluster.clone(), HealthConfig::default());
-        
+
         // Simulate multiple degraded health checks by seeding recent_checks directly
         // (check_all uses random healthy values, so we manually push degraded results)
         for _ in 0..3 {
@@ -427,7 +431,10 @@ mod tests {
                 status: HealthStatus::Degraded,
                 timestamp: std::time::Instant::now(),
             };
-            monitor.recent_checks.lock().unwrap()
+            monitor
+                .recent_checks
+                .lock()
+                .unwrap()
                 .entry("node-a".to_string())
                 .or_default()
                 .push(result);
@@ -439,11 +446,11 @@ mod tests {
     #[test]
     fn health_metrics_aggregates() {
         let mut metrics = HealthMetrics::new();
-        
+
         metrics.record(1.0, 0.98);
         metrics.record(2.0, 0.95);
         metrics.record(1.5, 0.97);
-        
+
         assert!((metrics.avg_latency_us - 1.5).abs() < 0.1);
         assert!(metrics.min_latency_us <= 1.0);
         assert!(metrics.max_latency_us >= 2.0);
@@ -453,13 +460,13 @@ mod tests {
     fn fault_detector_detects_failures() {
         let cluster = Arc::new(ClusterState::new());
         cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
-        
+
         // Wait for timeout
         std::thread::sleep(Duration::from_secs(6));
-        
+
         let detector = FaultDetector::new(cluster.clone(), Duration::from_secs(1));
         let failed = detector.detect_failures();
-        
+
         assert!(failed.contains(&"node-a".to_string()));
     }
 
@@ -467,26 +474,29 @@ mod tests {
     fn fault_detector_recovers_nodes() {
         let cluster = Arc::new(ClusterState::new());
         cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
-        
+
         std::thread::sleep(Duration::from_secs(6));
-        
+
         let detector = FaultDetector::new(cluster.clone(), Duration::from_secs(1));
         detector.detect_failures();
-        
+
         assert!(cluster.get_metrics("node-a").unwrap().status == NodeStatus::Failed);
-        
+
         detector.recover_node("node-a");
-        assert_eq!(cluster.get_metrics("node-a").unwrap().status, NodeStatus::Active);
+        assert_eq!(
+            cluster.get_metrics("node-a").unwrap().status,
+            NodeStatus::Active
+        );
     }
 
     #[test]
     fn health_monitor_gets_recommendation() {
         let mut metrics = HealthMetrics::new();
-        
+
         // Good cluster
         metrics.record(1.0, 0.98);
         metrics.record(2.0, 0.95);
-        
+
         let recommendation = metrics.get_recommendation();
         assert!(recommendation.contains("healthy"));
     }

--- a/crates/ghostlink-core/src/health.rs
+++ b/crates/ghostlink-core/src/health.rs
@@ -37,7 +37,7 @@ impl Default for HealthConfig {
 }
 
 /// Health status for a node
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum HealthStatus {
     /// Node is healthy
     Healthy,
@@ -46,13 +46,8 @@ pub enum HealthStatus {
     /// Node has failed
     Failed,
     /// No health data available yet
+    #[default]
     Unknown,
-}
-
-impl Default for HealthStatus {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 
 /// Health check result

--- a/crates/ghostlink-core/src/health.rs
+++ b/crates/ghostlink-core/src/health.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use crate::cluster::{ClusterState, NodeMetrics, NodeStatus};
+use crate::cluster::{ClusterState, NodeStatus};
 
 /// Health check configuration
 #[derive(Clone, Copy, Debug)]
@@ -98,12 +98,15 @@ impl NetworkHealthMonitor {
     pub fn check_all(&self) {
         let now = Instant::now();
         
-        for node in self.cluster.nodes() {
-            if let Some(metrics) = self.cluster.get_metrics(&node.id) {
-                // Simulate health check (in production, would use actual ping/pong)
-                let latency_us = 1.0 + (rand::random::<f32>() * 0.5); // Random latency
-                let delivery_ratio = 0.98 - (rand::random::<f32>() * 0.05); // Random delivery ratio
-                
+        for node in self.cluster.nodes_snapshot().iter() {
+            // Simulate health check inputs (production would gather real probe results)
+            let latency_us = 1.0 + (rand::random::<f32>() * 0.5);
+            let delivery_ratio = 0.98 - (rand::random::<f32>() * 0.05);
+
+            if self.cluster.get_metrics_mut(&node.id, |m| {
+                m.record_latency(latency_us);
+                m.record_delivery_ratio(delivery_ratio);
+            }).is_some() {
                 let result = HealthCheckResult {
                     node_id: node.id.clone(),
                     latency_us,
@@ -123,13 +126,6 @@ impl NetworkHealthMonitor {
                     checks.insert(node.id.clone(), vec![result]);
                 }
                 
-                // Update cluster metrics
-                self.cluster.get_metrics_mut(&node.id, |m| {
-                    m.record_latency(latency_us);
-                });
-                self.cluster.get_metrics_mut(&node.id, |m| {
-                    m.record_delivery_ratio(delivery_ratio);
-                });
             }
         }
         
@@ -339,7 +335,7 @@ impl FaultDetector {
     pub fn detect_failures(&self) -> Vec<String> {
         let mut failed_nodes: Vec<String> = Vec::new();
         
-        for node in self.cluster.nodes() {
+        for node in self.cluster.nodes_snapshot().iter() {
             if self.cluster.check_heartbeat_timeout(&node.id) {
                 if let Some(metrics) = self.cluster.get_metrics(&node.id) {
                     // Check if node is already marked as failed

--- a/crates/ghostlink-core/src/lib.rs
+++ b/crates/ghostlink-core/src/lib.rs
@@ -1,5 +1,5 @@
 //! Ghost-Link Core Library
-//! 
+//!
 //! A zero-config LAN fabric that turns spare local GPUs into a shared execution surface
 //! for large-model inference and training.
 //!
@@ -38,6 +38,9 @@ pub mod xdp;
 
 // Re-export common types for convenience
 pub use cluster::{ClusterState, NodeMetrics, NodeStatus};
-pub use planning::{LayerAssignment, LayerSpec, PlacementPlan, QuantizationMode, assign_layers_sequentially, select_quantization_mode};
+pub use planning::{
+    assign_layers_sequentially, select_quantization_mode, LayerAssignment, LayerSpec,
+    PlacementPlan, QuantizationMode,
+};
 pub use protocol::NodeResources;
-pub use ring::{SpscRingBuffer, RingConfig};
+pub use ring::{RingConfig, SpscRingBuffer};

--- a/crates/ghostlink-core/src/load_balance.rs
+++ b/crates/ghostlink-core/src/load_balance.rs
@@ -1,5 +1,5 @@
 //! Tensor Distribution and Load Balancing for Ghost-Link Cluster
-//! 
+//!
 //! This module provides:
 //! - Tensor distribution across nodes based on VRAM capacity
 //! - Dynamic load shedding
@@ -65,40 +65,40 @@ pub struct LoadDistributionPlan {
 impl LoadDistributionPlan {
     /// Create new distribution plan
     pub fn new(distributions: Vec<(String, Vec<TensorSlice>)>, total_layers: usize) -> Self {
-        let participating_nodes = distributions.iter()
+        let participating_nodes = distributions
+            .iter()
             .map(|(node_id, _)| node_id.clone())
             .collect();
-        
+
         Self {
             distributions,
             total_layers,
             participating_nodes,
         }
     }
-    
+
     /// Generate human-readable plan summary
     pub fn summary(&self) -> String {
         let mut output = String::from("Load Distribution Plan\n");
         output.push_str("======================\n\n");
-        
+
         for (node_id, slices) in &self.distributions {
             output.push_str(&format!("Node: {}\n", node_id));
-            
-            let total_size_gb: f32 = slices.iter()
-                .map(|s| s.size_gb)
-                .sum();
-            
+
+            let total_size_gb: f32 = slices.iter().map(|s| s.size_gb).sum();
+
             output.push_str(&format!("  Total size: {:.1} GB\n", total_size_gb));
-            output.push_str(&format!("  Layers: {}-{}\n", 
+            output.push_str(&format!(
+                "  Layers: {}-{}\n",
                 slices.first().map(|s| s.layer_range.0).unwrap_or(0),
                 slices.last().map(|s| s.layer_range.1).unwrap_or(0)
             ));
             output.push('\n');
         }
-        
+
         output.push_str(&format!("Total layers: {}\n", self.total_layers));
         output.push_str(&format!("Nodes: {}\n", self.participating_nodes.join(", ")));
-        
+
         output
     }
 }
@@ -115,37 +115,41 @@ pub struct LoadBalancer {
 impl LoadBalancer {
     /// Create new load balancer
     pub fn new(cluster: Arc<ClusterState>, config: LoadBalanceConfig) -> Self {
-        Self {
-            cluster,
-            config,
-        }
+        Self { cluster, config }
     }
-    
+
     /// Distribute tensor layers across nodes based on VRAM capacity
-    pub fn distribute_layers(&self, layers: &[crate::planning::LayerSpec]) -> Result<LoadDistributionPlan, String> {
+    pub fn distribute_layers(
+        &self,
+        layers: &[crate::planning::LayerSpec],
+    ) -> Result<LoadDistributionPlan, String> {
         let nodes_snapshot = self.cluster.nodes_snapshot();
         if nodes_snapshot.is_empty() {
             return Err("no nodes available".into());
         }
-        
+
         // Sort nodes by VRAM capacity (descending)
         let mut sorted_nodes: Vec<_> = nodes_snapshot.iter().cloned().collect();
-        sorted_nodes.sort_by(|a, b| b.vram_gb.partial_cmp(&a.vram_gb).unwrap_or(std::cmp::Ordering::Equal));
-        
+        sorted_nodes.sort_by(|a, b| {
+            b.vram_gb
+                .partial_cmp(&a.vram_gb)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
         // Collect all layers into a single sorted vector (by index)
         let mut all_layers: Vec<_> = layers.iter().cloned().collect();
         all_layers.sort_by_key(|l| l.index);
         let total_layer_count = all_layers.len();
-        
+
         // Greedy assignment: assign contiguous layers to nodes based on VRAM
         let mut distributions = Vec::new();
         let mut remaining_layers = all_layers;
-        
+
         for node in &sorted_nodes {
             if remaining_layers.is_empty() {
                 break;
             }
-            
+
             let mut used_vram = 0.0f32;
             let mut start_enum = usize::MAX;
             let mut end_enum = 0usize;
@@ -154,28 +158,28 @@ impl LoadBalancer {
                 if used_vram + layer.vram_gb > node.vram_gb {
                     break;
                 }
-                
+
                 if start_enum == usize::MAX {
                     start_enum = enum_idx;
                 }
                 end_enum = enum_idx + 1;
-                
+
                 used_vram += layer.vram_gb;
             }
-            
+
             if start_enum != usize::MAX {
                 let slices: Vec<TensorSlice> = remaining_layers[start_enum..end_enum]
                     .iter()
                     .map(|l| TensorSlice::new((l.index, l.index + 1), l.vram_gb))
                     .collect();
-                
+
                 distributions.push((node.id.clone(), slices));
-                
+
                 // Remove assigned layers from remaining
                 remaining_layers.drain(start_enum..end_enum);
             }
         }
-        
+
         if remaining_layers.is_empty() {
             Ok(LoadDistributionPlan::new(distributions, total_layer_count))
         } else {
@@ -185,86 +189,102 @@ impl LoadBalancer {
             ))
         }
     }
-    
+
     /// Rebalance load based on current node metrics
     pub fn rebalance(&self) -> bool {
         let active_nodes = self.cluster.active_nodes();
-        
+
         if active_nodes.is_empty() {
             return false;
         }
-        
+
         // Calculate average available VRAM across nodes
-        let total_available: f32 = active_nodes.iter()
+        let total_available: f32 = active_nodes
+            .iter()
             .map(|m| m.available_vram_gb)
-            .sum::<f32>() / active_nodes.len() as f32;
-        
+            .sum::<f32>()
+            / active_nodes.len() as f32;
+
         // Check if any node has significantly more available VRAM than average
         for node in &active_nodes {
             let ratio = node.available_vram_gb / total_available;
-            
+
             if ratio > self.config.min_load_threshold {
                 // Node has excess capacity - mark for rebalancing
-                tracing::info!("Node {} has {:.1}% more available VRAM than average", 
-                    node.name, ratio * 100.0);
+                tracing::info!(
+                    "Node {} has {:.1}% more available VRAM than average",
+                    node.name,
+                    ratio * 100.0
+                );
                 return true;
             }
         }
-        
+
         false
     }
-    
+
     /// Shed load from overloaded nodes to underloaded ones
     pub fn shed_load(&self) -> Vec<(String, String)> {
         let mut transfers: Vec<(String, String)> = Vec::new();
-        
+
         // Find overloaded nodes (using < 50% VRAM utilization as overloaded)
-        let overloaded_nodes: Vec<_> = self.cluster.active_nodes()
+        let overloaded_nodes: Vec<_> = self
+            .cluster
+            .active_nodes()
             .into_iter()
             .filter(|m| m.available_vram_gb > m.total_vram_gb * 0.5)
             .collect();
-        
+
         // Find underloaded nodes (using > 80% VRAM utilization as underloaded)
-        let underloaded_nodes: Vec<_> = self.cluster.active_nodes()
+        let underloaded_nodes: Vec<_> = self
+            .cluster
+            .active_nodes()
             .into_iter()
             .filter(|m| m.available_vram_gb < m.total_vram_gb * 0.2)
             .collect();
-        
+
         // For each overloaded node, find a suitable underloaded target
         for overloaded in &overloaded_nodes {
             if let Some(target) = self.find_best_target(underloaded_nodes.as_slice(), overloaded) {
                 transfers.push((overloaded.name.clone(), target.name.clone()));
             }
         }
-        
+
         transfers
     }
-    
+
     /// Find best target node for load transfer
-    fn find_best_target(&self, targets: &[NodeMetrics], source: &NodeMetrics) -> Option<NodeMetrics> {
+    fn find_best_target(
+        &self,
+        targets: &[NodeMetrics],
+        source: &NodeMetrics,
+    ) -> Option<NodeMetrics> {
         // Find node with most available VRAM that's different from source
         let mut best_target: Option<&NodeMetrics> = None;
         let mut max_available = 0.0f32;
-        
+
         for target in targets {
             if target.name == source.name {
                 continue;
             }
-            
+
             if target.available_vram_gb > max_available {
                 max_available = target.available_vram_gb;
                 best_target = Some(target);
             }
         }
-        
+
         best_target.cloned()
     }
-    
+
     /// Distribute layers with deadlock prevention
-    pub fn distribute_with_deadlock_prevention(&self, layers: &[crate::planning::LayerSpec]) -> Result<LoadDistributionPlan, String> {
+    pub fn distribute_with_deadlock_prevention(
+        &self,
+        layers: &[crate::planning::LayerSpec],
+    ) -> Result<LoadDistributionPlan, String> {
         // Use timeout-based acquisition to prevent deadlocks
         let start_time = std::time::Instant::now();
-        
+
         while start_time.elapsed().as_micros() < self.config.lock_timeout_us as u128 {
             match self.distribute_layers(layers) {
                 Ok(plan) => return Ok(plan),
@@ -274,7 +294,7 @@ impl LoadBalancer {
                 }
             }
         }
-        
+
         Err("deadlock prevention timeout".into())
     }
 }
@@ -297,16 +317,19 @@ impl LoadStats {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Record layer distribution
     pub fn record_distribution(&mut self, num_layers: usize, vram_gb: f32) {
         self.total_layers_distributed += num_layers;
         self.total_vram_used_gb += vram_gb;
     }
-    
+
     /// Update load balance ratio
     pub fn update_balance_ratio(&mut self, ratio: f32) {
-        if self.avg_load_balance_ratio == 0.0 && self.rebalancing_count == 0 && self.total_layers_distributed == 0 {
+        if self.avg_load_balance_ratio == 0.0
+            && self.rebalancing_count == 0
+            && self.total_layers_distributed == 0
+        {
             // First call - initialize directly
             self.avg_load_balance_ratio = ratio;
         } else {
@@ -314,12 +337,12 @@ impl LoadStats {
             self.avg_load_balance_ratio = self.avg_load_balance_ratio * 0.9 + ratio * 0.1;
         }
     }
-    
+
     /// Record rebalancing operation
     pub fn record_rebalancing(&mut self) {
         self.rebalancing_count += 1;
     }
-    
+
     /// Get load report
     pub fn report(&self) -> String {
         format!(
@@ -346,23 +369,25 @@ mod tests {
 
     fn sample_layers(count: usize, vram_gb: f32) -> Vec<crate::planning::LayerSpec> {
         (0..count)
-            .map(|index| crate::planning::LayerSpec { 
-                index, 
-                vram_gb, 
-                num_weights: 0, 
+            .map(|index| crate::planning::LayerSpec {
+                index,
+                vram_gb,
+                num_weights: 0,
             })
             .collect()
     }
 
     fn sample_nodes(count: usize, base_vram: f32) -> Vec<NodeResources> {
         (0..count)
-            .map(|i| NodeResources::new(
-                format!("node-{}", i),
-                base_vram + (i as f32 * 6.0),
-                64.0,
-                "8.9".to_string(),
-                None,
-            ))
+            .map(|i| {
+                NodeResources::new(
+                    format!("node-{}", i),
+                    base_vram + (i as f32 * 6.0),
+                    64.0,
+                    "8.9".to_string(),
+                    None,
+                )
+            })
             .collect()
     }
 
@@ -372,10 +397,10 @@ mod tests {
         for node in sample_nodes(2, 24.0) {
             cluster.register(node);
         }
-        
+
         let layers = sample_layers(33, 1.0);
         let balancer = LoadBalancer::new(Arc::new(cluster), LoadBalanceConfig::default());
-        
+
         let plan = balancer.distribute_layers(&layers).unwrap();
         assert_eq!(plan.total_layers, 33);
     }
@@ -386,23 +411,23 @@ mod tests {
         for node in sample_nodes(2, 24.0) {
             cluster.register(node);
         }
-        
+
         let layers = sample_layers(33, 1.0);
         let balancer = LoadBalancer::new(Arc::new(cluster), LoadBalanceConfig::default());
-        
+
         let plan = balancer.distribute_layers(&layers).unwrap();
         let summary = plan.summary();
-        
+
         assert!(summary.contains("Total layers: 33"));
     }
 
     #[test]
     fn load_stats_records_distribution() {
         let mut stats = LoadStats::new();
-        
+
         stats.record_distribution(24, 24.0);
         stats.record_distribution(9, 9.0);
-        
+
         assert_eq!(stats.total_layers_distributed, 33);
         assert!((stats.total_vram_used_gb - 33.0).abs() < 0.01);
     }
@@ -410,10 +435,10 @@ mod tests {
     #[test]
     fn load_stats_updates_balance_ratio() {
         let mut stats = LoadStats::new();
-        
+
         stats.update_balance_ratio(0.95);
         assert!((stats.avg_load_balance_ratio - 0.95).abs() < 1e-6);
-        
+
         stats.update_balance_ratio(0.85);
         // EMA: 0.95 * 0.9 + 0.85 * 0.1 = 0.855 + 0.085 = 0.94
         assert!((stats.avg_load_balance_ratio - 0.94).abs() < 1e-6);
@@ -422,10 +447,10 @@ mod tests {
     #[test]
     fn load_stats_reports() {
         let mut stats = LoadStats::new();
-        
+
         stats.record_distribution(24, 24.0);
         stats.update_balance_ratio(0.95);
-        
+
         let report = stats.report();
         assert!(report.contains("Total layers distributed: 24"));
     }

--- a/crates/ghostlink-core/src/load_balance.rs
+++ b/crates/ghostlink-core/src/load_balance.rs
@@ -137,7 +137,7 @@ impl LoadBalancer {
         });
 
         // Collect all layers into a single sorted vector (by index)
-        let mut all_layers: Vec<_> = layers.iter().cloned().collect();
+        let mut all_layers: Vec<_> = layers.to_vec();
         all_layers.sort_by_key(|l| l.index);
         let total_layer_count = all_layers.len();
 

--- a/crates/ghostlink-core/src/load_balance.rs
+++ b/crates/ghostlink-core/src/load_balance.rs
@@ -123,12 +123,13 @@ impl LoadBalancer {
     
     /// Distribute tensor layers across nodes based on VRAM capacity
     pub fn distribute_layers(&self, layers: &[crate::planning::LayerSpec]) -> Result<LoadDistributionPlan, String> {
-        if self.cluster.nodes().is_empty() {
+        let nodes_snapshot = self.cluster.nodes_snapshot();
+        if nodes_snapshot.is_empty() {
             return Err("no nodes available".into());
         }
         
         // Sort nodes by VRAM capacity (descending)
-        let mut sorted_nodes: Vec<_> = self.cluster.nodes().into_iter().collect();
+        let mut sorted_nodes: Vec<_> = nodes_snapshot.iter().cloned().collect();
         sorted_nodes.sort_by(|a, b| b.vram_gb.partial_cmp(&a.vram_gb).unwrap_or(std::cmp::Ordering::Equal));
         
         // Collect all layers into a single sorted vector (by index)

--- a/crates/ghostlink-core/src/planning.rs
+++ b/crates/ghostlink-core/src/planning.rs
@@ -217,7 +217,7 @@ pub fn assign_layers_with_fault_tolerance(
     cluster: &ClusterState,
     layers: &[LayerSpec],
 ) -> Result<PlacementPlan, String> {
-    let nodes = cluster.nodes();
+    let nodes = cluster.nodes_snapshot();
     
     if nodes.is_empty() {
         return Err("no nodes available".into());
@@ -307,7 +307,7 @@ pub fn calculate_cluster_health(cluster: &ClusterState) -> (f32, usize, Vec<Stri
         .sum::<f32>() / active_nodes.len() as f32;
     
     // Count failed nodes
-    let failed_count = cluster.nodes().iter()
+    let failed_count = cluster.nodes_snapshot().iter()
         .filter(|n| {
             if let Some(metrics) = cluster.get_metrics(&n.id) {
                 metrics.status == NodeStatus::Failed
@@ -318,7 +318,7 @@ pub fn calculate_cluster_health(cluster: &ClusterState) -> (f32, usize, Vec<Stri
         .count();
     
     // Get failed node IDs
-    let failed_nodes: Vec<String> = cluster.nodes()
+    let failed_nodes: Vec<String> = cluster.nodes_snapshot()
         .iter()
         .filter(|n| {
             if let Some(metrics) = cluster.get_metrics(&n.id) {
@@ -336,7 +336,6 @@ pub fn calculate_cluster_health(cluster: &ClusterState) -> (f32, usize, Vec<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cluster::NodeMetrics;
 
     fn sample_layers(count: usize, vram_gb: f32) -> Vec<LayerSpec> {
         (0..count)
@@ -345,18 +344,6 @@ mod tests {
                 vram_gb, 
                 num_weights: 0, 
             })
-            .collect()
-    }
-
-    fn sample_nodes(count: usize, base_vram: f32) -> Vec<NodeResources> {
-        (0..count)
-            .map(|i| NodeResources::new(
-                format!("node-{}", i),
-                base_vram + (i as f32 * 6.0),
-                64.0,
-                "8.9".to_string(),
-                None,
-            ))
             .collect()
     }
 

--- a/crates/ghostlink-core/src/planning.rs
+++ b/crates/ghostlink-core/src/planning.rs
@@ -1,13 +1,13 @@
 //! Greedy Layer Assignment with Fault Tolerance and Adaptive Quantization
-//! 
+//!
 //! This module provides:
 //! - Sequential greedy layer splitting across nodes based on VRAM capacity
 //! - Adaptive quantization trigger (select_quantization_mode)
 //! - Load balancing and fault detection integration
 
+use crate::cluster::NodeStatus;
 use crate::cluster::{ClusterState, NodeMetrics};
 use crate::protocol::NodeResources;
-use crate::cluster::NodeStatus;
 
 /// Delivery ratio thresholds for adaptive quantization
 pub const DELIVERY_RATIO_INT8_THRESHOLD: f32 = 0.95;
@@ -60,7 +60,7 @@ impl LayerAssignment {
             num_layers: end_layer - start_layer,
         }
     }
-    
+
     /// Get average VRAM per layer
     pub fn avg_vram_per_layer(&self) -> f32 {
         if self.num_layers == 0 {
@@ -98,13 +98,9 @@ pub struct PlacementPlan {
 impl PlacementPlan {
     /// Create new placement plan
     pub fn new(assignments: Vec<LayerAssignment>, quantization_mode: QuantizationMode) -> Self {
-        let participating_nodes = assignments.iter()
-            .map(|a| a.node_id.clone())
-            .collect();
-        let total_layers = assignments.iter()
-            .map(|a| a.num_layers)
-            .sum();
-        
+        let participating_nodes = assignments.iter().map(|a| a.node_id.clone()).collect();
+        let total_layers = assignments.iter().map(|a| a.num_layers).sum();
+
         Self {
             assignments,
             quantization_mode,
@@ -112,7 +108,7 @@ impl PlacementPlan {
             participating_nodes,
         }
     }
-    
+
     /// Get human-readable plan summary
     pub fn summary(&self) -> String {
         let mode_str = match self.quantization_mode {
@@ -120,7 +116,7 @@ impl PlacementPlan {
             QuantizationMode::Int8 => "8-bit Quantized",
             QuantizationMode::Int4 => "4-bit Quantized",
         };
-        
+
         format!(
             "Placement Plan ({})\n\
              =================\n\
@@ -186,7 +182,7 @@ pub fn assign_layers_sequentially(
 
         // Assign layer to current node
         remaining_capacity -= layer.vram_gb;
-        
+
         match current_assignment.as_mut() {
             Some(assignment) => {
                 assignment.end_layer = layer.index + 1;
@@ -218,48 +214,47 @@ pub fn assign_layers_with_fault_tolerance(
     layers: &[LayerSpec],
 ) -> Result<PlacementPlan, String> {
     let nodes = cluster.nodes_snapshot();
-    
+
     if nodes.is_empty() {
         return Err("no nodes available".into());
     }
-    
+
     // First pass: greedy assignment
     let assignments = assign_layers_sequentially(&nodes, layers)?;
-    
+
     // Calculate average delivery ratio across all nodes
-    let total_delivery_ratio = cluster.active_nodes()
+    let total_delivery_ratio = cluster
+        .active_nodes()
         .iter()
         .map(|m| m.delivery_ratio)
-        .sum::<f32>() / cluster.active_nodes().len() as f32;
-    
+        .sum::<f32>()
+        / cluster.active_nodes().len() as f32;
+
     // Select quantization mode based on health
     let quantization_mode = select_quantization_mode(total_delivery_ratio);
-    
+
     Ok(PlacementPlan::new(assignments, quantization_mode))
 }
 
 /// Update layer assignments based on node health metrics
-pub fn rebalance_assignments(
-    cluster: &ClusterState,
-    plan: &mut PlacementPlan,
-) -> bool {
+pub fn rebalance_assignments(cluster: &ClusterState, plan: &mut PlacementPlan) -> bool {
     // Check if any active node has high available VRAM
     let mut needs_rebalance = false;
-    
+
     for assignment in &mut plan.assignments {
         if let Some(metrics) = cluster.get_metrics(&assignment.node_id) {
             if metrics.status != NodeStatus::Active {
                 // Skip failed nodes
                 continue;
             }
-            
+
             // Check if this node can take more layers
             let available = metrics.available_vram_gb;
             let avg_layer_size = assignment.avg_vram_per_layer();
-            
+
             if available > 0.0 && avg_layer_size > 0.0 {
                 let potential_layers = (available / avg_layer_size) as usize;
-                
+
                 // If node has significant capacity, mark for rebalancing
                 if potential_layers > 2 {
                     needs_rebalance = true;
@@ -268,7 +263,7 @@ pub fn rebalance_assignments(
             }
         }
     }
-    
+
     needs_rebalance
 }
 
@@ -280,34 +275,35 @@ pub fn simulate_layer_streaming(
     end_layer: usize,
 ) -> Option<NodeMetrics> {
     let mut metrics = cluster.get_metrics(node_id)?;
-    
+
     // Record VRAM usage
     let num_layers = end_layer - start_layer;
     let avg_vram = (metrics.available_vram_gb + metrics.vram_gb) / 2.0;
     let vram_per_layer = avg_vram / num_layers as f32;
     metrics.record_vram_usage(vram_per_layer * num_layers as f32);
-    
+
     // Set streaming layers
     metrics.set_streaming_layers(start_layer, end_layer);
-    
+
     Some(metrics)
 }
 
 /// Calculate network health across the cluster
 pub fn calculate_cluster_health(cluster: &ClusterState) -> (f32, usize, Vec<String>) {
     let active_nodes = cluster.active_nodes();
-    
+
     if active_nodes.is_empty() {
         return (0.0, 0, vec![]);
     }
-    
+
     // Calculate average delivery ratio
-    let avg_delivery_ratio = active_nodes.iter()
-        .map(|m| m.delivery_ratio)
-        .sum::<f32>() / active_nodes.len() as f32;
-    
+    let avg_delivery_ratio =
+        active_nodes.iter().map(|m| m.delivery_ratio).sum::<f32>() / active_nodes.len() as f32;
+
     // Count failed nodes
-    let failed_count = cluster.nodes_snapshot().iter()
+    let failed_count = cluster
+        .nodes_snapshot()
+        .iter()
         .filter(|n| {
             if let Some(metrics) = cluster.get_metrics(&n.id) {
                 metrics.status == NodeStatus::Failed
@@ -316,9 +312,10 @@ pub fn calculate_cluster_health(cluster: &ClusterState) -> (f32, usize, Vec<Stri
             }
         })
         .count();
-    
+
     // Get failed node IDs
-    let failed_nodes: Vec<String> = cluster.nodes_snapshot()
+    let failed_nodes: Vec<String> = cluster
+        .nodes_snapshot()
         .iter()
         .filter(|n| {
             if let Some(metrics) = cluster.get_metrics(&n.id) {
@@ -329,7 +326,7 @@ pub fn calculate_cluster_health(cluster: &ClusterState) -> (f32, usize, Vec<Stri
         })
         .map(|n| n.id.clone())
         .collect();
-    
+
     (avg_delivery_ratio, failed_count, failed_nodes)
 }
 
@@ -339,10 +336,10 @@ mod tests {
 
     fn sample_layers(count: usize, vram_gb: f32) -> Vec<LayerSpec> {
         (0..count)
-            .map(|index| LayerSpec { 
-                index, 
-                vram_gb, 
-                num_weights: 0, 
+            .map(|index| LayerSpec {
+                index,
+                vram_gb,
+                num_weights: 0,
             })
             .collect()
     }
@@ -413,7 +410,7 @@ mod tests {
             vec![LayerAssignment::new("node-a".into(), 0, 24, 24.0)],
             QuantizationMode::None,
         );
-        
+
         // Would need actual cluster state to test rebalancing
         assert!(!rebalance_assignments(&ClusterState::default(), &mut plan));
     }

--- a/crates/ghostlink-core/src/protocol.rs
+++ b/crates/ghostlink-core/src/protocol.rs
@@ -1,5 +1,5 @@
 //! Binary Protocol with CRC32 Checksums for Ghost-Link Discovery
-//! 
+//!
 //! This module implements a fixed-width binary protocol using:
 //! - Fixed-size fields for zero-copy parsing
 //! - CRC32 checksums for frame integrity
@@ -31,12 +31,12 @@ pub struct FrameHeader {
 
 impl FrameHeader {
     const HEADER_SIZE: usize = 8; // 2 + 1 + 1 + 4 bytes
-    
+
     /// Create a new frame header with computed CRC
     pub fn new(ether_type: u16, kind: u8, payload: &[u8]) -> Self {
         let mut hasher = Hasher::new();
         hasher.update(payload);
-        
+
         Self {
             ether_type,
             kind,
@@ -44,7 +44,7 @@ impl FrameHeader {
             crc: hasher.finalize(),
         }
     }
-    
+
     /// Encode header as bytes (little-endian)
     pub fn encode(&self) -> [u8; Self::HEADER_SIZE] {
         let mut header = [0u8; Self::HEADER_SIZE];
@@ -130,9 +130,9 @@ impl NodeResources {
             gpu_name,
         }
     }
-    
+
     /// Serialize node resources to fixed-width binary payload
-    /// 
+    ///
     /// Format: [id_len(1) + id + vram_f32_le + mem_f32_le + cc_len(1) + cc]
     #[inline]
     pub fn encode_payload(&self, max_size: usize) -> Vec<u8> {
@@ -149,10 +149,8 @@ impl NodeResources {
             }
         }
 
-        let payload_len = 11
-            + id_bytes.len()
-            + cc_bytes.len()
-            + gpu_bytes.map_or(0, |bytes| 2 + bytes.len());
+        let payload_len =
+            11 + id_bytes.len() + cc_bytes.len() + gpu_bytes.map_or(0, |bytes| 2 + bytes.len());
         if payload_len > max_size {
             return Vec::new();
         }
@@ -179,42 +177,43 @@ impl NodeResources {
 
         payload
     }
-    
+
     /// Deserialize node resources from binary payload
     pub fn decode_payload(payload: &[u8]) -> Result<Self, String> {
         if payload.len() < 16 {
             return Err("payload too short".into());
         }
-        
+
         // Read ID length
         let id_len = payload[0] as usize;
         if id_len > payload.len() - 4 {
             return Err("invalid ID length".into());
         }
-        
+
         // Read ID
         let id = unsafe { std::str::from_utf8_unchecked(&payload[1..1 + id_len]) };
-        
+
         // Read VRAM (little-endian f32)
         let vram_bytes: [u8; 4] = payload[1 + id_len..5 + id_len].try_into().unwrap();
         let vram_gb = f32::from_le_bytes(vram_bytes);
-        
+
         // Read system memory (little-endian f32)
         let mem_bytes: [u8; 4] = payload[5 + id_len..9 + id_len].try_into().unwrap();
         let system_memory_gb = f32::from_le_bytes(mem_bytes);
-        
+
         // Read compute capability length
         let cc_len = payload[9 + id_len] as usize;
         if cc_len > payload.len() - 10 {
             return Err("invalid CC length".into());
         }
-        
+
         // Read compute capability
-        let cc = unsafe { std::str::from_utf8_unchecked(&payload[10 + id_len..10 + id_len + cc_len]) };
-        
+        let cc =
+            unsafe { std::str::from_utf8_unchecked(&payload[10 + id_len..10 + id_len + cc_len]) };
+
         // Check for GPU name flag
         let has_gpu_name = payload[10 + id_len + cc_len] == 1;
-        
+
         Ok(Self {
             id: id.to_string(),
             vram_gb,
@@ -225,12 +224,14 @@ impl NodeResources {
                 if gpu_len > payload.len() - 12 - id_len - cc_len {
                     return Err("invalid GPU name length".into());
                 }
-                Some(unsafe {
-                    std::str::from_utf8_unchecked(
-                        &payload[10 + id_len + cc_len + 2..10 + id_len + cc_len + 2 + gpu_len],
-                    )
-                }
-                .to_string())
+                Some(
+                    unsafe {
+                        std::str::from_utf8_unchecked(
+                            &payload[10 + id_len + cc_len + 2..10 + id_len + cc_len + 2 + gpu_len],
+                        )
+                    }
+                    .to_string(),
+                )
             } else {
                 None
             },
@@ -250,12 +251,12 @@ impl DiscoveryFrame {
     #[inline]
     pub fn encode(&self) -> Vec<u8> {
         let payload = self.node.encode_payload(MAX_PAYLOAD_SIZE);
-        
+
         // Compute CRC32 over payload
         let mut hasher = Hasher::new();
         hasher.update(&payload);
         let crc = hasher.finalize();
-        
+
         // Build header
         let header = FrameHeader {
             ether_type: GHOSTLINK_ETHERTYPE,
@@ -264,53 +265,55 @@ impl DiscoveryFrame {
             crc,
         };
         let header_bytes = header.encode();
-        
+
         // Combine header and payload
         let mut frame = Vec::with_capacity(header_bytes.len() + payload.len());
         frame.extend_from_slice(&header_bytes);
         frame.extend_from_slice(&payload);
-        
+
         frame
     }
-    
+
     /// Decode discovery frame from bytes (header + payload)
     #[inline]
     pub fn decode(bytes: &[u8]) -> Result<Self, String> {
         if bytes.len() < FrameHeader::HEADER_SIZE {
             return Err("frame too short".into());
         }
-        
+
         // Parse header
         let ether_type = u16::from_le_bytes([bytes[0], bytes[1]]);
         let kind = FrameKind::try_from(bytes[2])?;
         let version = bytes[3];
         let expected_crc = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
-        
+
         if ether_type != GHOSTLINK_ETHERTYPE {
             return Err(format!("unexpected EtherType 0x{ether_type:04x}"));
         }
-        
+
         if version != PROTOCOL_VERSION {
             return Err(format!("unsupported protocol version {version}"));
         }
-        
+
         // Parse payload with CRC verification
         let payload_start = FrameHeader::HEADER_SIZE;
         let payload_end = bytes.len();
         let payload = &bytes[payload_start..payload_end];
-        
+
         // Compute CRC over payload
         let mut hasher = Hasher::new();
         hasher.update(payload);
         let computed_crc = hasher.finalize();
-        
+
         if computed_crc != expected_crc {
-            return Err(format!("CRC mismatch: expected 0x{expected_crc:08x}, got 0x{computed_crc:08x}"));
+            return Err(format!(
+                "CRC mismatch: expected 0x{expected_crc:08x}, got 0x{computed_crc:08x}"
+            ));
         }
-        
+
         // Decode node resources from payload
         let node = NodeResources::decode_payload(payload)?;
-        
+
         Ok(Self { kind, node })
     }
 }
@@ -344,7 +347,7 @@ mod tests {
         let encoded = frame.encode();
         let mut modified = encoded.clone();
         modified[10] ^= 0xFF; // Modify payload
-        
+
         let result = DiscoveryFrame::decode(&modified);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("CRC mismatch"));
@@ -354,8 +357,8 @@ mod tests {
     fn rejects_wrong_ether_type() {
         let mut fake_frame = vec![0u8; 10];
         fake_frame[0] = 0xB5u8; // Low byte of GHOSTLINK_ETHERTYPE (0x88B5 LE)
-        fake_frame[1] = 0xFF;   // Wrong high byte
-        
+        fake_frame[1] = 0xFF; // Wrong high byte
+
         let result = DiscoveryFrame::decode(&fake_frame);
         assert!(result.is_err());
     }
@@ -365,17 +368,20 @@ mod tests {
         let frame = DiscoveryFrame {
             kind: FrameKind::Discovery,
             node: NodeResources::new(
-                "gpu-node-1", 
-                24.0, 
-                64.0, 
-                "9.0", 
-                Some("NVIDIA GeForce RTX 4090".to_string())
+                "gpu-node-1",
+                24.0,
+                64.0,
+                "9.0",
+                Some("NVIDIA GeForce RTX 4090".to_string()),
             ),
         };
 
         let encoded = frame.encode();
         let decoded = DiscoveryFrame::decode(&encoded).unwrap();
 
-        assert_eq!(decoded.node.gpu_name, Some("NVIDIA GeForce RTX 4090".to_string()));
+        assert_eq!(
+            decoded.node.gpu_name,
+            Some("NVIDIA GeForce RTX 4090".to_string())
+        );
     }
 }

--- a/crates/ghostlink-core/src/protocol.rs
+++ b/crates/ghostlink-core/src/protocol.rs
@@ -6,7 +6,6 @@
 //! - Sequence numbers and versioning for ordering
 
 use crc32fast::Hasher;
-use std::mem::MaybeUninit;
 
 /// Ghost-Link EtherType (0x88B5)
 pub const GHOSTLINK_ETHERTYPE: u16 = 0x88B5;
@@ -135,50 +134,49 @@ impl NodeResources {
     /// Serialize node resources to fixed-width binary payload
     /// 
     /// Format: [id_len(1) + id + vram_f32_le + mem_f32_le + cc_len(1) + cc]
+    #[inline]
     pub fn encode_payload(&self, max_size: usize) -> Vec<u8> {
-        let mut payload = Vec::with_capacity(max_size);
-        
-        // ID length (1 byte)
         let id_bytes = self.id.as_bytes();
-        if id_bytes.len() > max_size - 4 {
-            return Vec::new(); // Too long
+        let cc_bytes = self.compute_capability.as_bytes();
+        let gpu_bytes = self.gpu_name.as_ref().map(|name| name.as_bytes());
+
+        if id_bytes.len() > u8::MAX as usize || cc_bytes.len() > u8::MAX as usize {
+            return Vec::new();
         }
+        if let Some(gpu_bytes) = gpu_bytes {
+            if gpu_bytes.len() > u8::MAX as usize {
+                return Vec::new();
+            }
+        }
+
+        let payload_len = 11
+            + id_bytes.len()
+            + cc_bytes.len()
+            + gpu_bytes.map_or(0, |bytes| 2 + bytes.len());
+        if payload_len > max_size {
+            return Vec::new();
+        }
+
+        let mut payload = Vec::with_capacity(payload_len);
         payload.push(id_bytes.len() as u8);
         payload.extend_from_slice(id_bytes);
-        
-        // VRAM (4 bytes, little-endian f32)
-        unsafe {
-            let ptr = &self.vram_gb as *const f32 as *const u8;
-            payload.extend_from_slice(&*(ptr as *const [u8; 4]));
-        }
-        
-        // System memory (4 bytes, little-endian f32)
-        unsafe {
-            let ptr = &self.system_memory_gb as *const f32 as *const u8;
-            payload.extend_from_slice(&*(ptr as *const [u8; 4]));
-        }
-        
-        // Compute capability length (1 byte)
-        let cc_bytes = self.compute_capability.as_bytes();
-        if cc_bytes.len() > max_size - 8 {
-            return Vec::new(); // Too long
-        }
+        payload.extend_from_slice(unsafe {
+            std::slice::from_raw_parts(&self.vram_gb as *const f32 as *const u8, 4)
+        });
+        payload.extend_from_slice(unsafe {
+            std::slice::from_raw_parts(&self.system_memory_gb as *const f32 as *const u8, 4)
+        });
         payload.push(cc_bytes.len() as u8);
         payload.extend_from_slice(cc_bytes);
-        
-        // GPU name (optional, prefixed with length)
-        if let Some(ref gpu_name) = self.gpu_name {
-            let gpu_bytes = gpu_name.as_bytes();
-            if gpu_bytes.len() > max_size - 10 {
-                return Vec::new(); // Too long
-            }
-            payload.push(1); // Flag indicating GPU name present
+
+        if let Some(gpu_bytes) = gpu_bytes {
+            payload.push(1);
             payload.push(gpu_bytes.len() as u8);
             payload.extend_from_slice(gpu_bytes);
         } else {
-            payload.push(0); // No GPU name
+            payload.push(0);
         }
-        
+
         payload
     }
     
@@ -195,8 +193,7 @@ impl NodeResources {
         }
         
         // Read ID
-        let id = std::str::from_utf8(&payload[1..1 + id_len])
-            .map_err(|e| e.to_string())?;
+        let id = unsafe { std::str::from_utf8_unchecked(&payload[1..1 + id_len]) };
         
         // Read VRAM (little-endian f32)
         let vram_bytes: [u8; 4] = payload[1 + id_len..5 + id_len].try_into().unwrap();
@@ -213,8 +210,7 @@ impl NodeResources {
         }
         
         // Read compute capability
-        let cc = std::str::from_utf8(&payload[10 + id_len..10 + id_len + cc_len])
-            .map_err(|e| e.to_string())?;
+        let cc = unsafe { std::str::from_utf8_unchecked(&payload[10 + id_len..10 + id_len + cc_len]) };
         
         // Check for GPU name flag
         let has_gpu_name = payload[10 + id_len + cc_len] == 1;
@@ -229,9 +225,12 @@ impl NodeResources {
                 if gpu_len > payload.len() - 12 - id_len - cc_len {
                     return Err("invalid GPU name length".into());
                 }
-                Some(std::str::from_utf8(&payload[10 + id_len + cc_len + 2..10 + id_len + cc_len + 2 + gpu_len])
-                    .map_err(|e| e.to_string())?
-                    .to_string())
+                Some(unsafe {
+                    std::str::from_utf8_unchecked(
+                        &payload[10 + id_len + cc_len + 2..10 + id_len + cc_len + 2 + gpu_len],
+                    )
+                }
+                .to_string())
             } else {
                 None
             },
@@ -248,9 +247,9 @@ pub struct DiscoveryFrame {
 
 impl DiscoveryFrame {
     /// Encode discovery frame to bytes (header + payload)
+    #[inline]
     pub fn encode(&self) -> Vec<u8> {
-        // Create payload
-        let mut payload = self.node.encode_payload(MAX_PAYLOAD_SIZE);
+        let payload = self.node.encode_payload(MAX_PAYLOAD_SIZE);
         
         // Compute CRC32 over payload
         let mut hasher = Hasher::new();
@@ -264,16 +263,18 @@ impl DiscoveryFrame {
             version: PROTOCOL_VERSION,
             crc,
         };
+        let header_bytes = header.encode();
         
         // Combine header and payload
-        let mut frame = Vec::with_capacity(header.encode().len() + payload.len());
-        frame.extend_from_slice(&header.encode());
+        let mut frame = Vec::with_capacity(header_bytes.len() + payload.len());
+        frame.extend_from_slice(&header_bytes);
         frame.extend_from_slice(&payload);
         
         frame
     }
     
     /// Decode discovery frame from bytes (header + payload)
+    #[inline]
     pub fn decode(bytes: &[u8]) -> Result<Self, String> {
         if bytes.len() < FrameHeader::HEADER_SIZE {
             return Err("frame too short".into());

--- a/crates/ghostlink-core/src/ring.rs
+++ b/crates/ghostlink-core/src/ring.rs
@@ -1,5 +1,5 @@
 //! Zero-Copy SPSC Ring Buffer with AF_XDP Integration
-//! 
+//!
 //! This implementation uses pinned allocations and proper memory ordering
 //! for single-producer/single-consumer DMA-style hand-off.
 
@@ -19,8 +19,8 @@ pub struct RingConfig {
 impl Default for RingConfig {
     fn default() -> Self {
         Self {
-            capacity: 1023, // Must be < RING_CAPACITY to avoid wraparound aliasing
-            backpressure_threshold: 716 // ~70% of 1023, // 70% of 1024
+            capacity: 1023,              // Must be < RING_CAPACITY to avoid wraparound aliasing
+            backpressure_threshold: 716, // ~70% of 1023, // 70% of 1024
         }
     }
 }
@@ -29,7 +29,7 @@ impl Default for RingConfig {
 const RING_CAPACITY: usize = 1024;
 
 /// Zero-copy SPSC ring buffer with proper memory ordering
-/// 
+///
 /// # Safety
 /// This type is only safe to use when:
 /// - Only one producer thread exists
@@ -53,16 +53,19 @@ pub struct SpscRingBuffer<T> {
 
 impl<T> SpscRingBuffer<T> {
     const CAPACITY: usize = RING_CAPACITY;
-    
+
     /// Create a new SPSC ring buffer with the given configuration
     pub fn new(config: RingConfig) -> Self {
-        assert!(config.capacity < Self::CAPACITY, "capacity must be strictly less than RING_CAPACITY");
-        
+        assert!(
+            config.capacity < Self::CAPACITY,
+            "capacity must be strictly less than RING_CAPACITY"
+        );
+
         // Safety: MaybeUninit does not require initialization
         let buffer = UnsafeCell::new(unsafe {
             MaybeUninit::<[MaybeUninit<T>; RING_CAPACITY]>::uninit().assume_init()
         });
-        
+
         Self {
             buffer,
             head: AtomicUsize::new(0),
@@ -72,73 +75,69 @@ impl<T> SpscRingBuffer<T> {
             config,
         }
     }
-    
+
     /// Push an element into the ring buffer
-    /// 
+    ///
     /// Returns `Ok(())` on success, or `Err(value)` if the ring is full.
     /// When full, the producer should wait/backpressure until space is available.
     pub fn push(&self, value: T) -> Result<(), T> {
         let tail = self.tail.load(Ordering::Acquire);
         let head = self.head.load(Ordering::Acquire);
-        
+
         // Check if ring is full using count (respects config.capacity)
         let current_len = if tail >= head {
             tail - head
         } else {
             Self::CAPACITY - head + tail
         };
-        
+
         if current_len >= self.config.capacity {
             self.overflow_count.fetch_add(1, Ordering::Relaxed);
             return Err(value);
         }
-        
+
         let next_tail = Self::increment(tail);
-        
+
         // Write the value at tail position
         unsafe {
             let buf = &mut *self.buffer.get();
             buf[tail].write(value);
-            
+
             // Release store to make write visible to consumer
             self.tail.store(next_tail, Ordering::Release);
         }
-        
+
         Ok(())
     }
-    
+
     /// Pop an element from the ring buffer
-    /// 
+    ///
     /// Returns `Some(value)` on success, or `None` if the ring is empty.
     pub fn pop(&self) -> Option<T> {
         let head = self.head.load(Ordering::Acquire);
         let tail = self.tail.load(Ordering::Acquire);
-        
+
         // Check if ring is empty (with wrap-around handling)
-        let is_empty = if head >= tail {
-            head == tail
-        } else {
-            false
-        };
-        
+        let is_empty = if head >= tail { head == tail } else { false };
+
         if is_empty {
             return None;
         }
-        
+
         // Read the value at head position
         let value = unsafe {
             let buf = &mut *self.buffer.get();
             let val = buf[head].assume_init_read();
-            
+
             // Release store to make read visible to producer
             self.head.store(Self::increment(head), Ordering::Release);
-            
+
             val
         };
-        
+
         Some(value)
     }
-    
+
     /// Get the current number of elements in the ring
     pub fn len(&self) -> usize {
         let head = self.head.load(Ordering::Acquire);
@@ -146,35 +145,35 @@ impl<T> SpscRingBuffer<T> {
 
         tail.wrapping_sub(head) & (Self::CAPACITY - 1)
     }
-    
+
     /// Check if the ring is empty
     pub fn is_empty(&self) -> bool {
         self.head.load(Ordering::Acquire) == self.tail.load(Ordering::Acquire)
     }
-    
+
     /// Get the configured capacity
     pub fn capacity(&self) -> usize {
         self.config.capacity
     }
-    
+
     /// Get overflow count for backpressure monitoring
     pub fn overflow_count(&self) -> usize {
         self.overflow_count.load(Ordering::Relaxed)
     }
-    
+
     /// Get empty count for backpressure monitoring
     pub fn empty_count(&self) -> usize {
         self.empty_count.load(Ordering::Relaxed)
     }
-    
+
     /// Check if backpressure should be applied (ring >= threshold)
     pub fn should_backpressure(&self) -> bool {
         let len = self.len();
         len >= self.config.backpressure_threshold
     }
-    
+
     /// Wait for space to become available
-    /// 
+    ///
     /// Spins until there's room in the ring buffer.
     pub fn wait_for_space(&self) {
         while self.should_backpressure() {
@@ -182,9 +181,9 @@ impl<T> SpscRingBuffer<T> {
             std::thread::yield_now();
         }
     }
-    
+
     /// Wait for an element to become available
-    /// 
+    ///
     /// Spins until there's data in the ring buffer.
     pub fn wait_for_data(&self) {
         while self.is_empty() {
@@ -192,7 +191,7 @@ impl<T> SpscRingBuffer<T> {
             std::thread::yield_now();
         }
     }
-    
+
     fn increment(index: usize) -> usize {
         (index + 1) & (Self::CAPACITY - 1)
     }
@@ -280,19 +279,19 @@ mod tests {
     #[test]
     fn handles_wrap_around_correctly() {
         let ring = SpscRingBuffer::<i32>::new(RingConfig::default());
-        
+
         // Fill most of the ring
         for i in 0..1020 {
             ring.push(i).unwrap();
         }
-        
+
         assert_eq!(ring.len(), 1020);
-        
+
         // Pop all elements in FIFO order
         for i in 0..1020 {
             assert_eq!(ring.pop(), Some(i));
         }
-        
+
         assert!(ring.is_empty());
     }
 
@@ -303,13 +302,13 @@ mod tests {
             backpressure_threshold: 70,
         };
         let ring = SpscRingBuffer::<i32>::new(config);
-        
+
         // Fill to threshold - should not backpressure
         for i in 0..69 {
             ring.push(i).unwrap();
         }
         assert!(!ring.should_backpressure());
-        
+
         // Fill one more - should backpressure
         let result = ring.push(70);
         assert!(result.is_ok()); // Push succeeds until capacity (100) is reached

--- a/crates/ghostlink-core/src/ring.rs
+++ b/crates/ghostlink-core/src/ring.rs
@@ -143,12 +143,8 @@ impl<T> SpscRingBuffer<T> {
     pub fn len(&self) -> usize {
         let head = self.head.load(Ordering::Acquire);
         let tail = self.tail.load(Ordering::Acquire);
-        
-        if tail >= head {
-            tail - head
-        } else {
-            Self::CAPACITY - head + tail
-        }
+
+        tail.wrapping_sub(head) & (Self::CAPACITY - 1)
     }
     
     /// Check if the ring is empty
@@ -198,7 +194,7 @@ impl<T> SpscRingBuffer<T> {
     }
     
     fn increment(index: usize) -> usize {
-        (index + 1) % Self::CAPACITY
+        (index + 1) & (Self::CAPACITY - 1)
     }
 }
 

--- a/crates/ghostlink-core/src/xdp.rs
+++ b/crates/ghostlink-core/src/xdp.rs
@@ -1,5 +1,5 @@
 //! AF_XDP/eBPF Socket Integration for Ghost-Link
-//! 
+//!
 //! This module provides:
 //! - Raw socket binding with AF_XDP
 //! - EtherType filtering (0x88B5)
@@ -46,23 +46,25 @@ impl XdpSocketHandle {
     pub fn new(interface_name: &str) -> Result<Self, String> {
         // Note: This is a placeholder for Linux-specific implementation
         // Actual implementation would use syscall! macro or bindgen
-        
-        Err(format!("AF_XDP sockets are Linux-only (requested interface: {interface_name})"))
+
+        Err(format!(
+            "AF_XDP sockets are Linux-only (requested interface: {interface_name})"
+        ))
     }
-    
+
     /// Bind socket to interface (Linux-specific)
     pub fn bind(&self, _interface_name: &str) -> Result<(), String> {
         Err("AF_XDP binding requires Linux kernel support".into())
     }
-    
+
     /// Receive frame from XDP socket
-    /// 
+    ///
     /// Returns the raw frame bytes.
     pub fn recv_frame(&self, _buffer: &mut [u8]) -> Option<usize> {
         // Placeholder - actual implementation uses recvmsg syscall
         None
     }
-    
+
     /// Send frame to XDP socket (for outgoing traffic)
     pub fn send_frame(&self, _data: &[u8]) -> Result<(), String> {
         Err("AF_XDP send requires specific setup".into())
@@ -82,35 +84,35 @@ impl XdpFrameReceiver {
     /// Create new frame receiver
     pub fn new(config: XdpConfig) -> Self {
         let ring = crate::ring::SpscRingBuffer::new(RingConfig::default());
-        
+
         Self {
             config,
             ring_buffer: ring,
         }
     }
-    
+
     /// Receive and parse discovery frame from raw socket
     pub fn recv_discovery_frame(&self) -> Option<DiscoveryFrame> {
         let _ = (&self.config.interface_name, self.config.memory_order);
         None
     }
-    
+
     /// Process raw frame bytes and extract discovery frame
     pub fn process_frame(&self, bytes: &[u8]) -> Option<DiscoveryFrame> {
         if bytes.len() < 10 {
             return None;
         }
-        
+
         // Check EtherType filter
         let ether_type = u16::from_le_bytes([bytes[0], bytes[1]]);
         if ether_type != GHOSTLINK_ETHERTYPE {
             return None;
         }
-        
+
         // Try to decode as discovery frame
         DiscoveryFrame::decode(bytes).ok()
     }
-    
+
     /// Get ring buffer statistics
     pub fn ring_stats(&self) -> (usize, usize) {
         (self.ring_buffer.len(), self.ring_buffer.capacity())
@@ -131,15 +133,21 @@ impl EbpfProgramLoader {
             program_name: program_name.to_string(),
         }
     }
-    
+
     /// Load eBPF program (Linux-specific)
     pub fn load(&self, _program_path: &str) -> Result<(), String> {
-        Err(format!("eBPF loading for '{}' requires Linux kernel support", self.program_name))
+        Err(format!(
+            "eBPF loading for '{}' requires Linux kernel support",
+            self.program_name
+        ))
     }
-    
+
     /// Attach eBPF program to XDP socket
     pub fn attach(&self, _fd: c_int) -> Result<(), String> {
-        Err(format!("eBPF attachment for '{}' requires Linux kernel support", self.program_name))
+        Err(format!(
+            "eBPF attachment for '{}' requires Linux kernel support",
+            self.program_name
+        ))
     }
 }
 
@@ -165,23 +173,23 @@ impl XdpStats {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Record frame received
     pub fn record_received(&mut self) {
         self.frames_received += 1;
     }
-    
+
     /// Record frame dropped
     pub fn record_dropped(&mut self) {
         self.frames_received += 1;
         self.frames_dropped += 1;
     }
-    
+
     /// Record frame processed
     pub fn record_processed(&mut self) {
         self.frames_processed += 1;
     }
-    
+
     /// Update average latency
     pub fn update_latency(&mut self, latency_us: f32) {
         if !self.latency_initialized {
@@ -192,7 +200,7 @@ impl XdpStats {
             self.avg_latency_us = self.avg_latency_us * 0.9 + latency_us * 0.1;
         }
     }
-    
+
     /// Get throughput estimate (frames/sec)
     pub fn throughput(&self, duration_seconds: f32) -> Option<f64> {
         if duration_seconds > 0.0 {
@@ -201,7 +209,7 @@ impl XdpStats {
             None
         }
     }
-    
+
     /// Generate statistics report
     pub fn report(&self) -> String {
         format!(
@@ -240,14 +248,14 @@ impl XdpReceiver {
     /// Create new XDP receiver with statistics
     pub fn new(config: XdpConfig) -> Self {
         let frame_receiver = XdpFrameReceiver::new(config.clone());
-        
+
         Self {
             config,
             frame_receiver,
             stats: XdpStats::new(),
         }
     }
-    
+
     /// Receive and process frames from socket
     pub fn recv_loop(&self) -> Result<(), String> {
         // In production, this would use AF_XDP recvmsg in a loop
@@ -255,7 +263,7 @@ impl XdpReceiver {
         let _ = (&self.config.interface_name, self.config.memory_order);
         Ok(())
     }
-    
+
     /// Process received frame and extract discovery frame
     pub fn process_frame(&mut self, bytes: &[u8]) -> Option<DiscoveryFrame> {
         if let Some(frame) = self.frame_receiver.process_frame(bytes) {
@@ -268,7 +276,7 @@ impl XdpReceiver {
             None
         }
     }
-    
+
     /// Get current statistics
     pub fn stats(&self) -> &XdpStats {
         &self.stats
@@ -292,7 +300,7 @@ impl XdpSocketManager {
             fd: None,
         }
     }
-    
+
     /// Initialize AF_XDP socket and bind to interface
     pub fn init(&mut self) -> Result<(), String> {
         // This would use syscall! macro for Linux-specific syscalls
@@ -300,18 +308,18 @@ impl XdpSocketManager {
         let _ = &self.interface_name;
         Ok(())
     }
-    
+
     /// Receive frame using AF_XDP recvmsg
     pub fn recv_frame(&mut self, _buffer: &mut [u8]) -> Option<usize> {
         // Placeholder - actual implementation uses recvmsg syscall
         None
     }
-    
+
     /// Send frame using AF_XDP sendmsg
     pub fn send_frame(&mut self, _data: &[u8]) -> Result<(), String> {
         Err("AF_XDP send requires specific setup".into())
     }
-    
+
     /// Close socket
     pub fn close(&mut self) {
         if let Some(fd) = self.fd.take() {
@@ -331,16 +339,16 @@ mod tests {
     #[test]
     fn xdp_receiver_processes_frames() {
         let mut receiver = XdpReceiver::new(XdpConfig::default());
-        
+
         // Create a test discovery frame
         let node = NodeResources::new("test-node", 24.0, 64.0, "8.9".to_string(), None);
         let frame = DiscoveryFrame {
             kind: FrameKind::Discovery,
             node,
         };
-        
+
         let encoded = frame.encode();
-        
+
         // Process the frame
         let decoded = receiver.process_frame(&encoded);
         assert!(decoded.is_some());
@@ -349,12 +357,12 @@ mod tests {
     #[test]
     fn xdp_stats_tracks_frames() {
         let mut stats = XdpStats::new();
-        
+
         stats.record_received();
         stats.record_received();
         stats.record_dropped();
         stats.record_processed();
-        
+
         assert_eq!(stats.frames_received, 3);
         assert_eq!(stats.frames_dropped, 1);
         assert_eq!(stats.frames_processed, 1);
@@ -363,10 +371,10 @@ mod tests {
     #[test]
     fn xdp_stats_reports_throughput() {
         let mut stats = XdpStats::new();
-        
+
         stats.record_received();
         stats.record_received();
-        
+
         let throughput = stats.throughput(2.0);
         assert_eq!(throughput, Some(1.0));
     }
@@ -374,10 +382,10 @@ mod tests {
     #[test]
     fn xdp_stats_updates_latency() {
         let mut stats = XdpStats::new();
-        
+
         stats.update_latency(1.0);
         assert_eq!(stats.avg_latency_us, 1.0);
-        
+
         stats.update_latency(2.0);
         // EMA: 1.0 * 0.9 + 2.0 * 0.1 = 0.9 + 0.2 = 1.1
         assert!((stats.avg_latency_us - 1.1).abs() < 1e-6);
@@ -386,12 +394,12 @@ mod tests {
     #[test]
     fn xdp_receiver_rejects_wrong_ether_type() {
         let mut receiver = XdpReceiver::new(XdpConfig::default());
-        
+
         // Create a frame with wrong EtherType
         let mut fake_frame = vec![0u8; 10];
         fake_frame[0] = 0xB5u8; // Low byte of GHOSTLINK_ETHERTYPE (0x88B5 LE)
-        fake_frame[1] = 0xFF;   // Wrong high byte
-        
+        fake_frame[1] = 0xFF; // Wrong high byte
+
         let result = receiver.process_frame(&fake_frame);
         assert!(result.is_none());
     }
@@ -399,12 +407,12 @@ mod tests {
     #[test]
     fn xdp_stats_reports() {
         let mut stats = XdpStats::new();
-        
+
         stats.record_received();
         stats.record_received();
         stats.record_dropped();
         stats.update_latency(1.5);
-        
+
         let report = stats.report();
         assert!(report.contains("Frames received: 3"));
         assert!(report.contains("Frames dropped: 1"));

--- a/crates/ghostlink-core/src/xdp.rs
+++ b/crates/ghostlink-core/src/xdp.rs
@@ -6,18 +6,10 @@
 //! - Frame reception loop with zero-copy buffers
 //! - eBPF program loading helpers
 
-use std::ffi::c_void;
-use std::mem;
-use std::os::raw::{c_char, c_int};
-use std::ptr;
+use std::os::raw::c_int;
 
 use crate::protocol::{DiscoveryFrame, GHOSTLINK_ETHERTYPE};
 use crate::ring::RingConfig;
-
-/// AF_XDP socket constants (Linux-specific)
-const SOL_XDP: i32 = 0x2F;
-const XDP_ATTACHED: i32 = 1;
-const XDP_UNMAP: i32 = 1;
 
 /// Maximum size of XDP frame (including header)
 pub const MAX_XDP_FRAME_SIZE: usize = 2048;
@@ -55,7 +47,7 @@ impl XdpSocketHandle {
         // Note: This is a placeholder for Linux-specific implementation
         // Actual implementation would use syscall! macro or bindgen
         
-        Err("AF_XDP sockets are Linux-only".into())
+        Err(format!("AF_XDP sockets are Linux-only (requested interface: {interface_name})"))
     }
     
     /// Bind socket to interface (Linux-specific)
@@ -66,13 +58,13 @@ impl XdpSocketHandle {
     /// Receive frame from XDP socket
     /// 
     /// Returns the raw frame bytes.
-    pub fn recv_frame(&self, buffer: &mut [u8]) -> Option<usize> {
+    pub fn recv_frame(&self, _buffer: &mut [u8]) -> Option<usize> {
         // Placeholder - actual implementation uses recvmsg syscall
         None
     }
     
     /// Send frame to XDP socket (for outgoing traffic)
-    pub fn send_frame(&self, data: &[u8]) -> Result<(), String> {
+    pub fn send_frame(&self, _data: &[u8]) -> Result<(), String> {
         Err("AF_XDP send requires specific setup".into())
     }
 }
@@ -99,12 +91,7 @@ impl XdpFrameReceiver {
     
     /// Receive and parse discovery frame from raw socket
     pub fn recv_discovery_frame(&self) -> Option<DiscoveryFrame> {
-        // Allocate buffer for incoming frame
-        let mut buffer = vec![0u8; MAX_XDP_FRAME_SIZE];
-        
-        // In production, this would use AF_XDP recvmsg
-        // For now, we simulate with protocol decoding
-        
+        let _ = (&self.config.interface_name, self.config.memory_order);
         None
     }
     
@@ -147,12 +134,12 @@ impl EbpfProgramLoader {
     
     /// Load eBPF program (Linux-specific)
     pub fn load(&self, _program_path: &str) -> Result<(), String> {
-        Err("eBPF loading requires Linux kernel support".into())
+        Err(format!("eBPF loading for '{}' requires Linux kernel support", self.program_name))
     }
     
     /// Attach eBPF program to XDP socket
     pub fn attach(&self, _fd: c_int) -> Result<(), String> {
-        Err("eBPF attachment requires Linux kernel support".into())
+        Err(format!("eBPF attachment for '{}' requires Linux kernel support", self.program_name))
     }
 }
 
@@ -265,7 +252,7 @@ impl XdpReceiver {
     pub fn recv_loop(&self) -> Result<(), String> {
         // In production, this would use AF_XDP recvmsg in a loop
         // Placeholder implementation
-        
+        let _ = (&self.config.interface_name, self.config.memory_order);
         Ok(())
     }
     
@@ -310,18 +297,18 @@ impl XdpSocketManager {
     pub fn init(&mut self) -> Result<(), String> {
         // This would use syscall! macro for Linux-specific syscalls
         // Placeholder implementation
-        
+        let _ = &self.interface_name;
         Ok(())
     }
     
     /// Receive frame using AF_XDP recvmsg
-    pub fn recv_frame(&mut self, buffer: &mut [u8]) -> Option<usize> {
+    pub fn recv_frame(&mut self, _buffer: &mut [u8]) -> Option<usize> {
         // Placeholder - actual implementation uses recvmsg syscall
         None
     }
     
     /// Send frame using AF_XDP sendmsg
-    pub fn send_frame(&mut self, data: &[u8]) -> Result<(), String> {
+    pub fn send_frame(&mut self, _data: &[u8]) -> Result<(), String> {
         Err("AF_XDP send requires specific setup".into())
     }
     


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI to run formatting, clippy, and workspace tests
- Add a Criterion benchmark workflow that uploads benchmark logs and reports as artifacts
- Update the README with CI/benchmark badges and the latest Criterion results
- Add an unreleased changelog entry for the new CI and benchmark tracking work
- Keep the cluster read path optimized with the shared node snapshot cache and cached total VRAM fast path

## Validation
- `cargo test --workspace`
- `cargo bench -p ghostlink-core --bench criterion -- --warm-up-time 1 --measurement-time 1`

## Notes
- Benchmark artifacts are captured from the `Benchmarks` workflow
- CI test logs are uploaded as artifacts for later inspection