### PR TITLE
fix: hardware auto-detect misses NVIDIA dGPU on hybrid laptops

### DIFF
--- a/launch-complete.bat
+++ b/launch-complete.bat
@@ -83,22 +83,40 @@ for /f "delims=" %%a in ('powershell -NoProfile -Command "Get-CimInstance Win32_
 set "GPU_COUNT=%GPU_INDEX%"
 
 REM --- NVIDIA GPU Detection (CUDA) ---
+REM nvidia-smi is often not on PATH; check its standard install locations too.
+set "NVIDIA_SMI="
 where nvidia-smi >nul 2>&1
-if not errorlevel 1 (
-    for /f "tokens=*" %%a in ('nvidia-smi --query-gpu=name --format=csv,noheader 2^>nul') do set "NVIDIA_GPU=%%a"
+if not errorlevel 1 set "NVIDIA_SMI=nvidia-smi"
+if not defined NVIDIA_SMI if exist "%SystemRoot%\System32\nvidia-smi.exe" set "NVIDIA_SMI=%SystemRoot%\System32\nvidia-smi.exe"
+if not defined NVIDIA_SMI if exist "%ProgramFiles%\NVIDIA Corporation\NVSMI\nvidia-smi.exe" set "NVIDIA_SMI=%ProgramFiles%\NVIDIA Corporation\NVSMI\nvidia-smi.exe"
+if defined NVIDIA_SMI (
+    "!NVIDIA_SMI!" --query-gpu=name --format=csv,noheader > "%TEMP%\ghostlink_gpu.txt" 2>nul
+    for /f "usebackq tokens=*" %%a in ("%TEMP%\ghostlink_gpu.txt") do set "NVIDIA_GPU=%%a"
+    del "%TEMP%\ghostlink_gpu.txt" 2>nul
     if defined NVIDIA_GPU (
-        for /f "tokens=*" %%a in ('nvidia-smi --query-gpu=name,memory.total,compute_cap --format=csv,noheader,nounits 2^>nul') do (
-            set "GPU_INFO=%%a"
-        )
         echo   [CUDA] NVIDIA GPU: !NVIDIA_GPU!
         set "GPU_VENDOR=nvidia"
         set "BACKEND=cuda"
-        REM Get VRAM
-        for /f "tokens=2 delims=, " %%a in ('nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2^>nul') do set "TOTAL_VRAM_MB=%%a"
-        if not defined TOTAL_VRAM_MB set "TOTAL_VRAM_MB=4096"
+        REM Get VRAM (single-column query: the value is token 1, not 2)
+        "!NVIDIA_SMI!" --query-gpu=memory.total --format=csv,noheader,nounits > "%TEMP%\ghostlink_vram.txt" 2>nul
+        for /f "usebackq tokens=1 delims=, " %%a in ("%TEMP%\ghostlink_vram.txt") do set "TOTAL_VRAM_MB=%%a"
+        del "%TEMP%\ghostlink_vram.txt" 2>nul
+        if "!TOTAL_VRAM_MB!"=="0" set "TOTAL_VRAM_MB=4096"
         set /a "VRAM_GB=!TOTAL_VRAM_MB! / 1024" 2>nul
         if "!VRAM_GB!"=="0" set "VRAM_GB=4"
         echo   VRAM: !VRAM_GB! GB ^(!TOTAL_VRAM_MB! MB^)
+    )
+)
+
+REM --- NVIDIA GPU via WMI fallback (driver present but nvidia-smi unavailable) ---
+REM On hybrid laptops (NVIDIA dGPU + AMD/Intel iGPU) this must run BEFORE the
+REM iGPU fallbacks, or inference silently lands on the weak integrated GPU.
+if not defined GPU_VENDOR (
+    for /f "delims=" %%a in ('powershell -NoProfile -Command "Get-CimInstance Win32_VideoController | Where-Object { $_.Name -match 'nvidia|geforce|rtx|gtx|quadro' } | Select-Object -First 1 | ForEach-Object { $_.Name }" 2^>nul') do (
+        echo   [Vulkan] NVIDIA GPU: %%a ^(nvidia-smi not found - CUDA unavailable, using Vulkan^)
+        set "GPU_NAME=%%a"
+        set "GPU_VENDOR=nvidia"
+        set "BACKEND=vulkan"
     )
 )
 

--- a/launch.bat
+++ b/launch.bat
@@ -54,13 +54,30 @@ for /f "delims=" %%a in ('powershell -NoProfile -Command "Get-CimInstance Win32_
     set "GPU_DETECTED=1"
 )
 
-REM Check NVIDIA via nvidia-smi
+REM Check NVIDIA via nvidia-smi (often not on PATH; try standard locations too)
+set "NVIDIA_SMI="
 where nvidia-smi >nul 2>&1
-if not errorlevel 1 (
-    for /f "tokens=*" %%a in ('nvidia-smi --query-gpu=name --format=csv,noheader 2^>nul') do set "NVIDIA_GPU=%%a"
+if not errorlevel 1 set "NVIDIA_SMI=nvidia-smi"
+if not defined NVIDIA_SMI if exist "%SystemRoot%\System32\nvidia-smi.exe" set "NVIDIA_SMI=%SystemRoot%\System32\nvidia-smi.exe"
+if not defined NVIDIA_SMI if exist "%ProgramFiles%\NVIDIA Corporation\NVSMI\nvidia-smi.exe" set "NVIDIA_SMI=%ProgramFiles%\NVIDIA Corporation\NVSMI\nvidia-smi.exe"
+if defined NVIDIA_SMI (
+    "!NVIDIA_SMI!" --query-gpu=name --format=csv,noheader > "%TEMP%\ghostlink_gpu.txt" 2>nul
+    for /f "usebackq tokens=*" %%a in ("%TEMP%\ghostlink_gpu.txt") do set "NVIDIA_GPU=%%a"
+    del "%TEMP%\ghostlink_gpu.txt" 2>nul
     if defined NVIDIA_GPU (
         set "GPU_VENDOR=nvidia"
         set "BACKEND=CUDA"
+    )
+)
+
+REM NVIDIA GPU present but nvidia-smi unavailable: on hybrid laptops
+REM (NVIDIA dGPU + AMD/Intel iGPU) this must win over the iGPU name matching
+REM below, or inference silently lands on the integrated GPU.
+if not defined GPU_VENDOR (
+    for /f "delims=" %%a in ('powershell -NoProfile -Command "Get-CimInstance Win32_VideoController | Where-Object { $_.Name -match 'nvidia|geforce|rtx|gtx|quadro' } | Select-Object -First 1 | ForEach-Object { $_.Name }" 2^>nul') do (
+        set "GPU_NAME=%%a"
+        set "GPU_VENDOR=nvidia"
+        set "BACKEND=Vulkan"
     )
 )
 


### PR DESCRIPTION
## Summary

On hybrid laptops (NVIDIA dGPU + AMD/Intel iGPU — e.g. Ryzen AI machines with a GeForce dGPU), both Windows launchers only detect NVIDIA when `nvidia-smi` is on PATH. When it is not (it commonly lives in `System32` or the NVIDIA driver folder without a PATH entry), detection falls through to the AMD/Intel WMI fallbacks, matches the *integrated* GPU, and inference silently runs on the weak iGPU. You can see this in the earlier launch log from this exact hardware: an RTX 5070 present, but only `[DirectML] AMD GPU: Radeon 860M` detected.

### Changes

- Resolve `nvidia-smi` from PATH, then `%SystemRoot%\System32`, then `%ProgramFiles%\NVIDIA Corporation\NVSMI`, and invoke it by full path
- Add an NVIDIA WMI fallback that runs **before** the iGPU fallbacks when `nvidia-smi` is unavailable (Vulkan backend, since CUDA cannot be verified without driver tools)
- Fix VRAM parsing in `launch-complete.bat`: the single-column `memory.total` output is token 1, not token 2 — `TOTAL_VRAM_MB` was never populated, so VRAM-based GPU-layer planning always fell back to the conservative default
- `launch.bat`: same `nvidia-smi` resolution, and stops the last-listed WMI controller (often the iGPU) from deciding the vendor when a dGPU is present

### Verification

Static checks pass on both files (goto/label pairing, no labels inside parenthesized blocks, all referenced variables defined). The temp-file pattern for reading command output matches the existing NPU-detection idiom. Needs one real run on a hybrid Windows machine — expected result on the 5070+860M laptop: `[CUDA] NVIDIA GPU` with real VRAM-based layer planning instead of the iGPU.
