### PR TITLE
fix: disable Nagle on inter-stage TCP bridges to remove delayed-ACK stalls

### DIFF
--- a/crates/ghostlink-core/src/runtime.rs
+++ b/crates/ghostlink-core/src/runtime.rs
@@ -761,6 +761,13 @@ pub fn spawn_tcp_bridge(
             }
         };
 
+        // Inter-stage frames are small and latency-sensitive. With Nagle's
+        // algorithm enabled these coalesce and stall on peer delayed-ACKs
+        // (~40ms), which compounds across hops and dominates multi-stage paths.
+        if let Err(e) = client_stream.set_nodelay(true) {
+            tracing::debug!("TCP Bridge: failed to set TCP_NODELAY on client: {}", e);
+        }
+
         let (server_stream, _) = match listener.accept() {
             Ok(parts) => parts,
             Err(_) => {
@@ -772,6 +779,10 @@ pub fn spawn_tcp_bridge(
                 return BridgeAccumulator::default_with_stage(source_stage);
             }
         };
+
+        if let Err(e) = server_stream.set_nodelay(true) {
+            tracing::debug!("TCP Bridge: failed to set TCP_NODELAY on server: {}", e);
+        }
 
         let writer_auth_token = config.auth_token.clone();
         let reader_auth_token = config.auth_token.clone();


### PR DESCRIPTION
## Summary

The inter-stage TCP bridges never set `TCP_NODELAY`, so small latency-sensitive frames coalesce under Nagle's algorithm and stall on the peer's delayed ACK (~40 ms per stall). The effect compounds per hop, which is why the four-stage split benchmark sits at ~82.7 ms with a 28–188 ms range (quantized in ~40 ms steps) while the two-stage path runs at ~815 µs.

This change sets `TCP_NODELAY` on both sides of the bridge (client and accepted server stream) in `spawn_tcp_bridge`, with failures logged at debug level rather than treated as fatal.

## Why this is safe

- Inter-stage frames are small and already batched at the protocol layer; Nagle adds latency here without meaningful bandwidth savings.
- `set_nodelay` failure is non-fatal — the bridge degrades to current behavior.
- No wire-format or API changes.

## Expected impact

The four-stage TCP split should drop from ~82.7 ms (28–188 ms range) into the low-millisecond range, in line with two-stage scaling, and micro-batch latency variance should tighten. Happy to post before/after Criterion numbers on the PR once re-run.

## Testing

- `cargo check -p ghostlink-core` — clean
- `cargo clippy -p ghostlink-core` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
