### PR TITLE
fix(launch): harden free_port and detect stale-process false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.3.3] - 2026-07-22 (Launch Script: Stale-Process Detection Hardening)
+
+### 🐛 Launch Reliability
+
+- `free_port()` previously relied entirely on `fuser`/`lsof`/`ss`/`netstat` being installed to find and kill a stale listener on a port before (re)starting a service. On a host with none of those tools, it silently did nothing. Added a tool-independent fallback (`proc_net_pids_for_port`) that parses `/proc/net/tcp{,6}` directly, so a stale process can be found and killed on any Linux host regardless of what's installed.
+- The `cargo run` fallback path (used when the prebuilt API binary 404s on a route it predates) now verifies the replacement process is actually still alive (`kill -0`) after its health checks pass, before trusting them. Previously, if the old process was never actually killed (exactly the scenario above), the new process would fail to bind the already-occupied port and exit — but the health checks would keep silently succeeding against the still-running old process the whole time, only failing later with a confusing 404 on whatever route the stale binary happened to predate. This now fails fast with a diagnostic that names the real cause.
+
+### ✅ Validation
+
+- `bash -n launch.sh` — syntax OK
+- `proc_net_pids_for_port` verified against a real listening process — correctly identifies its PID, matching `pgrep` ground truth
+- `free_port` verified end-to-end — confirmed it terminates a test server and the port becomes unreachable afterward
+- Full `launch.sh` run on the normal fast path (prebuilt binary works, no fallback triggered) — unaffected, reaches healthy state as before
+
+---
+
 ## [1.3.2] - 2026-07-22 (GPU/CPU Auto-Discovery Fix & Worker Discovery)
 
 ### 🐛 Hardware Auto-Discovery

--- a/launch.sh
+++ b/launch.sh
@@ -520,21 +520,61 @@ resolve_node_bin() {
 }
 
 # Free a TCP port (best-effort) so stale processes do not cause bind errors / 405 from wrong servers
+# Tool-independent fallback: find PIDs with a LISTEN socket on $1 by walking
+# /proc directly. Needed on minimal hosts without fuser/lsof/ss/netstat —
+# without this, free_port() silently no-ops on such hosts, a stale listener
+# is never actually killed, and a later health check can be fooled into
+# reporting a freshly-started replacement as "ready" when it's really still
+# talking to the old process (which then fails on any route added since).
+proc_net_pids_for_port() {
+    local port="$1"
+    [ -r /proc/net/tcp ] || return 0
+    local hex_port
+    hex_port=$(printf '%04X' "$port")
+    local inodes
+    inodes=$( { cat /proc/net/tcp 2>/dev/null; cat /proc/net/tcp6 2>/dev/null; } \
+        | awk -v hp="$hex_port" 'NR>1 { split($2,a,":"); if (a[2]==hp && $4=="0A") print $10 }' \
+        | sort -u)
+    [ -n "$inodes" ] || return 0
+    local inode fd link pid
+    local -A seen=()
+    for fd in /proc/[0-9]*/fd/*; do
+        link=$(readlink "$fd" 2>/dev/null) || continue
+        case "$link" in
+            socket:\[*\])
+                for inode in $inodes; do
+                    if [ "$link" = "socket:[$inode]" ]; then
+                        pid="${fd#/proc/}"
+                        pid="${pid%%/*}"
+                        if [ -z "${seen[$pid]:-}" ]; then
+                            seen[$pid]=1
+                            echo "$pid"
+                        fi
+                    fi
+                done
+                ;;
+        esac
+    done
+}
+
 free_port() {
     local port="$1"
     local pids=""
     if command -v fuser >/dev/null 2>&1; then
         fuser -k "${port}/tcp" >/dev/null 2>&1 || true
-        return 0
-    fi
-    if command -v lsof >/dev/null 2>&1; then
+    elif command -v lsof >/dev/null 2>&1; then
         pids=$(lsof -ti "tcp:${port}" -sTCP:LISTEN 2>/dev/null || lsof -ti ":${port}" 2>/dev/null || true)
     elif command -v ss >/dev/null 2>&1; then
         pids=$(ss -lptn "sport = :${port}" 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u || true)
     elif command -v netstat >/dev/null 2>&1 && [[ "$(uname -s)" != "Darwin" ]]; then
         pids=$(netstat -tlnp 2>/dev/null | awk -v p=":${port}" '$4 ~ p"$" {print $7}' | cut -d/ -f1 | grep -E '^[0-9]+$' || true)
     fi
-    if [ -n "$pids" ]; then
+    # Always cross-check via /proc directly — covers hosts with none of the
+    # above tools, and catches orphaned processes the tool-based lookup missed.
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        pids="$pids $(proc_net_pids_for_port "$port" 2>/dev/null || true)"
+    fi
+    if [ -n "${pids// /}" ]; then
         # shellcheck disable=SC2086
         kill -9 $pids >/dev/null 2>&1 || true
     fi
@@ -1080,6 +1120,22 @@ start_services() {
             fi
             if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health (cargo fallback)" 30; then
                 echo -e "  ${RED}✗${NC} /api/health failed after cargo fallback"
+                return 1
+            fi
+
+            # A passing health check above is not proof the NEW process answered
+            # it: if the old process was never actually killed (e.g. free_port
+            # had no way to find it, or it was orphaned by shell subshell
+            # semantics), the new `cargo run` fails to bind the port, exits, and
+            # every health check up to here would have kept talking to the OLD
+            # process the whole time — which then still 404s on any route it
+            # predates. Catch that here with a clear diagnostic instead of
+            # letting it surface as a confusing later 404.
+            if ! kill -0 "$API_PID" 2>/dev/null; then
+                echo -e "  ${RED}✗${NC} cargo-fallback API process exited — port ${BACKEND_PORT} is likely still held by a stale process"
+                echo -e "  ${DIM}Health checks above answered from that stale process, not the rebuild. See /tmp/ghostlink_api.log${NC}"
+                echo -e "  ${DIM}Fix: manually stop whatever holds port ${BACKEND_PORT} (e.g. sudo lsof -i:${BACKEND_PORT}) and relaunch.${NC}"
+                tail -20 /tmp/ghostlink_api.log 2>/dev/null || true
                 return 1
             fi
 


### PR DESCRIPTION
## Summary

A user reported a launch failure on a real (non-WSL) Linux machine, on latest `main` (includes #144): `launch.sh`'s `cargo run` fallback — triggered because the prebuilt API binary 404'd on `/api/settings`, indicating it predates that route — *itself* also 404'd on `/api/settings` after rebuilding from current source, even though that route is present and unchanged in current `main`.

The tell: `/health` and `/api/health` kept passing throughout, both before and after the "fallback." That's consistent with those checks being answered by the **same old process** the entire time, not a freshly rebuilt one.

**Root cause:** `free_port()` depended entirely on `fuser`/`lsof`/`ss`/`netstat` being installed. On a host with none of them, it silently no-ops. If the old process is never actually killed, `cargo run`'s attempt to bind the same port fails and it exits immediately — but the script has no way to notice, so every subsequent health check keeps hitting the still-running stale binary while reporting "ready."

## Changes

- `free_port()` now also cross-checks via `/proc/net/tcp{,6}` directly (`proc_net_pids_for_port`, no external tools required), so a stale listener can be found and killed on any Linux host regardless of what's installed.
- After the `cargo run` fallback's health checks pass, explicitly verify the new process is still alive (`kill -0 "$API_PID"`) before trusting those checks. If it already exited, this now fails fast with a diagnostic that names the actual cause (stale process still holding the port) instead of a confusing later 404 on an unrelated-looking route.
- CHANGELOG.md entry per CONTRIBUTING.md's documentation expectations.

## Test plan

- [x] `bash -n launch.sh` — syntax OK
- [x] `proc_net_pids_for_port` tested against a real listening process (`python3 -m http.server`) — correctly identifies its PID, matching `pgrep` ground truth
- [x] `free_port` tested end-to-end — confirmed it terminates the test server and the port becomes unreachable afterward
- [x] Full `launch.sh` run on the normal fast path (prebuilt binary works, no fallback triggered) — unaffected, reaches healthy state as before, `/api/settings` and `/api/health` both 200
- [ ] Not reproduced on the reporting user's exact machine (I don't have access to it) — this fix addresses the failure mode inferred from the log they posted (health checks passing while a route the old binary predates keeps 404ing after a supposed rebuild), not a byte-for-byte reproduction. If it recurs, the new diagnostic message will name the real cause directly instead of leaving it to be inferred from log forensics.

## Known caveat

This is a defensive hardening fix for a failure mode I could not directly reproduce (different machine, no SSH access) — confidence is high based on the log evidence and the `free_port` design gap it points to, but not 100%. If it doesn't fully resolve the reporting user's issue, the added `kill -0` diagnostic should at least narrow down the real cause quickly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)