### PR TITLE
feat: extend prebuilt llama.cpp fallback to macOS (arm64 + x86_64)

### DIFF
--- a/launch-complete.sh
+++ b/launch-complete.sh
@@ -60,16 +60,28 @@ warn() { printf '[launch-complete] WARN: %s\n' "$*" >&2; }
 # Without this, machines with no build toolchain silently drop to simulated
 # mode and every chat fails with "could not connect to 127.0.0.1:8080".
 download_prebuilt_llama() {
-    if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
-        warn "prebuilt llama.cpp fallback supports Linux x86_64 only"
-        return 1
-    fi
-    # The Vulkan build drives NVIDIA/AMD/Intel GPUs through the system Vulkan
-    # loader without needing a CUDA/ROCm toolchain installed.
-    local variant="ubuntu-x64"
-    if ldconfig -p 2>/dev/null | grep -q "libvulkan.so.1"; then
-        variant="ubuntu-vulkan-x64"
-    fi
+    local variant
+    case "$(uname -s)/$(uname -m)" in
+        Linux/x86_64)
+            # The Vulkan build drives NVIDIA/AMD/Intel GPUs through the system
+            # Vulkan loader without needing a CUDA/ROCm toolchain installed.
+            variant="ubuntu-x64"
+            if ldconfig -p 2>/dev/null | grep -q "libvulkan.so.1"; then
+                variant="ubuntu-vulkan-x64"
+            fi
+            ;;
+        Darwin/arm64)
+            # Apple Silicon: official build ships with Metal GPU support.
+            variant="macos-arm64"
+            ;;
+        Darwin/x86_64)
+            variant="macos-x64"
+            ;;
+        *)
+            warn "prebuilt llama.cpp fallback supports Linux x86_64 and macOS only"
+            return 1
+            ;;
+    esac
     log "llama-server: resolving official prebuilt binaries ($variant)..."
     # Releases are listed newest-first; not every release publishes all
     # assets, so scan a few and take the newest matching one.


### PR DESCRIPTION
## Summary

Extends the prebuilt llama.cpp fallback (from the Linux PR) to macOS. Without it, a Mac lacking cmake silently drops to simulated mode and every chat fails with the port-8080 connection error.

llama.cpp publishes official `macos-arm64` (Metal included) and `macos-x64` release binaries in the same archive layout as the Linux ones, so the identical resolve/download/extract path applies — this PR just adds the platform cases.

## Verification (from Linux, uname-mocked)

Ran the real function with `uname` mocked per-platform:

| Platform | Result |
|---|---|
| Darwin/arm64 | resolves `macos-arm64`, downloads, extracts — genuine **Mach-O arm64 executable** installed at the expected path |
| Darwin/x86_64 | resolves `macos-x64` correctly |
| Linux/x86_64 (native, regression) | installs and **executes** (version 10068), Vulkan variant selected |

**Honest caveat:** executing the Mac binary end-to-end still needs one run on real Apple hardware. 30-minute checklist for whoever has a Mac:

1. `./launch-complete.sh` on a Mac **without** cmake — expect `llama-server: resolving official prebuilt binaries (macos-arm64)...` and native mode instead of simulated
2. Download a small model from the HF tab (e.g. `mradermacher/llama2.c-stories15M-GGUF`)
3. Send one chat — expect a coherent answer, and Activity Monitor should show llama-server GPU usage (Metal)
