### PR TITLE
fix: repair launch-complete.bat config ordering lost in merge resolution

### DIFF
--- a/launch-complete.bat
+++ b/launch-complete.bat
@@ -15,12 +15,19 @@ set "BACKEND_HOST=127.0.0.1"
 set "BACKEND_PORT=8003"
 set "GUI_PORT=5173"
 set "LLAMA_PORT=8080"
+REM PROJECT_ROOT must be set before any variable that derives from it
+set "PROJECT_ROOT=%~dp0"
 set "MODEL_DIR=%PROJECT_ROOT%models"
 set "MODEL_FILE=%MODEL_DIR%\stories15M-q4_0.gguf"
 set "MODEL_URL=https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories15M-q4_0.gguf"
-set "PROJECT_ROOT=%~dp0"
+set "LLAMA_SERVER_EXPECTED=%PROJECT_ROOT%third_party\llama.cpp\build\bin\Release\llama-server.exe"
+set "LLAMA_SERVER_ALT_EXPECTED=%PROJECT_ROOT%third_party\llama.cpp\build\bin\llama-server.exe"
 
 REM ==================== Manual Overrides (set via env vars) ====================
+REM   GHOSTLINK_LLAMA_PORT     - Override llama-server port
+REM   GHOSTLINK_MODEL_FILE     - Set custom model path
+if not "%GHOSTLINK_LLAMA_PORT%"=="" set "LLAMA_PORT=%GHOSTLINK_LLAMA_PORT%"
+if not "%GHOSTLINK_MODEL_FILE%"=="" set "MODEL_FILE=%GHOSTLINK_MODEL_FILE%"
 
 REM Validate VITE_GHOSTLINK_API_BASE if set
 if not "%VITE_GHOSTLINK_API_BASE%"=="" (
@@ -305,10 +312,6 @@ if "%GHOSTLINK_SKIP_MODEL%"=="1" (
 REM ==================== Find or Build llama-server ====================
 set "ACTUAL_LLAMA_SERVER="
 set "LLAMA_BUILT=0"
-
-REM Pre-compute the expected binary path (absolute)
-set "LLAMA_SERVER_EXPECTED=%PROJECT_ROOT%third_party\llama.cpp\build\bin\Release\llama-server.exe"
-set "LLAMA_SERVER_ALT_EXPECTED=%PROJECT_ROOT%third_party\llama.cpp\build\bin\llama-server.exe"
 
 if "%GHOSTLINK_SKIP_BUILD%"=="1" (
     echo [INFO] Skipping build ^(GHOSTLINK_SKIP_BUILD=1^)


### PR DESCRIPTION
## Summary

Three small regressions crept into `launch-complete.bat` during recent merge conflict resolutions:

1. **`MODEL_DIR`/`MODEL_FILE` set before `PROJECT_ROOT`** — both expanded with an empty root, so model paths were relative and only worked when the script ran from the repo directory. `PROJECT_ROOT` now comes first.
2. **The `GHOSTLINK_LLAMA_PORT` / `GHOSTLINK_MODEL_FILE` env overrides vanished**, leaving the Manual Overrides section empty. Restored.
3. **`NEED_BUILD` checked `LLAMA_SERVER_EXPECTED` ~50 lines before it was defined** — it always saw empty paths, so every launch demanded a rebuild (and errored without cmake) even with a built binary sitting right there. The definitions moved into the Configuration block, before first use; late duplicates removed.

Statically verified: definition-before-use ordering confirmed, goto/label pairing intact, all referenced variables defined.
