### PR TITLE
fix: correct GPU/CPU auto-discovery false-positive and wire up worker discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.3.2] - 2026-07-22 (GPU/CPU Auto-Discovery Fix & Worker Discovery)
+
+### 🐛 Hardware Auto-Discovery
+
+- Fixed a false-positive in `detect_gpu_from_env()` (`ghostlink-core/src/system_profile.rs`): the mere presence of `GHOSTLINK_VRAM_GB` (which `launch.sh` exports unconditionally, defaulting to `"0"` in CPU-only mode) was treated as an explicit GPU override, short-circuiting every real hardware probe (nvidia-smi/rocm-smi/WMI/lspci/Vulkan) and injecting a fake `"env-gpu"` device. `GET /api/health` reported `gpu_available: true` on pure-CPU hosts launched via the shipped launch scripts. Now requires a genuine signal (name, compute capability, or VRAM > 0).
+- Added a regression case for the zero-VRAM-default scenario, folded into the existing `detect_gpu_handles_env_overrides` test (sequentially, not as a separate `#[test]`) — Rust runs tests in parallel by default, and process-global env vars mean two independent tests setting/clearing the same vars race regardless of what either asserts. A separate test was tried first and observed to fail intermittently under `cargo test --workspace` for exactly this reason.
+
+### 🔌 Worker Discovery
+
+- `GET /api/workers/discover` was a hardcoded stub returning `{"count": 2}`, disconnected from the real HMAC-authenticated UDP discovery module (`ghostlink_core::discovery`) already running in background threads. It now performs a real `broadcast_and_collect`, registers replies into the live `ClusterState`, and returns genuine counts.
+- `GET /api/workers` now merges auto-discovered cluster peers with manually-added workers (previously showed only the latter), deduplicated by node id.
+
+### 🔧 Launch Scripts
+
+- `launch.bat`: fixed a 100%-reproducible failure where `%~dp0`'s trailing backslash broke WSL's argument parsing in `wsl wslpath -a "...\"` (bash saw an unterminated quote), causing every invocation to fail with "Failed to resolve repository path inside WSL."
+- `launch.sh`: removed two blind, system-wide `pkill -f llama-server` / `pkill -f ghost-link` calls in favor of the already-correct port-scoped `free_port` cleanup — the blind form could kill an unrelated process from a different user or session sharing the same binary name. Now also passes the real detected GPU name through (`GHOSTLINK_GPU_NAME`) when a vendor is actually found, so the env override reports accurate hardware instead of a generic placeholder when it legitimately applies.
+
+### ✅ Validation
+
+- `cargo fmt --all --check` — OK
+- `cargo clippy --workspace --all-targets -- -D warnings` — OK
+- `cargo test -p ghost-link -p ghostlink-core` — 229/229 passing
+- `cargo test --workspace` — passing; also surfaced a pre-existing, unrelated flaky test (`runtime_switcher::tests::test_environment_manager_set_env`, same process-global-env-var race pattern, not touched by this change) — flagged separately, not fixed here to keep this PR scoped
+- `cargo run -p ghost-link -- probe my-node --full` — no regression (correctly reports `GPU: cpu`, `GPU VRAM: 0.0 GB`, `Acceleration: AVX-512` on this CPU-only host)
+- Live end-to-end verification on Windows 11 + WSL2 (AMD Ryzen AI 7 350, no functioning GPU driver in-guest): both `launch.sh` and `launch.bat` reach healthy state; `/api/health` correctly reports `gpu_available: false`; native↔Ollama runtime switching verified with two models each (SmolLM2-360M-Instruct + stories15M native, smollm2:135m + qwen2.5:0.5b via Ollama), each producing distinct, correctly-attributed, real inference responses; `/api/backends/switch` succeeds for `cpu` and cleanly rejects `cuda`/`rocm` as unavailable
+
+### ⚠️ Known Caveats (host-specific)
+
+- GPU-accelerated inference was **not** verified on real GPU hardware in this change — no CUDA/ROCm/functioning-Vulkan device was available in the test environment (WSL2 exposes the GPU device node but this Ubuntu image's Mesa build lacks the D3D12/"dozen" driver needed to bridge to it, and `/dev/dri` is absent). The fixed code paths are covered by existing unit tests (`infer_backend_cuda`, `infer_backend_rocm`, etc.) but not exercised against physical GPU hardware.
+- The React frontend (GUI) was verified only through its backend API surface (curl/HTTP), not by driving the rendered UI in a browser.
+
+---
+
 ## [1.3.1] - 2026-07-22 (Launch Reliability & CI Stabilization)
 
 ### 🔧 Launch Hardening

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -8,7 +8,7 @@
 use crate::runtime::Runtime;
 use anyhow::Result;
 use ghostlink_core::autotune::AutoTuner;
-use ghostlink_core::cluster::{ClusterState, NodeMetrics};
+use ghostlink_core::cluster::{ClusterState, NodeMetrics, NodeStatus};
 use ghostlink_core::dashboard::Dashboard;
 use ghostlink_core::discovery::{
     broadcast_and_collect, respond_once, serve_discovery, serve_discovery_with_stats,
@@ -2810,8 +2810,48 @@ InferenceBackend::Native => match native_engine_client
     async fn handle_gui_workers(
         State(state): State<Arc<Mutex<BackendState>>>,
     ) -> Json<serde_json::Value> {
-        let backend = lock_state(&state);
-        Json(serde_json::json!({ "workers": backend.workers }))
+        let (manual_workers, cluster) = {
+            let backend = lock_state(&state);
+            (backend.workers.clone(), Arc::clone(&backend.cluster))
+        };
+
+        // Merge manually-added workers with peers found via UDP auto-discovery.
+        // `cluster` is kept live by the background broadcast/listen threads
+        // started in `serve` and by explicit /api/workers/discover calls.
+        let mut seen: std::collections::HashSet<String> =
+            manual_workers.iter().map(|w| w.id.clone()).collect();
+        let mut workers = manual_workers;
+
+        for node in cluster.nodes() {
+            if !seen.insert(node.id.clone()) {
+                continue;
+            }
+            let metrics = cluster.get_metrics(&node.id);
+            let (host, port) = metrics
+                .as_ref()
+                .and_then(|m| m.ip_address)
+                .map(|addr| (addr.ip().to_string(), addr.port()))
+                .unwrap_or_else(|| ("unknown".to_string(), 0));
+            let status = match metrics.as_ref().map(|m| m.status) {
+                Some(NodeStatus::Failed) => "Disconnected",
+                Some(NodeStatus::Degraded) => "Degraded",
+                _ => "Connected",
+            };
+            workers.push(WorkerRecord {
+                id: node.id.clone(),
+                host,
+                port,
+                status: status.to_string(),
+                model: node
+                    .gpu_name
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
+                threads: 0,
+                load: 0,
+            });
+        }
+
+        Json(serde_json::json!({ "workers": workers }))
     }
 
     async fn handle_gui_workers_connect() -> Json<serde_json::Value> {
@@ -2835,8 +2875,61 @@ InferenceBackend::Native => match native_engine_client
         Json(serde_json::json!({ "status": "ok" }))
     }
 
-    async fn handle_gui_workers_discover() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "status": "ok", "count": 2 }))
+    async fn handle_gui_workers_discover(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let (cluster, discovery_broadcast, discovery_auth_token) = {
+            let backend = lock_state(&state);
+            (
+                Arc::clone(&backend.cluster),
+                backend.settings.discovery_broadcast.clone(),
+                backend.settings.discovery_auth_token.clone(),
+            )
+        };
+
+        let broadcast_addr = discovery_broadcast
+            .parse::<SocketAddr>()
+            .unwrap_or_else(|_| SocketAddr::from(([255, 255, 255, 255], DEFAULT_DISCOVERY_PORT)));
+        let auth_token = if discovery_auth_token.is_empty() {
+            None
+        } else {
+            Some(discovery_auth_token)
+        };
+        let local_node = detect_runtime_profile("workers-discover").node_resources;
+
+        // broadcast_and_collect blocks on a UDP recv loop for response_timeout —
+        // run it off the async runtime so it can't stall other requests.
+        let peers = tokio::task::spawn_blocking(move || {
+            let config = UdpDiscoveryConfig {
+                broadcast_addr,
+                auth_token,
+                response_timeout: Duration::from_millis(1200),
+                allow_legacy_crc32: env_default_bool(
+                    "GHOSTLINK_DISCOVERY_ALLOW_LEGACY_CRC32",
+                    false,
+                ),
+                ..UdpDiscoveryConfig::default()
+            };
+            let frame = DiscoveryFrame {
+                kind: FrameKind::Join,
+                node: local_node,
+            };
+            broadcast_and_collect(&frame, &config)
+        })
+        .await
+        .unwrap_or_else(|_| Ok(Vec::new()))
+        .unwrap_or_default();
+
+        let discovered = peers.len();
+        for (peer_frame, peer_addr) in peers {
+            cluster.register_with_addr(peer_frame.node, Some(peer_addr));
+        }
+
+        Json(serde_json::json!({
+            "status": "ok",
+            "discovered": discovered,
+            "count": cluster.node_count(),
+        }))
     }
 
     async fn handle_gui_workers_disconnect(

--- a/crates/ghostlink-core/src/system_profile.rs
+++ b/crates/ghostlink-core/src/system_profile.rs
@@ -1649,6 +1649,10 @@ mod tests {
         assert_eq!(rp.recommended_workers, sp.recommended_workers);
     }
 
+    // Both scenarios below live in one test (rather than two separate #[test]
+    // fns) because they mutate process-global env vars — Rust runs tests in
+    // parallel by default, and a second test setting/clearing the same vars
+    // races with this one regardless of what either asserts.
     #[test]
     fn detect_gpu_handles_env_overrides() {
         std::env::set_var("GHOSTLINK_GPU_NAME", "RTX 4090");
@@ -1663,19 +1667,12 @@ mod tests {
         std::env::remove_var("GHOSTLINK_GPU_NAME");
         std::env::remove_var("GHOSTLINK_VRAM_GB");
         std::env::remove_var("GHOSTLINK_COMPUTE_CAPABILITY");
-    }
 
-    #[test]
-    fn detect_gpu_from_env_ignores_zero_vram_default() {
-        // launch.sh always exports GHOSTLINK_VRAM_GB (defaulting to "0" on CPU-only
-        // hosts). That alone must not be treated as a GPU override, or CPU-only
-        // hosts would falsely report GPU acceleration as available.
-        std::env::remove_var("GHOSTLINK_GPU_NAME");
+        // launch.sh always exports GHOSTLINK_VRAM_GB (defaulting to "0" on
+        // CPU-only hosts). That alone must not be treated as a GPU override,
+        // or CPU-only hosts would falsely report GPU acceleration available.
         std::env::set_var("GHOSTLINK_VRAM_GB", "0");
-        std::env::remove_var("GHOSTLINK_COMPUTE_CAPABILITY");
-
         assert!(detect_gpu_from_env().is_none());
-
         std::env::remove_var("GHOSTLINK_VRAM_GB");
     }
 

--- a/crates/ghostlink-core/src/system_profile.rs
+++ b/crates/ghostlink-core/src/system_profile.rs
@@ -786,13 +786,22 @@ fn detect_gpus(mode: ProbeMode) -> Vec<GpuInfo> {
 }
 
 fn detect_gpu_from_env() -> Option<GpuInfo> {
-    let name = env::var("GHOSTLINK_GPU_NAME").ok();
+    let name = env::var("GHOSTLINK_GPU_NAME")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
     let vram_gb = env::var("GHOSTLINK_VRAM_GB")
         .ok()
         .and_then(|v| v.parse::<f32>().ok());
-    let cc = env::var("GHOSTLINK_COMPUTE_CAPABILITY").ok();
-    let has_any = name.is_some() || vram_gb.is_some() || cc.is_some();
-    if !has_any {
+    let cc = env::var("GHOSTLINK_COMPUTE_CAPABILITY")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+    // A VRAM value of 0 (or absent) is not a meaningful GPU signal on its own —
+    // launch scripts unconditionally export GHOSTLINK_VRAM_GB=0 in CPU-only mode,
+    // and treating that as an override used to short-circuit the real hardware
+    // probes below, permanently masking true auto-discovery and falsely reporting
+    // GPU acceleration as available on CPU-only hosts.
+    let has_gpu_signal = name.is_some() || cc.is_some() || vram_gb.is_some_and(|v| v > 0.0);
+    if !has_gpu_signal {
         return None;
     }
 
@@ -1654,6 +1663,20 @@ mod tests {
         std::env::remove_var("GHOSTLINK_GPU_NAME");
         std::env::remove_var("GHOSTLINK_VRAM_GB");
         std::env::remove_var("GHOSTLINK_COMPUTE_CAPABILITY");
+    }
+
+    #[test]
+    fn detect_gpu_from_env_ignores_zero_vram_default() {
+        // launch.sh always exports GHOSTLINK_VRAM_GB (defaulting to "0" on CPU-only
+        // hosts). That alone must not be treated as a GPU override, or CPU-only
+        // hosts would falsely report GPU acceleration as available.
+        std::env::remove_var("GHOSTLINK_GPU_NAME");
+        std::env::set_var("GHOSTLINK_VRAM_GB", "0");
+        std::env::remove_var("GHOSTLINK_COMPUTE_CAPABILITY");
+
+        assert!(detect_gpu_from_env().is_none());
+
+        std::env::remove_var("GHOSTLINK_VRAM_GB");
     }
 
     #[test]

--- a/launch.bat
+++ b/launch.bat
@@ -5,6 +5,7 @@ REM Ghostlink unified launcher for Windows hosts.
 REM This wrapper runs the Linux launcher inside WSL to keep one source of truth.
 
 set "ROOT_DIR=%~dp0"
+if "%ROOT_DIR:~-1%"=="\" set "ROOT_DIR=%ROOT_DIR:~0,-1%"
 cd /d "%ROOT_DIR%"
 
 where wsl >nul 2>nul

--- a/launch.sh
+++ b/launch.sh
@@ -754,14 +754,16 @@ start_services() {
     echo ""
     echo -e "  ${DIM}Inference backend: ${INFERENCE_BACKEND}${NC}"
 
-    # Clear stale listeners that cause 404/405 and bind failures
+    # Clear stale listeners that cause 404/405 and bind failures.
+    # Scoped to the exact ports we're about to bind (via free_port's PID lookup on
+    # that port) rather than a blind `pkill -f llama-server` / `pkill -f ghost-link`,
+    # which would kill any matching process system-wide — including one started by
+    # a different user, session, or repo that just happens to share the binary name.
     free_port "$BACKEND_PORT"
     free_port "$GUI_PORT"
     if [ "$INFERENCE_BACKEND" = "native" ]; then
         free_port "$LLAMA_PORT"
-        pkill -f "llama-server" >/dev/null 2>&1 || true
     fi
-    pkill -f "ghost-link.*serve" >/dev/null 2>&1 || true
     sleep 0.5
 
     GPU_VENDOR="${GPU_VENDOR:-}"
@@ -817,6 +819,13 @@ start_services() {
     export GHOSTLINK_VRAM_GB="${VRAM_GB:-0}"
     export GHOSTLINK_LLAMA_NGL="${LLAMA_NGL:-0}"
     export GHOSTLINK_LLAMA_THREADS="${THREADS}"
+    # Only pass the detected GPU name through when a real vendor was found — the
+    # Rust-side auto-discovery treats GHOSTLINK_GPU_NAME as an explicit override,
+    # so this must stay unset in CPU-only mode (GPU_VENDOR empty) to let it fall
+    # through to real hardware probes instead of reporting a fake GPU.
+    if [ -n "${GPU_VENDOR:-}" ]; then
+        export GHOSTLINK_GPU_NAME="${GPU_NAME}"
+    fi
 
     local NATIVE_ENGINE="simulated"
     LLAMA_PID=""
@@ -1251,7 +1260,7 @@ cleanup() {
     [ -n "${GUI_PID:-}" ] && kill $GUI_PID 2>/dev/null && wait $GUI_PID 2>/dev/null || true
     [ -n "${API_PID:-}" ] && kill $API_PID 2>/dev/null && wait $API_PID 2>/dev/null || true
     [ -n "${LLAMA_PID:-}" ] && kill $LLAMA_PID 2>/dev/null && wait $LLAMA_PID 2>/dev/null || true
-    pkill -f "llama-server" >/dev/null 2>&1 || true
+    # Port-scoped cleanup only (see start_services) — never a blind system-wide pkill.
     free_port "${GHOSTLINK_API_PORT:-8003}" 2>/dev/null || true
     free_port "${GHOSTLINK_LLAMA_SERVER_PORT:-8080}" 2>/dev/null || true
     free_port "${GUI_PORT:-5173}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Found and fixed while verifying that GPU/CPU compute-backend switching and cluster auto-discovery actually work end to end (both `launch.sh` and `launch.bat`).

- **GPU auto-discovery false positive** (`system_profile.rs`) — `detect_gpu_from_env()` treated the mere presence of `GHOSTLINK_VRAM_GB` as an explicit GPU override, including the value `"0"` that `launch.sh` exports unconditionally on CPU-only hosts. This short-circuited every real hardware probe (nvidia-smi/rocm-smi/WMI/lspci/Vulkan) and injected a fake `"env-gpu"` device, so `/api/health` reported `gpu_available: true` on machines with no GPU at all whenever launched via the shipped launch scripts. Now requires a genuine signal (name, compute capability, or VRAM > 0).
- **`/api/workers/discover` was a hardcoded stub** (`main.rs`) — it returned `{"count": 2}` regardless of reality, fully disconnected from the real HMAC-authenticated UDP discovery module (`ghostlink_core::discovery`) that background threads already run on startup. It now performs a real `broadcast_and_collect`, registers replies into the live `ClusterState`, and returns genuine counts. `/api/workers` now merges those auto-discovered peers with the manually-added list (previously it only ever showed the latter) with dedup by node id.
- **`launch.bat` was completely non-functional** — `%~dp0` always carries a trailing backslash, and `wsl wslpath -a "...\"` breaks bash's argument parsing (`unexpected EOF while looking for matching \`"'`), so every invocation failed with "Failed to resolve repository path inside WSL." Fixed by stripping the trailing slash before quoting.
- **`launch.sh` reliability** — removed two blind, system-wide `pkill -f llama-server` / `pkill -f ghost-link` calls in favor of the already-correct port-scoped `free_port` cleanup (the blind form can kill an unrelated process from a different user/session sharing the same binary name). Also now passes the real detected GPU name through (`GHOSTLINK_GPU_NAME`) when a vendor is actually found, so the Rust-side env override — when it legitimately applies — reports accurate hardware instead of a generic `"env-gpu"` placeholder.
- **CHANGELOG.md** — added a `[1.3.2]` entry per the contributing guide's documentation expectations, including host-specific caveats.
- **Fixed a flaky test I introduced** — my first regression test raced against an existing test over shared process-global env vars (`cargo test --workspace` runs tests in parallel; both tests set/cleared the same vars). Folded into one sequential test. Running the full suite in a loop also surfaced a second, *pre-existing, unrelated* instance of the same race pattern (`runtime_switcher::tests::test_environment_manager_set_env`) — flagged separately (not fixed here) to keep this PR scoped to its stated theme.

## Test plan (per CONTRIBUTING.md's pre-push checklist)

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p ghost-link -p ghostlink-core` — 229/229 passing
- [x] `cargo test --workspace` — passing, run 5x in a loop to confirm no flakiness from this change (surfaced and fixed the race described above; the second, unrelated flaky test found this way is tracked separately)
- [x] `cargo run -p ghost-link -- probe my-node --full` — required by CONTRIBUTING.md for hardware-detection changes; no regression, correctly reports `GPU: cpu`, `GPU VRAM: 0.0 GB`, `Acceleration: AVX-512` on this CPU-only host
- [x] Live end-to-end run of both `launch.sh` (direct WSL) and `launch.bat` (Windows → WSL wrapper): API, llama-server, and Vite frontend all reach healthy state; real chat inference confirmed
- [x] `GET /api/health` reports `gpu_available: false, gpu_name: "cpu"` on this CPU-only host (previously falsely `true`/`"env-gpu"`)
- [x] `GET /api/backends` auto-discovers only `cpu` with the real detected CPU name
- [x] `POST /api/backends/switch {"backend":"cpu"}` succeeds; `{"backend":"cuda"}`/`{"backend":"rocm"}` fail cleanly with "not available" (no crash)
- [x] `GET /api/workers/discover` performs a real broadcast and returns genuine `discovered`/`count`; `GET /api/workers` reflects it with no duplicate entries
- [x] Native ↔ Ollama runtime switch, each tested with two distinct models: native (stories15M, SmolLM2-360M-Instruct) and Ollama (smollm2:135m, qwen2.5:0.5b, installed userspace without sudo) — every combination produced a real, correctly-attributed, distinct inference response

## Known caveats (host-specific — called out per CONTRIBUTING.md)

- **GPU hardware not verified.** No CUDA/ROCm/functioning-Vulkan device was available in the test environment — WSL2 exposes the GPU device node (`/dev/dxg`) but this Ubuntu image's Mesa build lacks the D3D12/"dozen" driver needed to bridge to it, and `/dev/dri` is absent. The fixed code paths are exercised by existing unit tests (`infer_backend_cuda`, `infer_backend_rocm`, etc.) but not against physical GPU hardware.
- **GUI not driven in a browser.** All verification went through the backend HTTP API directly (curl), not the rendered React frontend. Button clicks, form submissions, and rendering correctness in the actual UI are untested by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)