### PR TITLE
fix(gui): avoid cargo-run lock conflicts on Windows

### DIFF
--- a/crates/ghostlink-gui/src-tauri/src/main.rs
+++ b/crates/ghostlink-gui/src-tauri/src/main.rs
@@ -1053,6 +1053,45 @@ fn repo_root() -> PathBuf {
 
 fn run_ghostlink_command(args: Vec<&str>) -> Result<CommandResult, String> {
     let root = repo_root();
+    let executable_name = if cfg!(windows) {
+        "ghost-link.exe"
+    } else {
+        "ghost-link"
+    };
+
+    // Prefer direct binary execution to avoid `cargo run` rebuilds that can
+    // fail on Windows when another ghost-link process already has the exe open.
+    let binary_candidates = [
+        root.join("target").join("release").join(executable_name),
+        root.join("target").join("debug").join(executable_name),
+    ];
+
+    for binary in binary_candidates {
+        if !binary.exists() {
+            continue;
+        }
+
+        let output = Command::new(&binary)
+            .args(&args)
+            .current_dir(&root)
+            .output()
+            .map_err(|err| {
+                format!(
+                    "failed to execute ghost-link binary {}: {}",
+                    binary.display(),
+                    err
+                )
+            })?;
+
+        return Ok(CommandResult {
+            command: format!("{} {}", binary.display(), args.join(" ")),
+            ok: output.status.success(),
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+
     let rendered = format!("cargo run -p ghost-link -- {}", args.join(" "));
     let output = Command::new("cargo")
         .arg("run")

--- a/scripts/launch_studio.py
+++ b/scripts/launch_studio.py
@@ -96,7 +96,7 @@ def main():
     if requested_gui_mode not in {'tauri', 'tkinter'}:
         requested_gui_mode = 'tauri'
     tauri_ready = can_launch_tauri()
-    effective_gui_mode = requested_gui_mode if requested_gui_mode == 'tkinter' else ('tauri' if tauri_ready else 'tkinter')
+    effective_gui_mode = requested_gui_mode
 
     log("Starting Ghostlink Studio initialization...")
     log(f"GUI mode requested: {requested_gui_mode}")
@@ -125,11 +125,18 @@ def main():
         log("  [OK] Model Manager will run on port 8001")
         log("  [OK] Gateway Proxy will run on port 9999")
         if requested_gui_mode == 'tauri' and not tauri_ready:
-            log("  [WARN] Tauri GUI prerequisites missing (cargo tauri and/or npm). Launcher will fallback to Tkinter.")
+            log("  [WARN] Tauri GUI prerequisites missing (cargo tauri and/or npm).")
+            log("         Install Tauri toolchain or set GHOSTLINK_STUDIO_GUI=tkinter explicitly.")
         else:
             log(f"  [OK] GUI launch mode: {effective_gui_mode}")
         log("Preflight completed successfully")
         return 0
+
+    if requested_gui_mode == 'tauri' and not tauri_ready:
+        fail(
+            "Tauri GUI prerequisites missing (cargo tauri and/or npm). "
+            "Install them or set GHOSTLINK_STUDIO_GUI=tkinter for legacy GUI."
+        )
 
     # 1. Build Backend
     log("Building Ghostlink backend (release)...")


### PR DESCRIPTION
- run existing ghost-link binaries (release/debug) for probe/flow/cluster commands

- fallback to cargo run only when binaries are unavailable

# Summary

- What production gap(s) does this PR close?

## Phase Mapping

- Phase: <!-- e.g., Phase 2: Multi-Node Reliability Validation -->
- Plan reference: docs/PRODUCTION_REMEDIATION_PLAN.md

## Weekly Status (Required for phase work)

- Progress this week:
- Blockers:
- Next actions:

## Tracker Links

- Issue(s):
- Artifact/report links:
- Related tracker entry: docs/PRODUCTION_PHASE_TRACKER.md

## Validation

- [ ] cargo fmt --all --check
- [ ] cargo clippy --workspace --all-targets -- -D warnings
- [ ] cargo test --workspace
- [ ] scripts/run_full_validation.sh (or phase-specific equivalent)

## Security / Ops Impact

- [ ] Secrets/tokens are not hardcoded
- [ ] Logging output avoids sensitive data
- [ ] Docs updated for operator runbooks

## Rollback Plan

- How to disable/revert quickly if regression occurs:
