### PR TITLE
fix: HF download integrity (.part+rename), backend deadlock after downloads, gated-repo auth + GUI catalog

### DIFF
--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -2446,6 +2446,15 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             msg
         })?;
 
+        // Optional token for gated/private repos (both common env names accepted)
+        let hf_token = std::env::var("HF_TOKEN")
+            .or_else(|_| std::env::var("HUGGING_FACE_HUB_TOKEN"))
+            .ok()
+            .filter(|t| !t.trim().is_empty());
+        if hf_token.is_some() {
+            eprintln!("[download_hf_model] Using HF token from environment");
+        }
+
         // Try primary URL and mirrors
         let mirrors = vec![
             format!("https://huggingface.co/api/models/{}", model_id),
@@ -2454,10 +2463,15 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
         let mut model_data = None;
         let mut used_mirror = String::new();
+        let mut auth_blocked = false;
 
         for api_url in &mirrors {
             eprintln!("[download_hf_model] Fetching model info from {}", api_url);
-            let resp = client.get(api_url).send().await.map_err(|e| {
+            let mut req = client.get(api_url);
+            if let Some(t) = &hf_token {
+                req = req.bearer_auth(t);
+            }
+            let resp = req.send().await.map_err(|e| {
                 let msg = format!("API error for '{}': {}", model_id, e);
                 eprintln!("[download_hf_model] {}", msg);
                 msg
@@ -2472,6 +2486,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 used_mirror = api_url.clone();
                 break;
             }
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED
+                || resp.status() == reqwest::StatusCode::FORBIDDEN
+            {
+                auth_blocked = true;
+            }
             eprintln!(
                 "[download_hf_model] Mirror {} returned HTTP {}",
                 api_url,
@@ -2479,8 +2498,16 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             );
         }
 
-        let data = model_data
-            .ok_or_else(|| format!("Model '{}' not found on HuggingFace or mirrors", model_id))?;
+        let data = model_data.ok_or_else(|| {
+            if auth_blocked {
+                format!(
+                    "Model '{}' is gated or private. Set HF_TOKEN to a HuggingFace access token and accept the model's license on huggingface.co, then retry.",
+                    model_id
+                )
+            } else {
+                format!("Model '{}' not found on HuggingFace or mirrors", model_id)
+            }
+        })?;
         eprintln!(
             "[download_hf_model] Model info received successfully from {}",
             used_mirror
@@ -2515,6 +2542,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         ];
 
         let dest_path = models_dir.join(filename);
+        // In-progress downloads are written to a .part file and only renamed to
+        // dest_path after size verification, so dest_path existing means a
+        // previous download actually completed.
+        let part_path = models_dir.join(format!("{}.part", filename));
 
         // Check if file already exists and is complete
         if dest_path.exists() {
@@ -2549,8 +2580,8 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             let mut downloaded: u64 = 0;
             let mut range_header = None;
 
-            if dest_path.exists() {
-                if let Ok(metadata) = fs::metadata(&dest_path) {
+            if part_path.exists() {
+                if let Ok(metadata) = fs::metadata(&part_path) {
                     downloaded = metadata.len();
                     if downloaded > 0 {
                         range_header = Some(format!("bytes={}-", downloaded));
@@ -2559,6 +2590,9 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             }
 
             let mut req = client.get(file_url);
+            if let Some(t) = &hf_token {
+                req = req.bearer_auth(t);
+            }
             if let Some(ref range) = range_header {
                 req = req.header("Range", range);
             }
@@ -2578,7 +2612,16 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 if let Some(p) = progress.get_mut(model_id) {
                     p.status = "failed".to_string();
                 }
-                last_error = format!("Failed to download file (HTTP {})", resp.status());
+                last_error = if resp.status() == reqwest::StatusCode::UNAUTHORIZED
+                    || resp.status() == reqwest::StatusCode::FORBIDDEN
+                {
+                    format!(
+                        "Failed to download file (HTTP {}). The repo may be gated - set HF_TOKEN and accept the license on huggingface.co.",
+                        resp.status()
+                    )
+                } else {
+                    format!("Failed to download file (HTTP {})", resp.status())
+                };
                 eprintln!("[download_hf_model] {}", last_error);
                 continue;
             }
@@ -2599,11 +2642,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             let file = if downloaded > 0 && resp.status() == reqwest::StatusCode::PARTIAL_CONTENT {
                 tokio::fs::OpenOptions::new()
                     .append(true)
-                    .open(&dest_path)
+                    .open(&part_path)
                     .await
                     .map_err(|e| format!("File error: {}", e))?
             } else {
-                tokio::fs::File::create(&dest_path)
+                tokio::fs::File::create(&part_path)
                     .await
                     .map_err(|e| format!("File error: {}", e))?
             };
@@ -2634,10 +2677,13 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 }
             }
             file.flush().await.ok();
+            // Close the handle before rename (required on Windows)
+            drop(file);
 
-            // Verify download completed
-            let final_size = fs::metadata(&dest_path).map(|m| m.len()).unwrap_or(0);
+            // Verify download completed before promoting the .part file
+            let final_size = fs::metadata(&part_path).map(|m| m.len()).unwrap_or(0);
             if expected_total > 0 && final_size >= expected_total {
+                fs::rename(&part_path, &dest_path).map_err(|e| format!("Rename error: {}", e))?;
                 eprintln!(
                     "[download_hf_model] Download COMPLETED for '{}' at '{}' ({} bytes)",
                     model_id,
@@ -2661,6 +2707,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 return Ok(dest_path.to_string_lossy().to_string());
             } else if expected_total == 0 {
                 // No content-length, assume success
+                fs::rename(&part_path, &dest_path).map_err(|e| format!("Rename error: {}", e))?;
                 eprintln!("[download_hf_model] Download COMPLETED (no content-length) for '{}' at '{}' ({} bytes)", model_id, dest_path.display(), final_size);
 
                 {

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -2021,6 +2021,8 @@ fn lock_state(state: &Arc<Mutex<BackendState>>) -> std::sync::MutexGuard<'_, Bac
 }
 
 fn push_audit_entry(state: &Arc<Mutex<BackendState>>, event: &str, status: &str, detail: &str) {
+    // Takes the state lock: callers holding a lock_state guard must drop it
+    // first (std::sync::Mutex is not reentrant; relocking self-deadlocks).
     if let Ok(mut backend) = state.lock() {
         backend.audit_log.push(AuditEntry {
             event: event.to_string(),
@@ -2927,6 +2929,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                         hf_model_id: model_id_clone.clone(),
                     });
                     save_persistent_models(&backend.models);
+                    drop(backend);
 
                     push_audit_entry(
                         &state_clone,
@@ -2960,6 +2963,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                         .models
                         .retain(|m| m.name != model_id_clone && m.hf_model_id != model_id_clone);
                     save_persistent_models(&backend.models);
+                    drop(backend);
 
                     push_audit_entry(
                         &state_clone,

--- a/ghostlink_gui_modern/src/components/ModelsTab.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.tsx
@@ -19,9 +19,12 @@ import { GhostlinkAPI } from '../api';
 
 // POPULAR_MODELS used as fallback when search fails; kept for reference
 const POPULAR_MODELS = [
-  { id: 'meta-llama/Llama-3.2-3B-Instruct-GGUF', name: 'Llama 3.2 3B Instruct (GGUF)', downloads: 2500000, likes: 120000 },
-  { id: 'meta-llama/Llama-3.2-1B-Instruct-GGUF', name: 'Llama 3.2 1B Instruct (GGUF)', downloads: 1800000, likes: 90000 },
-  { id: 'mistralai/Mistral-7B-Instruct-v0.3-GGUF', name: 'Mistral 7B v0.3 Instruct (GGUF)', downloads: 3200000, likes: 150000 },
+  // Community GGUF mirrors: the upstream meta-llama/mistralai repos are gated
+  // (401 without an accepted license + HF token), so they fail as one-click
+  // downloads. These bartowski repos are public quantizations of the same models.
+  { id: 'bartowski/Llama-3.2-3B-Instruct-GGUF', name: 'Llama 3.2 3B Instruct (GGUF)', downloads: 2500000, likes: 120000 },
+  { id: 'bartowski/Llama-3.2-1B-Instruct-GGUF', name: 'Llama 3.2 1B Instruct (GGUF)', downloads: 1800000, likes: 90000 },
+  { id: 'bartowski/Mistral-7B-Instruct-v0.3-GGUF', name: 'Mistral 7B v0.3 Instruct (GGUF)', downloads: 3200000, likes: 150000 },
   { id: 'TheBloke/CodeLlama-7B-GGUF', name: 'CodeLlama 7B (GGUF)', downloads: 1500000, likes: 75000 },
   { id: 'TheBloke/Llama-2-7B-Chat-GGUF', name: 'Llama 2 7B Chat (GGUF)', downloads: 4100000, likes: 200000 },
   { id: 'TheBloke/Mistral-7B-Instruct-v0.2-GGUF', name: 'Mistral 7B v0.2 Instruct (GGUF)', downloads: 2800000, likes: 110000 },


### PR DESCRIPTION
## Summary

Three fixes that together make Hugging Face model downloads work reliably end-to-end. All were reproduced and verified against a live backend.

### 1. Partial downloads can no longer masquerade as complete (`download_hf_model`)

The completeness check accepted any existing non-empty `dest_path`, so a download interrupted by a crash or network loss looked "already downloaded" on the next attempt — and llama-server later failed on a truncated GGUF far from the cause. Because that early return ran before the download loop, the existing Range-resume logic was also unreachable across calls.

Downloads now stream to `<file>.gguf.part` and are renamed to the final name only after size verification. An interrupted `.part` resumes via Range on the next request.

Verified live: 18 MB test model streamed as `.part` and renamed at exactly the size HF's API advertises; truncating the `.part` to 5 MB and re-requesting completed it to the correct full size.

### 2. Whole backend deadlocked after any download finished or failed

Both completion arms of the download task called `push_audit_entry` while still holding the `lock_state` guard. `push_audit_entry` re-locks the same `std::sync::Mutex`, which is not reentrant — the worker self-deadlocked while holding the state lock, every subsequent request wedged another worker on `lock_state`, and within seconds the server stopped accepting connections entirely (observed live: all 16 tokio workers futex-parked, accept backlog of 112).

Every other audit call site already drops the guard first — these two were the only ones missing it, which is why only downloads froze the backend. This is likely the root cause behind much of the GUI flakiness around downloads.

### 3. GUI suggested models that cannot be downloaded

The `POPULAR_MODELS` fallback listed `meta-llama/Llama-3.2-{1B,3B}-Instruct-GGUF` and `mistralai/Mistral-7B-Instruct-v0.3-GGUF`, all of which return 401 without an accepted license + HF token — so the one-click downloads failed on every fresh install. Those entries now point at the public bartowski quantizations of the same models.

### Bonus: gated-repo support and honest errors

`HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` env vars are now forwarded as bearer auth on both the API lookup and the file download, and 401/403 reports "gated or private — set HF_TOKEN and accept the license" instead of the misleading "not found".

## Testing

- `cargo check` / `cargo clippy` clean
- `tsc --noEmit` clean for the GUI change
- Live verification: gated repo → correct actionable error, backend stays healthy afterward (deadlock regression test); public 1B model (657 MB) downloaded, verified, renamed; interrupted-download resume completed to byte-exact size

## Note

A truncated final `.gguf` left over from before this fix is still trusted by the exists-check (only new downloads get the `.part` protection). Deleting the model and re-downloading clears that; happy to add size revalidation as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
