### PR TITLE
⚡ Bolt: optimize cluster health query in planning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2026-07-02 - [Binary Protocol Serialization Optimization]
 **Learning:** Pre-allocating a single `Vec` of the exact final capacity and serializing struct payloads directly into it via an `encode_payload_into` method avoids the overhead of intermediate heap allocations and memory copies. Additionally, avoiding `copy_from_slice` in low-level header encoding by assigning elements directly to fixed indices eliminates bounds checks and improves instruction pipelining.
 **Action:** Always provide an `encode_into` style method for high-performance binary structures to allow zero-copy/zero-allocation serialization directly into target buffers or frames. Avoid bounds checking in short fixed-size array writes by indexing them directly with constant offsets instead of using slice copy methods.
+
+## 2026-07-02 - [Cluster Health Query Optimization]
+**Learning:** Redundant iterations and nested metric lookups on thread-safe collections (like `ClusterState::get_metrics`) introduce unnecessary mutex acquisition overhead and expensive clones of large status structs (such as `NodeMetrics`). Consolidating query loops with functional combinators like `filter_map` reduces lock contention and halves cloning/lookup overhead.
+**Action:** When querying statuses or counting/collecting across thread-safe shared maps or lists, perform lookups once per element, derive any required aggregations directly, and avoid secondary lookups or passes.

--- a/crates/ghostlink-core/src/planning.rs
+++ b/crates/ghostlink-core/src/planning.rs
@@ -405,32 +405,22 @@ pub fn calculate_cluster_health(cluster: &ClusterState) -> (f32, usize, Vec<Stri
     let avg_delivery_ratio =
         active_nodes.iter().map(|m| m.delivery_ratio).sum::<f32>() / active_nodes.len() as f32;
 
-    // Count failed nodes
-    let failed_count = cluster
-        .nodes_snapshot()
-        .iter()
-        .filter(|n| {
-            if let Some(metrics) = cluster.get_metrics(&n.id) {
-                metrics.status == NodeStatus::Failed
-            } else {
-                false
-            }
-        })
-        .count();
-
-    // Get failed node IDs
+    // Get failed node IDs and count them in a single pass, avoiding redundant mutex locks and clones of NodeMetrics
     let failed_nodes: Vec<String> = cluster
         .nodes_snapshot()
         .iter()
-        .filter(|n| {
-            if let Some(metrics) = cluster.get_metrics(&n.id) {
-                metrics.status == NodeStatus::Failed
-            } else {
-                false
-            }
+        .filter_map(|n| {
+            cluster.get_metrics(&n.id).and_then(|metrics| {
+                if metrics.status == NodeStatus::Failed {
+                    Some(n.id.clone())
+                } else {
+                    None
+                }
+            })
         })
-        .map(|n| n.id.clone())
         .collect();
+
+    let failed_count = failed_nodes.len();
 
     (avg_delivery_ratio, failed_count, failed_nodes)
 }


### PR DESCRIPTION
This PR implements an optimization in the `calculate_cluster_health` function of the planning module in `ghostlink-core`.

### 💡 What:
Optimized `calculate_cluster_health` in `crates/ghostlink-core/src/planning.rs` to process node health in a single `filter_map` pass over the node snapshot.

### 🎯 Why:
The original implementation had two separate sequential passes: one filter pass to count failed nodes and another filter/map pass to collect their IDs. Each pass for each node performed a lookup to retrieve the node metrics via `cluster.get_metrics(&n.id)`. Since `get_metrics` is a thread-safe method that acquires a Mutex lock and clones the substantial `NodeMetrics` struct, doing this twice per node creates unnecessary lock contention and duplication of CPU cycles.

### 📊 Impact:
- Reduces the number of iterations over the node snapshot from 2 to 1.
- Cuts the number of expensive `get_metrics` calls and lock acquisitions in half (from `2 * N` to `N`).
- Avoids redundant clones of `NodeMetrics` structs, improving overall cluster monitoring throughput and latency under high load or large clusters.

### 🔬 Measurement:
- All cargo tests (`cargo test`) pass.
- Verified compilation and benchmark execution with `cargo bench --bench criterion`.

---
*PR created automatically by Jules for task [15681865363913623556](https://jules.google.com/task/15681865363913623556) started by @rwilliamspbg-ops*