### PR TITLE
fix(ollama): skip unload for inactive models

### DIFF
--- a/crates/ghost-link/src/ollama.rs
+++ b/crates/ghost-link/src/ollama.rs
@@ -152,6 +152,10 @@ impl OllamaClient {
         }
     }
 
+    fn matches_model_name(candidate: &str, requested: &str) -> bool {
+        candidate == requested || candidate.eq_ignore_ascii_case(requested)
+    }
+
     /// Check if Ollama is reachable
     pub async fn health(&self) -> Result<bool, Box<dyn Error>> {
         match self
@@ -521,6 +525,14 @@ impl OllamaClient {
 
     /// Unload a model by setting keep_alive to zero.
     pub async fn unload_model(&self, model_name: &str) -> Result<String, Box<dyn Error>> {
+        let running_models = self.list_running().await.unwrap_or_default();
+        if !running_models
+            .iter()
+            .any(|model| Self::matches_model_name(&model.name, model_name))
+        {
+            return Ok(format!("model '{}' is not running; unload skipped", model_name));
+        }
+
         let payload = json!({
             "model": model_name,
             "prompt": "",

--- a/crates/ghost-link/src/ollama.rs
+++ b/crates/ghost-link/src/ollama.rs
@@ -530,7 +530,10 @@ impl OllamaClient {
             .iter()
             .any(|model| Self::matches_model_name(&model.name, model_name))
         {
-            return Ok(format!("model '{}' is not running; unload skipped", model_name));
+            return Ok(format!(
+                "model '{}' is not running; unload skipped",
+                model_name
+            ));
         }
 
         let payload = json!({


### PR DESCRIPTION
- Check running Ollama models before issuing keep_alive unload\n- Avoid noisy 404s from /api/generate when the model is already gone\n- Keep unload behavior intact for active models

# Summary

- What production gap(s) does this PR close?

## Phase Mapping

- Phase: <!-- e.g., Phase 2: Multi-Node Reliability Validation -->
- Plan reference: docs/PRODUCTION_REMEDIATION_PLAN.md

## Weekly Status (Required for phase work)

- Progress this week:
- Blockers:
- Next actions:

## Tracker Links

- Issue(s):
- Artifact/report links:
- Related tracker entry: docs/PRODUCTION_PHASE_TRACKER.md

## Validation

- [ ] cargo fmt --all --check
- [ ] cargo clippy --workspace --all-targets -- -D warnings
- [ ] cargo test --workspace
- [ ] scripts/run_full_validation.sh (or phase-specific equivalent)

## Security / Ops Impact

- [ ] Secrets/tokens are not hardcoded
- [ ] Logging output avoids sensitive data
- [ ] Docs updated for operator runbooks

## Rollback Plan

- How to disable/revert quickly if regression occurs:
