### PR TITLE
Fix bad main merge commit and keep Ollama 404 classification improvements

### DIFF
--- a/crates/ghost-link/src/backend_config.rs
+++ b/crates/ghost-link/src/backend_config.rs
@@ -102,13 +102,8 @@ impl ConfigManager {
             .map_err(|err| format!("Failed to read config file: {}", err))?;
 
         // Parse as TOML
-<<<<<<< HEAD
-        let config: toml::Table = toml::from_str(&content)
-            .map_err(|err| format!("Failed to parse TOML: {}", err))?;
-=======
         let config: toml::Table =
             toml::from_str(&content).map_err(|err| format!("Failed to parse TOML: {}", err))?;
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 
         // Extract [compute] section or use defaults
         let compute_config = if let Some(compute) = config.get("compute") {
@@ -135,12 +130,7 @@ impl ConfigManager {
             let content = std::fs::read_to_string(&self.config_path)
                 .map_err(|err| format!("Failed to read config file: {}", err))?;
 
-<<<<<<< HEAD
-            toml::from_str(&content)
-                .map_err(|err| format!("Failed to parse TOML: {}", err))?
-=======
             toml::from_str(&content).map_err(|err| format!("Failed to parse TOML: {}", err))?
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         } else {
             toml::Table::new()
         };
@@ -198,13 +188,9 @@ impl ConfigManager {
 
     /// Save preferred backend to config
     pub fn save_preferred_backend(&self, backend: ComputeBackend) -> Result<(), String> {
-<<<<<<< HEAD
-        let mut config = self.load_compute_config().unwrap_or_else(|_| ComputeConfig::new());
-=======
         let mut config = self
             .load_compute_config()
             .unwrap_or_else(|_| ComputeConfig::new());
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         config.set_preferred_backend(backend);
         self.save_compute_config(&config)
     }
@@ -300,23 +286,12 @@ mod tests {
         assert!(config.get_preferred_backend().is_none());
 
         config.set_preferred_backend(ComputeBackend::Rocm);
-<<<<<<< HEAD
-        assert_eq!(
-            config.get_preferred_backend(),
-            Some(ComputeBackend::Rocm)
-        );
-=======
         assert_eq!(config.get_preferred_backend(), Some(ComputeBackend::Rocm));
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
     }
 
     #[test]
     fn test_cli_overrides_from_args() {
-<<<<<<< HEAD
-        let args = vec![
-=======
         let args = [
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             "cmd".to_string(),
             "--backend".to_string(),
             "cpu".to_string(),
@@ -340,13 +315,7 @@ mod tests {
         let mut overrides = CLIOverrides::new();
 
         // No override, no config
-<<<<<<< HEAD
-        assert!(overrides
-            .get_effective_backend(None)
-            .is_none());
-=======
         assert!(overrides.get_effective_backend(None).is_none());
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 
         // No override, with config
         assert_eq!(
@@ -384,11 +353,7 @@ mod tests {
 
     #[test]
     fn test_cli_overrides_no_backend() {
-<<<<<<< HEAD
-        let args = vec!["cmd".to_string(), "--other".to_string()];
-=======
         let args = ["cmd".to_string(), "--other".to_string()];
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 
         let overrides = CLIOverrides::from_args(&args[1..]);
         assert!(overrides.preferred_backend.is_none());
@@ -396,13 +361,8 @@ mod tests {
 
     #[test]
     fn test_compute_config_defaults() {
-<<<<<<< HEAD
-        let config = ComputeConfig::new();
-        assert_eq!(default_auto_discover(), true);
-=======
         let _config = ComputeConfig::new();
         assert!(default_auto_discover());
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         assert_eq!(default_gpu_memory_allocation(), 0.80);
         assert_eq!(default_request_drain_timeout_secs(), 30);
     }

--- a/crates/ghost-link/src/backend_registry.rs
+++ b/crates/ghost-link/src/backend_registry.rs
@@ -50,13 +50,8 @@ pub struct BackendStatus {
     pub backend: ComputeBackend,
     pub device_name: String,
     pub vram_gb: Option<f32>,
-<<<<<<< HEAD
-    pub status: String, // "active", "ready", "unavailable"
-    pub health: String, // "healthy", "degraded", "error"
-=======
     pub status: String,           // "active", "ready", "unavailable"
     pub health: String,           // "healthy", "degraded", "error"
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
     pub utilization: Option<f32>, // percentage 0-100
     pub temperature: Option<f32>, // celsius
 }
@@ -84,18 +79,12 @@ impl BackendRegistry {
                 current = ComputeBackend::Rocm;
             }
             backends.push(info);
-<<<<<<< HEAD
-        } else if std::env::var("HSA_OVERRIDE_GFX_VERSION").is_ok() || std::env::var("HIP_VISIBLE_DEVICES").is_ok() {
-            // Fallback: ROCm environment detected but rocm-smi not available (Windows/WSL)
-            let gfx_version = std::env::var("HSA_OVERRIDE_GFX_VERSION").unwrap_or_else(|_| "gfx906".to_string());
-=======
         } else if std::env::var("HSA_OVERRIDE_GFX_VERSION").is_ok()
             || std::env::var("HIP_VISIBLE_DEVICES").is_ok()
         {
             // Fallback: ROCm environment detected but rocm-smi not available (Windows/WSL)
             let gfx_version =
                 std::env::var("HSA_OVERRIDE_GFX_VERSION").unwrap_or_else(|_| "gfx906".to_string());
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             backends.push(BackendInfo {
                 backend: ComputeBackend::Rocm,
                 device_name: "AMD Radeon 860M".to_string(),
@@ -144,13 +133,8 @@ impl BackendRegistry {
 
     fn detect_cuda() -> Option<BackendInfo> {
         let output = Command::new("nvidia-smi")
-<<<<<<< HEAD
-            .args(&["--query-gpu=name,memory.total,compute_cap,driver_version"])
-            .args(&["--format=csv,noheader,nounits"])
-=======
             .args(["--query-gpu=name,memory.total,compute_cap,driver_version"])
             .args(["--format=csv,noheader,nounits"])
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             .output()
             .ok()?;
 
@@ -186,19 +170,11 @@ impl BackendRegistry {
         #[cfg(target_os = "windows")]
         {
             // Try to detect ROCm via environment variables
-<<<<<<< HEAD
-            let rocm_installed = std::env::var("ROCM_HOME").is_ok() || 
-                                 std::env::var("HIP_PATH").is_ok() ||
-                                 std::env::var("HSA_OVERRIDE_GFX_VERSION").is_ok() ||
-                                 std::env::var("HIP_VISIBLE_DEVICES").is_ok();
-            
-=======
             let rocm_installed = std::env::var("ROCM_HOME").is_ok()
                 || std::env::var("HIP_PATH").is_ok()
                 || std::env::var("HSA_OVERRIDE_GFX_VERSION").is_ok()
                 || std::env::var("HIP_VISIBLE_DEVICES").is_ok();
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             if rocm_installed {
                 // ROCm installation detected via environment
                 return Some(BackendInfo {
@@ -214,11 +190,7 @@ impl BackendRegistry {
         }
 
         let output = Command::new("rocm-smi")
-<<<<<<< HEAD
-            .args(&["--showproductname"])
-=======
             .args(["--showproductname"])
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             .output()
             .ok()?;
 
@@ -229,48 +201,17 @@ impl BackendRegistry {
         let output_str = String::from_utf8_lossy(&output.stdout);
         let device_name = output_str
             .lines()
-<<<<<<< HEAD
-            .find_map(|line| {
-                line.split(':')
-                    .nth(1)
-                    .map(|s| s.trim().to_string())
-            })
-=======
             .find_map(|line| line.split(':').nth(1).map(|s| s.trim().to_string()))
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             .unwrap_or_else(|| "AMD ROCm GPU".to_string());
 
         // Get VRAM info
         let vram_output = Command::new("rocm-smi")
-<<<<<<< HEAD
-            .args(&["--showmeminfo", "vram"])
-=======
             .args(["--showmeminfo", "vram"])
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             .output()
             .ok();
 
         let vram_gb = vram_output.and_then(|output| {
             let text = String::from_utf8_lossy(&output.stdout);
-<<<<<<< HEAD
-            text.lines()
-                .find_map(|line| {
-                    if line.contains("vram Heap") {
-                        line.split_whitespace()
-                            .find_map(|s| s.parse::<f32>().ok())
-                            .map(|mb| mb / 1024.0)
-                    } else {
-                        None
-                    }
-                })
-        });
-
-        // Detect GFX version
-        let gfx_output = Command::new("rocm-smi")
-            .args(&["--showid"])
-            .output()
-            .ok();
-=======
             text.lines().find_map(|line| {
                 if line.contains("vram Heap") {
                     line.split_whitespace()
@@ -284,23 +225,12 @@ impl BackendRegistry {
 
         // Detect GFX version
         let gfx_output = Command::new("rocm-smi").args(["--showid"]).output().ok();
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 
         let compute_capability = gfx_output
             .and_then(|output| {
                 let text = String::from_utf8_lossy(&output.stdout);
                 text.lines().find_map(|line| {
                     if line.contains("gfx") {
-<<<<<<< HEAD
-                        line.split_whitespace()
-                            .find_map(|s| {
-                                if s.starts_with("gfx") {
-                                    Some(s.to_string())
-                                } else {
-                                    None
-                                }
-                            })
-=======
                         line.split_whitespace().find_map(|s| {
                             if s.starts_with("gfx") {
                                 Some(s.to_string())
@@ -308,7 +238,6 @@ impl BackendRegistry {
                                 None
                             }
                         })
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
                     } else {
                         None
                     }
@@ -318,25 +247,13 @@ impl BackendRegistry {
 
         // Get ROCm version
         let driver_version = Command::new("rocm-smi")
-<<<<<<< HEAD
-            .args(&["--version"])
-=======
             .args(["--version"])
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             .output()
             .ok()
             .and_then(|output| {
                 let text = String::from_utf8_lossy(&output.stderr);
                 text.lines()
-<<<<<<< HEAD
-                    .find_map(|line| {
-                        line.split_whitespace()
-                            .last()
-                            .map(|s| s.to_string())
-                    })
-=======
                     .find_map(|line| line.split_whitespace().last().map(|s| s.to_string()))
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             })
             .unwrap_or_else(|| "unknown".to_string());
 
@@ -351,24 +268,14 @@ impl BackendRegistry {
     }
 
     fn detect_oneapi() -> Option<BackendInfo> {
-<<<<<<< HEAD
-        let output = Command::new("sycl-ls")
-            .output()
-            .ok()?;
-=======
         let output = Command::new("sycl-ls").output().ok()?;
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 
         if !output.status.success() {
             return None;
         }
 
         let output_str = String::from_utf8_lossy(&output.stdout);
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         // Find Intel GPU device
         if let Some(device_line) = output_str.lines().find(|line| line.contains("Intel")) {
             return Some(BackendInfo {
@@ -396,16 +303,11 @@ impl BackendRegistry {
         }
 
         let output_str = String::from_utf8_lossy(&output.stdout);
-<<<<<<< HEAD
-        
-        if let Some(chipset_line) = output_str.lines().find(|line| line.contains("Chipset Model")) {
-=======
 
         if let Some(chipset_line) = output_str
             .lines()
             .find(|line| line.contains("Chipset Model"))
         {
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             let device_name = chipset_line
                 .split(':')
                 .nth(1)
@@ -428,13 +330,7 @@ impl BackendRegistry {
     fn detect_cpu_name() -> String {
         #[cfg(target_os = "linux")]
         {
-<<<<<<< HEAD
-            let output = Command::new("lscpu")
-                .output()
-                .ok();
-=======
             let output = Command::new("lscpu").output().ok();
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 
             if let Some(output) = output {
                 let text = String::from_utf8_lossy(&output.stdout);
@@ -510,11 +406,7 @@ impl BackendRegistry {
     /// Switch to a different backend
     pub fn switch_backend(&self, backend: ComputeBackend) -> Result<(), String> {
         let backends = self.backends.lock().unwrap();
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         if !backends.iter().any(|b| b.backend == backend && b.available) {
             return Err(format!("Backend {} is not available", backend.as_str()));
         }
@@ -560,11 +452,7 @@ mod tests {
     fn test_backend_registry_discover() {
         let registry = BackendRegistry::discover();
         let backends = registry.available_backends();
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         // CPU should always be available
         assert!(backends.iter().any(|b| b.backend == ComputeBackend::Cpu));
     }
@@ -573,11 +461,7 @@ mod tests {
     fn test_backend_registry_current() {
         let registry = BackendRegistry::discover();
         let current = registry.current_backend();
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         // Should have a current backend
         let backends = registry.available_backends();
         assert!(backends.iter().any(|b| b.backend == current));
@@ -586,11 +470,7 @@ mod tests {
     #[test]
     fn test_backend_switch() {
         let registry = BackendRegistry::discover();
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         // Switch to CPU should always work
         assert!(registry.switch_backend(ComputeBackend::Cpu).is_ok());
         assert_eq!(registry.current_backend(), ComputeBackend::Cpu);
@@ -600,11 +480,7 @@ mod tests {
     fn test_backend_info_get() {
         let registry = BackendRegistry::discover();
         let cpu_info = registry.get_backend(&ComputeBackend::Cpu);
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         assert!(cpu_info.is_some());
         assert_eq!(cpu_info.unwrap().backend, ComputeBackend::Cpu);
     }
@@ -613,11 +489,7 @@ mod tests {
     fn test_backend_status() {
         let registry = BackendRegistry::discover();
         let status = registry.get_status(&ComputeBackend::Cpu);
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         assert!(status.is_some());
         let s = status.unwrap();
         assert_eq!(s.status, "active"); // CPU is currently active by default

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -2893,54 +2893,124 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
         let (response_text, real_inference, backend_used, ollama_backend_available) =
             match inference_backend {
-                InferenceBackend::Ollama => match ollama_client
-                    .generate(
-                        &current_model,
-                        &req.message,
-                        temp,
-                        top_p,
-                        top_k,
-                        penalty,
-                        exec_tokens,
-                    )
-                    .await
-                {
-                    Ok(text) => (
-                        text.trim().to_string(),
-                        true,
-                        InferenceBackend::Ollama.as_str(),
-                        true,
-                    ),
-                    Err(err) => {
-                        let err_text = err.to_string();
-                        let is_model_not_found = err_text.contains("HTTP 404");
-                        let is_unreachable = err_text.contains("error sending request")
+                InferenceBackend::Ollama => {
+                    let is_unreachable = |err_text: &str| {
+                        err_text.contains("error sending request")
                             || err_text.contains("connection refused")
                             || err_text.contains("Connection refused")
-                            || err_text.contains("timed out");
+                            || err_text.contains("timed out")
+                    };
 
-                        let fallback = if is_model_not_found {
-                            format!(
-                            "Ollama model '{}' not found (HTTP 404). Pull or retag the model, then retry prompt '{}'.",
-                            current_model, req.message
-                        )
-                        } else {
-                            format!(
-                            "Inference backend '{}' unavailable. Generated degraded fallback for prompt: '{}'. Error: {}",
-                            InferenceBackend::Ollama.as_str(),
-                            req.message,
-                            err_text
-                        )
-                        };
+                    let resolve_model = |requested: &str, available: &[String]| -> Option<String> {
+                        if available.iter().any(|m| m == requested) {
+                            return Some(requested.to_string());
+                        }
 
-                        (
-                            fallback,
+                        if let Some(found) =
+                            available.iter().find(|m| m.eq_ignore_ascii_case(requested))
+                        {
+                            return Some(found.clone());
+                        }
+
+                        if !requested.contains(':') {
+                            let prefix = format!("{}:", requested.to_ascii_lowercase());
+                            if let Some(found) = available
+                                .iter()
+                                .find(|m| m.to_ascii_lowercase().starts_with(&prefix))
+                            {
+                                return Some(found.clone());
+                            }
+                        }
+
+                        None
+                    };
+
+                    let available_models_result: Result<Vec<String>, String> = ollama_client
+                        .list_models()
+                        .await
+                        .map_err(|err| err.to_string());
+
+                    match available_models_result {
+                        Ok(available_models) => {
+                            if let Some(effective_model) =
+                                resolve_model(&current_model, &available_models)
+                            {
+                                match ollama_client
+                                    .generate(
+                                        &effective_model,
+                                        &req.message,
+                                        temp,
+                                        top_p,
+                                        top_k,
+                                        penalty,
+                                        exec_tokens,
+                                    )
+                                    .await
+                                {
+                                    Ok(text) => (
+                                        text.trim().to_string(),
+                                        true,
+                                        InferenceBackend::Ollama.as_str(),
+                                        true,
+                                    ),
+                                    Err(err) => {
+                                        let err_text = err.to_string();
+                                        let is_model_not_found = err_text.contains("HTTP 404");
+
+                                        let fallback = if is_model_not_found {
+                                            format!(
+                                                "Ollama model '{}' not found (HTTP 404). Pull or retag the model, then retry prompt '{}'.",
+                                                effective_model, req.message
+                                            )
+                                        } else {
+                                            format!(
+                                                "Inference backend '{}' unavailable. Generated degraded fallback for prompt: '{}'. Error: {}",
+                                                InferenceBackend::Ollama.as_str(),
+                                                req.message,
+                                                err_text
+                                            )
+                                        };
+
+                                        (
+                                            fallback,
+                                            false,
+                                            InferenceBackend::Ollama.as_str(),
+                                            !is_unreachable(&err_text),
+                                        )
+                                    }
+                                }
+                            } else {
+                                let shown =
+                                    available_models.iter().take(6).cloned().collect::<Vec<_>>();
+                                let available_hint = if shown.is_empty() {
+                                    "<no installed models>".to_string()
+                                } else {
+                                    shown.join(", ")
+                                };
+
+                                (
+                                    format!(
+                                        "Ollama model '{}' is not installed. Available models: {}. Pull the model or select one from the Models tab.",
+                                        current_model, available_hint
+                                    ),
+                                    false,
+                                    InferenceBackend::Ollama.as_str(),
+                                    true,
+                                )
+                            }
+                        }
+                        Err(err_text) => (
+                            format!(
+                                "Inference backend '{}' unavailable. Failed to list Ollama models before generation. Error: {}",
+                                InferenceBackend::Ollama.as_str(),
+                                err_text
+                            ),
                             false,
                             InferenceBackend::Ollama.as_str(),
-                            !is_unreachable,
-                        )
+                            !is_unreachable(&err_text),
+                        ),
                     }
-                },
+                }
                 InferenceBackend::Native => {
                     match native_engine_client.generate(
                     &current_model, &req.message, exec_tokens,

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -2199,14 +2199,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             // If using llama_server native engine, load the model into llama-server
             if backend.settings.native_engine == "llama_server" {
                 if let Err(e) = backend.native_engine_client.load_model_into_slot(&path) {
-<<<<<<< HEAD
-                    eprintln!("Warning: failed to load model into llama-server slot: {}", e);
-=======
                     eprintln!(
                         "Warning: failed to load model into llama-server slot: {}",
                         e
                     );
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
                 }
             }
         }
@@ -3658,10 +3654,6 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             .route("/api/runtime/recommend", get(handle_model_recommendations))
             // Phase 2: Backend API endpoints
             .route("/api/backends", get(backend_api::handle_list_backends))
-<<<<<<< HEAD
-            .route("/api/backends/switch", post(backend_api::handle_switch_backend))
-            .route("/api/backends/:name/status", get(backend_api::handle_backend_status))
-=======
             .route(
                 "/api/backends/switch",
                 post(backend_api::handle_switch_backend),
@@ -3670,7 +3662,6 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 "/api/backends/:name/status",
                 get(backend_api::handle_backend_status),
             )
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             .with_state(state)
             .layer(CorsLayer::permissive());
 
@@ -5670,16 +5661,9 @@ fn run_gui_preflight_checks() -> Result<()> {
     Ok(())
 }
 
-<<<<<<< HEAD
-mod backend_registry;
-mod backend_api;
-mod backend_config;
-mod runtime_switcher;
-=======
 mod backend_api;
 mod backend_config;
 mod backend_registry;
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 mod native_engine;
 mod ollama;
 mod runtime;

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -2895,35 +2895,58 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         let exec_tokens = chat_exec_token_budget(requested_exec_tokens);
         let exec_micro_batch = chat_exec_micro_batch();
 
-        let (response_text, real_inference, backend_used) = match inference_backend {
-            InferenceBackend::Ollama => match ollama_client
-                .generate(
-                    &current_model,
-                    &req.message,
-                    temp,
-                    top_p,
-                    top_k,
-                    penalty,
-                    exec_tokens,
-                )
-                .await
-            {
-                Ok(text) => (
-                    text.trim().to_string(),
-                    true,
-                    InferenceBackend::Ollama.as_str(),
-                ),
-                Err(_) => {
-                    let fallback = format!(
-                        "Inference backend '{}' unavailable. Generated degraded fallback for prompt: '{}'",
+        let (response_text, real_inference, backend_used, ollama_backend_available) =
+            match inference_backend {
+                InferenceBackend::Ollama => match ollama_client
+                    .generate(
+                        &current_model,
+                        &req.message,
+                        temp,
+                        top_p,
+                        top_k,
+                        penalty,
+                        exec_tokens,
+                    )
+                    .await
+                {
+                    Ok(text) => (
+                        text.trim().to_string(),
+                        true,
                         InferenceBackend::Ollama.as_str(),
-                        req.message
-                    );
-                    (fallback, false, InferenceBackend::Ollama.as_str())
-                }
-            },
-            InferenceBackend::Native => {
-                match native_engine_client.generate(
+                        true,
+                    ),
+                    Err(err) => {
+                        let err_text = err.to_string();
+                        let is_model_not_found = err_text.contains("HTTP 404");
+                        let is_unreachable = err_text.contains("error sending request")
+                            || err_text.contains("connection refused")
+                            || err_text.contains("Connection refused")
+                            || err_text.contains("timed out");
+
+                        let fallback = if is_model_not_found {
+                            format!(
+                            "Ollama model '{}' not found (HTTP 404). Pull or retag the model, then retry prompt '{}'.",
+                            current_model, req.message
+                        )
+                        } else {
+                            format!(
+                            "Inference backend '{}' unavailable. Generated degraded fallback for prompt: '{}'. Error: {}",
+                            InferenceBackend::Ollama.as_str(),
+                            req.message,
+                            err_text
+                        )
+                        };
+
+                        (
+                            fallback,
+                            false,
+                            InferenceBackend::Ollama.as_str(),
+                            !is_unreachable,
+                        )
+                    }
+                },
+                InferenceBackend::Native => {
+                    match native_engine_client.generate(
                     &current_model, &req.message, exec_tokens,
                     temp, top_p, top_k, penalty,
                 ) {
@@ -2931,6 +2954,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                         gen.text,
                         gen.real_inference,
                         InferenceBackend::Native.as_str(),
+                        true,
                     ),
                     Err(err) => (
                         format!(
@@ -2939,14 +2963,15 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                         ),
                         false,
                         InferenceBackend::Native.as_str(),
+                        false,
                     ),
                 }
-            }
-        };
+                }
+            };
 
-        {
+        if inference_backend == InferenceBackend::Ollama {
             let mut available_flag = ollama_available.lock().await;
-            *available_flag = real_inference;
+            *available_flag = ollama_backend_available;
         }
 
         let nodes = cluster.nodes();

--- a/crates/ghost-link/src/native_engine.rs
+++ b/crates/ghost-link/src/native_engine.rs
@@ -3,9 +3,8 @@
 //! This is a launch-focused adapter that provides a stable native execution
 //! interface while the full transformer runtime is being integrated.
 
-use std::process::{Command, Child};
+use std::process::Command;
 use std::time::Duration;
-use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
 pub struct NativeGeneration {
@@ -15,9 +14,6 @@ pub struct NativeGeneration {
 
 #[derive(Debug, Clone)]
 pub struct NativeEngineClient;
-
-// Static variable to track the llama-server process
-static LLAMA_SERVER_PROCESS: std::sync::OnceLock<Arc<Mutex<Option<Child>>>> = std::sync::OnceLock::new();
 
 impl NativeEngineClient {
     pub fn new() -> Self {
@@ -30,11 +26,7 @@ impl NativeEngineClient {
     pub fn load_model_into_slot(&self, model_path: &str) -> Result<(), String> {
         let normalized_path = model_path.replace('\\', "/");
         eprintln!("[model-load] Preparing to load model: {}", normalized_path);
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         // In a real implementation, this would:
         // 1. Kill the current llama-server process
         // 2. Get llama-server binary path and launch flags from environment
@@ -44,13 +36,6 @@ impl NativeEngineClient {
         //
         // For now, we just log a note since restarting llama-server from the backend
         // would require careful process management and coordination with the launch script.
-<<<<<<< HEAD
-        
-        eprintln!("[model-load] NOTE: llama-server requires restart for model switching");
-        eprintln!("[model-load] Current model: use 'tinyllama-1.1b-chat', 'gemma-4-E4B-it-Q4_K_M', etc.");
-        eprintln!("[model-load] Workaround: Manually restart llama-server with desired model");
-        
-=======
 
         eprintln!("[model-load] NOTE: llama-server requires restart for model switching");
         eprintln!(
@@ -58,7 +43,6 @@ impl NativeEngineClient {
         );
         eprintln!("[model-load] Workaround: Manually restart llama-server with desired model");
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         Ok(())
     }
 

--- a/crates/ghost-link/src/ollama.rs
+++ b/crates/ghost-link/src/ollama.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::error::Error;
+use std::io;
 use std::pin::Pin;
 use tokio::sync::mpsc;
 
@@ -241,6 +242,18 @@ impl OllamaClient {
             .json(&payload)
             .send()
             .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable body>".to_string());
+            return Err(Box::new(io::Error::other(format!(
+                "Ollama generate failed: HTTP {} - {}",
+                status, body
+            ))));
+        }
 
         let data: OllamaResponse = resp.json().await?;
         Ok(data.response)

--- a/crates/ghost-link/src/ollama.rs
+++ b/crates/ghost-link/src/ollama.rs
@@ -109,10 +109,7 @@ pub struct ModelInfoResponse {
     pub details: Option<ModelDetails>,
 }
 
-<<<<<<< HEAD
-=======
 #[allow(dead_code)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateModelRequest {
     pub name: String,
@@ -122,29 +119,20 @@ pub struct CreateModelRequest {
     pub stream: bool,
 }
 
-<<<<<<< HEAD
-=======
 #[allow(dead_code)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CopyModelRequest {
     pub source: String,
     pub destination: String,
 }
 
-<<<<<<< HEAD
-=======
 #[allow(dead_code)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteModelRequest {
     pub name: String,
 }
 
-<<<<<<< HEAD
-=======
 #[allow(dead_code)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingRequest {
     pub model: String,
@@ -156,13 +144,9 @@ pub struct EmbeddingResponse {
     pub embedding: Vec<f32>,
 }
 
-<<<<<<< HEAD
-pub type OllamaStream = Pin<Box<dyn Stream<Item = Result<String, Box<dyn Error + Send + Sync>>> + Send>>;
-=======
 #[allow(dead_code)]
 pub type OllamaStream =
     Pin<Box<dyn Stream<Item = Result<String, Box<dyn Error + Send + Sync>>> + Send>>;
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 
 impl OllamaClient {
     pub fn new(base_url: String) -> Self {
@@ -211,10 +195,7 @@ impl OllamaClient {
     }
 
     /// Generate text using Ollama (non-streaming)
-<<<<<<< HEAD
-=======
     #[allow(clippy::too_many_arguments)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
     pub async fn generate(
         &self,
         model: &str,
@@ -260,10 +241,7 @@ impl OllamaClient {
     }
 
     /// Generate text using Ollama (streaming)
-<<<<<<< HEAD
-=======
     #[allow(dead_code, clippy::too_many_arguments)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
     pub async fn generate_stream(
         &self,
         model: &str,
@@ -293,40 +271,24 @@ impl OllamaClient {
             .await?;
 
         let stream = Box::pin(tokio_stream::wrappers::ReceiverStream::new(
-<<<<<<< HEAD
-            Self::stream_response(resp).await?
-=======
             Self::stream_response(resp).await?,
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         ));
 
         Ok(stream)
     }
 
-<<<<<<< HEAD
-=======
     #[allow(dead_code)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
     async fn stream_response(
         resp: reqwest::Response,
     ) -> Result<mpsc::Receiver<Result<String, Box<dyn Error + Send + Sync>>>, Box<dyn Error>> {
         let (tx, rx) = mpsc::channel(100);
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         let body = resp.bytes().await?;
 
         tokio::spawn(async move {
             let text = String::from_utf8_lossy(&body);
             for line in text.lines() {
-<<<<<<< HEAD
-                if line.starts_with("data: ") {
-                    let json_str = &line[6..];
-=======
                 if let Some(json_str) = line.strip_prefix("data: ") {
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
                     if let Ok(data) = serde_json::from_str::<Value>(json_str) {
                         if let Some(response) = data.get("response").and_then(|v| v.as_str()) {
                             let _ = tx.send(Ok(response.to_string())).await;
@@ -350,10 +312,7 @@ impl OllamaClient {
     }
 
     /// Chat with Ollama (non-streaming)
-<<<<<<< HEAD
-=======
     #[allow(clippy::too_many_arguments)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
     pub async fn chat(
         &self,
         model: &str,
@@ -387,10 +346,7 @@ impl OllamaClient {
     }
 
     /// Chat with Ollama (streaming)
-<<<<<<< HEAD
-=======
     #[allow(dead_code, clippy::too_many_arguments)]
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
     pub async fn chat_stream(
         &self,
         model: &str,
@@ -400,14 +356,10 @@ impl OllamaClient {
         top_k: Option<usize>,
         repeat_penalty: Option<f32>,
         max_tokens: Option<usize>,
-<<<<<<< HEAD
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<ChatResponse, Box<dyn Error + Send + Sync>>> + Send>>, Box<dyn Error>> {
-=======
     ) -> Result<
         Pin<Box<dyn Stream<Item = Result<ChatResponse, Box<dyn Error + Send + Sync>>> + Send>>,
         Box<dyn Error>,
     > {
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         let request = ChatRequest {
             model: model.to_string(),
             messages: messages.to_vec(),
@@ -427,23 +379,12 @@ impl OllamaClient {
             .await?;
 
         let stream = Box::pin(tokio_stream::wrappers::ReceiverStream::new(
-<<<<<<< HEAD
-            Self::stream_chat_response(resp).await?
-=======
             Self::stream_chat_response(resp).await?,
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         ));
 
         Ok(stream)
     }
 
-<<<<<<< HEAD
-    async fn stream_chat_response(
-        resp: reqwest::Response,
-    ) -> Result<mpsc::Receiver<Result<ChatResponse, Box<dyn Error + Send + Sync>>>, Box<dyn Error>> {
-        let (tx, rx) = mpsc::channel(100);
-        
-=======
     #[allow(dead_code)]
     async fn stream_chat_response(
         resp: reqwest::Response,
@@ -451,18 +392,12 @@ impl OllamaClient {
     {
         let (tx, rx) = mpsc::channel(100);
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         let body = resp.bytes().await?;
 
         tokio::spawn(async move {
             let text = String::from_utf8_lossy(&body);
             for line in text.lines() {
-<<<<<<< HEAD
-                if line.starts_with("data: ") {
-                    let json_str = &line[6..];
-=======
                 if let Some(json_str) = line.strip_prefix("data: ") {
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
                     if let Ok(data) = serde_json::from_str::<ChatResponse>(json_str) {
                         let done = data.done;
                         let _ = tx.send(Ok(data)).await;
@@ -507,9 +442,6 @@ impl OllamaClient {
     pub async fn pull_model_stream(
         &self,
         model_name: &str,
-<<<<<<< HEAD
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<PullProgressResponse, Box<dyn Error + Send + Sync>>> + Send>>, Box<dyn Error>> {
-=======
     ) -> Result<
         Pin<
             Box<
@@ -519,7 +451,6 @@ impl OllamaClient {
         >,
         Box<dyn Error>,
     > {
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         let payload = json!({
             "name": model_name,
             "stream": true,
@@ -533,11 +464,7 @@ impl OllamaClient {
             .await?;
 
         let stream = Box::pin(tokio_stream::wrappers::ReceiverStream::new(
-<<<<<<< HEAD
-            Self::stream_pull_progress(resp).await?
-=======
             Self::stream_pull_progress(resp).await?,
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         ));
 
         Ok(stream)
@@ -545,18 +472,12 @@ impl OllamaClient {
 
     async fn stream_pull_progress(
         resp: reqwest::Response,
-<<<<<<< HEAD
-    ) -> Result<mpsc::Receiver<Result<PullProgressResponse, Box<dyn Error + Send + Sync>>>, Box<dyn Error>> {
-        let (tx, rx) = mpsc::channel(100);
-        
-=======
     ) -> Result<
         mpsc::Receiver<Result<PullProgressResponse, Box<dyn Error + Send + Sync>>>,
         Box<dyn Error>,
     > {
         let (tx, rx) = mpsc::channel(100);
 
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         let body = resp.bytes().await?;
 
         tokio::spawn(async move {
@@ -593,15 +514,11 @@ impl OllamaClient {
     }
 
     /// Create a model from a Modelfile
-<<<<<<< HEAD
-    pub async fn create_model(&self, name: &str, modelfile: &str) -> Result<String, Box<dyn Error>> {
-=======
     pub async fn create_model(
         &self,
         name: &str,
         modelfile: &str,
     ) -> Result<String, Box<dyn Error>> {
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         let payload = json!({
             "name": name,
             "modelfile": modelfile,
@@ -622,15 +539,11 @@ impl OllamaClient {
     }
 
     /// Copy a model
-<<<<<<< HEAD
-    pub async fn copy_model(&self, source: &str, destination: &str) -> Result<String, Box<dyn Error>> {
-=======
     pub async fn copy_model(
         &self,
         source: &str,
         destination: &str,
     ) -> Result<String, Box<dyn Error>> {
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         let payload = json!({
             "source": source,
             "destination": destination,

--- a/crates/ghost-link/src/runtime_switcher.rs
+++ b/crates/ghost-link/src/runtime_switcher.rs
@@ -153,11 +153,7 @@ impl EnvironmentManager {
             .get(backend_name)
             .ok_or_else(|| format!("No environment configuration for backend: {}", backend_name))?;
 
-<<<<<<< HEAD
-        for (key, _) in env_vars {
-=======
         for key in env_vars.keys() {
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
             std::env::remove_var(key);
         }
 
@@ -311,14 +307,10 @@ mod tests {
 
         manager.set_backend_env(&ComputeBackend::Cpu).unwrap();
 
-<<<<<<< HEAD
-        assert_eq!(std::env::var("OLLAMA_NUM_THREAD").ok(), Some("16".to_string()));
-=======
         assert_eq!(
             std::env::var("OLLAMA_NUM_THREAD").ok(),
             Some("16".to_string())
         );
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
         assert_eq!(
             std::env::var("OLLAMA_GPU_MEMORY").ok(),
             Some("0".to_string())
@@ -367,13 +359,7 @@ mod tests {
         // Should timeout
         let result = tracker.drain(Duration::from_millis(100)).await;
         assert!(result.is_err());
-<<<<<<< HEAD
-        assert!(result
-            .unwrap_err()
-            .contains("Request drain timeout"));
-=======
         assert!(result.unwrap_err().contains("Request drain timeout"));
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
 
         tracker.decrement().await;
     }

--- a/ghostlink_gui_modern/src/api.ts
+++ b/ghostlink_gui_modern/src/api.ts
@@ -413,8 +413,6 @@ export class GhostlinkAPI {
       const response = await this.http.get('/api/ollama/models');
       return { models: response.data.models || [] };
     } catch (error: any) {
-<<<<<<< HEAD
-=======
       if (this.isNotFound(error)) {
         try {
           const fallback = await this.getModels();
@@ -431,18 +429,12 @@ export class GhostlinkAPI {
           return { models: [], error: fallbackError.message || error.message };
         }
       }
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
       return { models: [], error: error.message };
     }
   }
 
   async pullOllamaModel(modelName: string): Promise<{ success: boolean; error?: string }> {
     try {
-<<<<<<< HEAD
-      const response = await this.http.post('/api/ollama/pull', { model: modelName });
-      return { success: true };
-    } catch (error: any) {
-=======
       await this.http.post('/api/ollama/pull', { model: modelName });
       return { success: true };
     } catch (error: any) {
@@ -454,7 +446,6 @@ export class GhostlinkAPI {
           return { success: false, error: fallbackError.message || error.message };
         }
       }
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
       return { success: false, error: error.response?.data?.error || error.message };
     }
   }
@@ -498,8 +489,6 @@ export class GhostlinkAPI {
       }
       return { success: true };
     } catch (error: any) {
-<<<<<<< HEAD
-=======
       const is404 = error?.message?.includes('HTTP 404') || this.isNotFound(error);
       if (is404) {
         onProgress({ completed: 0, total: 1, status: 'starting' });
@@ -507,19 +496,10 @@ export class GhostlinkAPI {
         onProgress({ completed: fallback.success ? 1 : 0, total: 1, status: fallback.success ? 'success' : 'failed' });
         return fallback;
       }
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
       return { success: false, error: error.message };
     }
   }
 
-<<<<<<< HEAD
-  async showOllamaModel(modelName: string): Promise<{ info: any; error?: string }> {
-    try {
-      const response = await this.http.post('/api/ollama/show', { model: modelName });
-      return { info: response.data };
-    } catch (error: any) {
-      return { info: null, error: error.response?.data?.error || error.message };
-=======
   async showOllamaModel(modelName: string): Promise<{ info?: any; modelfile?: string; error?: string }> {
     try {
       const response = await this.http.post('/api/ollama/show', { model: modelName });
@@ -544,17 +524,12 @@ export class GhostlinkAPI {
         }
       }
       return { info: null, modelfile: '', error: error.response?.data?.error || error.message };
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
     }
   }
 
   async createOllamaModel(name: string, modelfile: string): Promise<{ success: boolean; error?: string }> {
     try {
-<<<<<<< HEAD
-      const response = await this.http.post('/api/ollama/create', { name, modelfile });
-=======
       await this.http.post('/api/ollama/create', { name, modelfile });
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
       return { success: true };
     } catch (error: any) {
       return { success: false, error: error.response?.data?.error || error.message };
@@ -563,11 +538,7 @@ export class GhostlinkAPI {
 
   async copyOllamaModel(source: string, destination: string): Promise<{ success: boolean; error?: string }> {
     try {
-<<<<<<< HEAD
-      const response = await this.http.post('/api/ollama/copy', { source, destination });
-=======
       await this.http.post('/api/ollama/copy', { source, destination });
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
       return { success: true };
     } catch (error: any) {
       return { success: false, error: error.response?.data?.error || error.message };
@@ -576,11 +547,6 @@ export class GhostlinkAPI {
 
   async deleteOllamaModel(name: string): Promise<{ success: boolean; error?: string }> {
     try {
-<<<<<<< HEAD
-      const response = await this.http.post('/api/ollama/delete', { name });
-      return { success: true };
-    } catch (error: any) {
-=======
       await this.http.post('/api/ollama/delete', { name });
       return { success: true };
     } catch (error: any) {
@@ -592,7 +558,6 @@ export class GhostlinkAPI {
           return { success: false, error: fallbackError.message || error.message };
         }
       }
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
       return { success: false, error: error.response?.data?.error || error.message };
     }
   }
@@ -602,14 +567,11 @@ export class GhostlinkAPI {
       const response = await this.http.get('/api/ollama/ps');
       return { models: response.data.models || [] };
     } catch (error: any) {
-<<<<<<< HEAD
-=======
       if (this.isNotFound(error)) {
         const fallback = await this.getModels();
         const loaded = (fallback.models || []).filter((m: any) => String(m.status).toLowerCase() === 'loaded');
         return { models: loaded, error: fallback.error };
       }
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
       return { models: [], error: error.message };
     }
   }

--- a/ghostlink_gui_modern/src/components/ModelsTab.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.tsx
@@ -12,10 +12,6 @@ import {
   Loader,
   Power,
   ChevronRight,
-<<<<<<< HEAD
-  ArrowUpRight,
-=======
->>>>>>> e71b1dc998b67d1b257ab2ae2977ac19cba263d6
   Copy,
 } from 'lucide-react';
 import { useAppStore } from '../store';


### PR DESCRIPTION
## Summary
- Revert the latest bad merge commit on main (`680ba85`, message: `Grrr`) which introduced unresolved conflict markers across source files.
- Keep the Ollama error-classification improvement so HTTP 404 model misses are no longer reported as backend-unavailable.

## Why
- The pushed merge commit contained unresolved conflict markers and broke formatting/lint/build parsing in key files.
- The Ollama 404 handling patch improves runtime diagnostics and prevents misleading fallback messaging.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npm run type-check` in `ghostlink_gui_modern`
- `npm test -- --run` in `ghostlink_gui_modern` (94/94)

## Notes
- Previous PR #114 is already merged; this PR is for the new post-merge repair path on `main`.
