### PR TITLE
Harden Mohawk GUI runtime for production readiness

### DIFF
--- a/third_party/mohawk_gui/auth_manager.py
+++ b/third_party/mohawk_gui/auth_manager.py
@@ -6,7 +6,7 @@ Provides secure JWT-based authentication and mTLS support.
 
 import jwt
 import hashlib
-import base64
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -33,13 +33,19 @@ class AuthManager:
             secret_key_path: Path to private key file for signing tokens
             key_size: RSA key size in bits (default: 2048)
         """
-        self.secret_key_path = secret_key_path
+        if secret_key_path:
+            self.secret_key_path = secret_key_path
+        else:
+            default_dir = os.path.join(os.path.dirname(__file__), "certs")
+            self.secret_key_path = os.path.join(default_dir, "jwt_private.pem")
+        self.key_size = key_size
         self._generate_key_if_needed()
         self.token_expiry_hours = 24
         self.refresh_window_hours = 1
         
     def _generate_key_if_needed(self):
         """Generate RSA key pair if no existing key."""
+        os.makedirs(os.path.dirname(self.secret_key_path), exist_ok=True)
         try:
             with open(self.secret_key_path, 'rb') as f:
                 # Try to load existing key
@@ -52,7 +58,7 @@ class AuthManager:
             # Generate new RSA key pair
             private_key = rsa.generate_private_key(
                 public_exponent=65537,
-                key_size=2048,
+                key_size=self.key_size,
                 backend=default_backend()
             )
             

--- a/third_party/mohawk_gui/connection_pool.py
+++ b/third_party/mohawk_gui/connection_pool.py
@@ -15,7 +15,7 @@ import random
 @dataclass
 class WebSocketConnection:
     """Represent a pooled WebSocket connection."""
-    ws: Optional[asyncio.WebSocketClientProtocol] = None
+    ws: Optional[Any] = None
     session_id: str = ""
     last_activity: float = field(default_factory=time.time)
     created_at: float = field(default_factory=time.time)

--- a/third_party/mohawk_gui/entry_point.py
+++ b/third_party/mohawk_gui/entry_point.py
@@ -9,13 +9,18 @@ or embedded in the PyInstaller executable.
 
 import sys
 import os
+from pathlib import Path
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from mohawk_gui.main import main
+try:
+    from mohawk_gui.main import main as run_main
+except ImportError:
+    # Support direct execution from within third_party/mohawk_gui.
+    from main import main as run_main
 
 def main():
     """Main entry point for Mohawk Inference Engine GUI."""
@@ -25,38 +30,9 @@ def main():
     print("╚═══════════════════════════════════════════════════════════╝")
     print()
     
-    # Parse command line arguments
-    import argparse
-    
-    parser = argparse.ArgumentParser(
-        description="Mohawk Inference Engine GUI - Production Ready"
-    )
-    parser.add_argument(
-        "--host", 
-        default="localhost",
-        help="Worker host (default: localhost)"
-    )
-    parser.add_argument(
-        "--port", 
-        type=int, 
-        default=8003,
-        help="Worker port (default: 8003)"
-    )
-    parser.add_argument(
-        "--config",
-        default="config.toml",
-        help="Configuration file path"
-    )
-    
-    args = parser.parse_args()
-    
-    # Initialize and run GUI
-    from mohawk_gui.main_window import MohawkGUI
-    
-    gui = MohawkGUI()
-    gui.show()
-    
-    return gui.exec()
+    # Delegate to the canonical launcher so argument parsing and QApplication
+    # lifecycle remain consistent with main.py.
+    return run_main()
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/third_party/mohawk_gui/main_window.py
+++ b/third_party/mohawk_gui/main_window.py
@@ -60,11 +60,6 @@ class MohawkGUI(QMainWindow):
         self.gui_service_url = "http://localhost:8003"
         self.worker_service_url = "http://localhost:8004"
         
-        # Health check thread
-        self.health_thread = WorkerHealthCheck(self.gui_service_url)
-        self.health_thread.health_updated.connect(self.on_health_update)
-        self.health_thread.start()
-        
         # Central widget
         central_widget = QWidget()
         self.setCentralWidget(central_widget)
@@ -100,6 +95,12 @@ class MohawkGUI(QMainWindow):
         
         status_layout.addStretch()
         layout.addWidget(status_group)
+
+        # Status bar must exist before any tab initialization that may emit
+        # refresh failures during startup.
+        self.status_bar = QStatusBar()
+        self.setStatusBar(self.status_bar)
+        self.status_bar.showMessage("Starting GUI...")
         
         # Store references for live updates (BEFORE creating tabs)
         self.metrics_bars = {}
@@ -126,10 +127,12 @@ class MohawkGUI(QMainWindow):
         self.tabs.addTab(self.workers_widget, "Worker Config")
         self.tabs.addTab(self.security_widget, "Security Center")
         self.tabs.addTab(self.history_widget, "History")
-        
-        # Status bar
-        self.status_bar = QStatusBar()
-        self.setStatusBar(self.status_bar)
+
+        # Health check thread
+        self.health_thread = WorkerHealthCheck(self.gui_service_url)
+        self.health_thread.health_updated.connect(self.on_health_update)
+        self.health_thread.start()
+
         self.status_bar.showMessage("Ready - Connecting to Docker backend services...")
         
         # Timer for periodic updates

--- a/third_party/mohawk_gui/monitoring.py
+++ b/third_party/mohawk_gui/monitoring.py
@@ -128,9 +128,17 @@ class SystemMonitor:
     
     def get_cpu_info(self) -> Dict[str, Any]:
         """Get CPU usage information."""
+        cpu_times = self.process.cpu_times()
+        if hasattr(cpu_times, "_asdict"):
+            times = cpu_times._asdict()
+        else:
+            times = {
+                "user": cpu_times[0] if len(cpu_times) > 0 else 0,
+                "system": cpu_times[1] if len(cpu_times) > 1 else 0,
+            }
         return {
             "percent": self.process.cpu_percent(),
-            "times": dict(self.process.cpu_times())
+            "times": times
         }
     
     def get_disk_usage(self, path: str = "/") -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
This PR hardens the vendored Mohawk GUI runtime paths to remove startup/import failures and validate all user-facing GUI actions for production readiness.

## Commit
- `4ac7e91216e5048b5c84cc5bbdaa1889cf7f912d`
- Message: `Harden Mohawk GUI runtime for production readiness`

## Changes
1. `third_party/mohawk_gui/entry_point.py`
- Added missing `Path` import.
- Reworked launcher to delegate to canonical `main.py` entrypoint.
- Removed invalid direct `QMainWindow.exec()` flow and duplicated argument parsing.
- Added fallback import path for direct execution from vendored folder.

2. `third_party/mohawk_gui/auth_manager.py`
- Added safe default JWT key path under `third_party/mohawk_gui/certs/jwt_private.pem` when no key path is provided.
- Ensured key directory exists before key generation.
- Honored configured `key_size` during RSA key generation.
- Removed unused `base64` import.

3. `third_party/mohawk_gui/connection_pool.py`
- Fixed import-time crash by replacing invalid `asyncio.WebSocketClientProtocol` annotation with `Optional[Any]`.

4. `third_party/mohawk_gui/monitoring.py`
- Fixed `SystemMonitor.get_cpu_info()` serialization by using `_asdict()` on psutil namedtuple (with safe fallback map).

5. `third_party/mohawk_gui/main_window.py`
- Reordered initialization so `status_bar` exists before any startup refresh calls.
- Moved health thread startup to after UI/tab initialization completes.
- This removes baseline constructor race/failure in startup path.

## Validation performed
### Function/action matrix
- Command: `/workspaces/Ghostlink/.venv/bin/python /tmp/gui_function_matrix_v3.py`
- Result: `total=45 pass=45 fail=0`
- Artifact: `tmp/gui-function-matrix.txt`

### GUI functional suite
- Command: `QT_QPA_PLATFORM=offscreen xvfb-run -a /workspaces/Ghostlink/.venv/bin/python third_party/mohawk_gui/test_dashboard.py`
- Result: PASS (`DASHBOARD_TEST_EXIT:0`)

### Rust + CLI integration checks
- `cargo test -p ghost-link` -> 4 passed
- `GHOSTLINK_PYTHON=/workspaces/Ghostlink/.venv/bin/python cargo run -p ghost-link -- gui-check --strict` -> PASS (exit 0)
- `QT_QPA_PLATFORM=offscreen xvfb-run -a env GHOSTLINK_PYTHON=/workspaces/Ghostlink/.venv/bin/python GHOSTLINK_GUI_DIAG_JSON=./tmp/gui-diagnostics-strict.json cargo run -p ghost-link -- gui-diagnose --strict` -> PASS (exit 0)

### Static diagnostics
- No errors reported in edited files via workspace diagnostics.

## User-facing impact
- `ghost-link gui` startup path is stable and no longer fails due to status-bar ordering.
- `ghost-link gui-check --strict` and `ghost-link gui-diagnose --strict` now pass in validated environment.
- Vendored Python entrypoint is now runnable and aligned with canonical launcher behavior.

## Risk assessment
- Changes are scoped to GUI vendored Python code and do not alter core runtime/planning logic.
- Most changes are startup and serialization fixes with direct test coverage in this run.

## Checklist
- [x] Commit pushed to branch
- [x] Function-level validation completed
- [x] User-facing GUI actions tested
- [x] Rust CLI GUI commands validated
- [x] Diagnostics artifact generated