### PR TITLE
fix(launch): detect port conflicts with unrelated services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.3.4] - 2026-07-22 (Launch: Port-Conflict Detection)
+
+### 🐛 Launch Reliability
+
+- Root-caused a real user-reported failure: on one machine, `launch.sh` consistently reported `Ghostlink API ready` / `API /api/health ready` and then failed with `GET /api/settings ... HTTP 404` — even after the `cargo run` fallback rebuild (added in [1.3.3]) confirmed a live, correctly-routed process. Turned out an unrelated Python/uvicorn service was already bound to port 8003 on that machine, answering `/health` and `/api/models` with its own (different-shaped) 200 responses. `free_port`'s kill couldn't keep it off the port, and a bare "curl succeeded" was never proof that *Ghostlink* was what answered.
+- `wait_for_http()` now accepts an optional content-marker argument: for the two `/health` and `/api/health` checks (both the initial and `cargo run`-fallback paths), it now requires `"inference_backend"` to actually appear in the response body, not just a 2xx status. Any unrelated service on the port — even one that respawns faster than `free_port` can evict it — is now correctly rejected instead of silently accepted, with a clear diagnostic naming the real cause and pointing at `GHOSTLINK_API_PORT=<port>` as an immediate workaround.
+
+### ✅ Validation
+
+- `bash -n launch.sh` — syntax OK
+- Reproduced the exact failure locally with a throwaway Python HTTP server bound to port 8003 (both a one-shot and an auto-respawning variant, matching the reported symptom) — confirmed `wait_for_http` now correctly times out and reports the new diagnostic instead of a false "ready"
+- Confirmed the positive case is unaffected: full `launch.sh` run with no port conflict reaches healthy state exactly as before, `/api/settings` returns `200`
+
+---
+
 ## [1.3.3] - 2026-07-22 (Launch Script: Stale-Process Detection Hardening)
 
 ### 🐛 Launch Reliability

--- a/launch.sh
+++ b/launch.sh
@@ -86,21 +86,42 @@ spinner() {
     return $?
 }
 
-# Wait for HTTP endpoint with animated spinner
+# Wait for HTTP endpoint with animated spinner.
+# Optional 4th arg: a substring that must appear in the response BODY, not
+# just a 2xx status. A bare "curl -sf succeeded" is not proof that GHOSTLINK
+# is what answered — any unrelated service already bound to the same port
+# (a leftover dev server, a different project's process, anything) will
+# also return 200 and fool a status-only check, especially since free_port
+# can't do anything about a process that immediately respawns (a supervised
+# service, `--reload`, a cron job). Content-checking a marker unique to
+# Ghostlink's own response body closes that gap regardless of what's
+# supervising the conflicting process or how fast it respawns.
 wait_for_http() {
     local url="$1"
     local label="$2"
     local timeout_s="${3:-120}"
+    local body_marker="${4:-}"
     local start
     start=$(date +%s)
-    
+    local body
+
     while true; do
-        if curl -sf "$url" >/dev/null 2>&1; then
+        if [ -n "$body_marker" ]; then
+            body=$(curl -sf "$url" 2>/dev/null || true)
+            if [ -n "$body" ] && echo "$body" | grep -qF "$body_marker"; then
+                printf "\r${CLEAR_LINE}  ${GREEN}✓${NC} ${WHITE}%s${NC} ${GREEN}ready${NC} at ${CYAN}%s${NC}\n" "$label" "$url"
+                return 0
+            fi
+        elif curl -sf "$url" >/dev/null 2>&1; then
             printf "\r${CLEAR_LINE}  ${GREEN}✓${NC} ${WHITE}%s${NC} ${GREEN}ready${NC} at ${CYAN}%s${NC}\n" "$label" "$url"
             return 0
         fi
         if (( $(date +%s) - start >= timeout_s )); then
             printf "\r${CLEAR_LINE}  ${RED}✗${NC} ${WHITE}%s${NC} ${RED}timeout${NC} after %ds: %s\n" "$label" "$timeout_s" "$url"
+            if [ -n "$body_marker" ] && [ -n "${body:-}" ]; then
+                echo -e "  ${YELLOW}⚠${NC} ${DIM}Something answered ${url} but it isn't Ghostlink (missing '${body_marker}' in response).${NC}"
+                echo -e "  ${DIM}A different service is likely already bound to this port. Pick another with GHOSTLINK_API_PORT=<port> ./launch.sh${NC}"
+            fi
             return 1
         fi
         printf "\r  ${CYAN}⠋${NC} ${WHITE}%s${NC} ${DIM}waiting...${NC}" "$label"
@@ -1083,13 +1104,13 @@ start_services() {
     if is_wsl; then
         api_wait=180
     fi
-    if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/health" "Ghostlink API" "$api_wait"; then
+    if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/health" "Ghostlink API" "$api_wait" "inference_backend"; then
         echo -e "  ${RED}✗${NC} API failed — see /tmp/ghostlink_api.log"
         echo -e "  ${DIM}Tip: ensure port ${BACKEND_PORT} is free and ghost-link is a Linux binary under WSL.${NC}"
         tail -40 /tmp/ghostlink_api.log 2>/dev/null || true
         return 1
     fi
-    if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health" 30; then
+    if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health" 30 "inference_backend"; then
         echo -e "  ${RED}✗${NC} /api/health failed — wrong process on :${BACKEND_PORT} or outdated binary"
         echo -e "  ${DIM}Check: curl -i http://${BACKEND_HOST}:${BACKEND_PORT}/api/health${NC}"
         tail -40 /tmp/ghostlink_api.log 2>/dev/null || true
@@ -1114,11 +1135,11 @@ start_services() {
             API_PID=$!
             API_LAUNCH_MODE="cargo"
 
-            if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/health" "Ghostlink API (cargo fallback)" 90; then
+            if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/health" "Ghostlink API (cargo fallback)" 90 "inference_backend"; then
                 echo -e "  ${RED}✗${NC} API failed after cargo fallback — see /tmp/ghostlink_api.log"
                 return 1
             fi
-            if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health (cargo fallback)" 30; then
+            if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health (cargo fallback)" 30 "inference_backend"; then
                 echo -e "  ${RED}✗${NC} /api/health failed after cargo fallback"
                 return 1
             fi


### PR DESCRIPTION
## Summary

Root cause for the `/api/settings` 404 failure reported after the previous fix (#145): it was never a Ghostlink bug. An unrelated Python/uvicorn service was already bound to port 8003 on the reporting machine, answering `/health` and `/api/models` with its own, differently-shaped `200` responses (`server: uvicorn` in the headers gave it away). `free_port`'s kill couldn't keep it off the port — most likely because it's supervised or auto-restarting — and a bare "curl succeeded" was never actual proof that *Ghostlink* was what answered.

The real `cargo run` fallback process even printed `Error: failed to bind ... Address already in use (os error 98)` and died immediately, but by the time that happened, `wait_for_http` had already declared the health check "ready" — because the *other* service answered `/health` first, before the doomed process had gotten far enough into startup to hit its own bind failure. That's a timing race the previous fix's `kill -0` liveness check couldn't reliably win.

## Fix

`wait_for_http()` now accepts an optional content-marker argument. For both `/health` checks (the initial attempt and the `cargo run` fallback), it now requires `"inference_backend"` to actually appear in the response **body**, not just a 2xx status. This closes the gap regardless of how fast a conflicting service respawns after being killed — a wrong answer is rejected outright rather than accepted and only discovered to be wrong several steps later on an unrelated-looking route. On timeout with a marker mismatch, it now prints a clear diagnostic naming the real cause and pointing at `GHOSTLINK_API_PORT=<port>` as an immediate workaround.

## Test plan

- [x] `bash -n launch.sh` — syntax OK
- [x] Reproduced the exact reported symptom locally with a throwaway Python HTTP server bound to port 8003, returning `200` to everything with a body shaped like the one from the bug report — confirmed `wait_for_http` now correctly times out with the new diagnostic instead of a false "ready"
- [x] Repeated with an auto-respawning variant (kills itself and restarts in a loop, simulating a supervised service) to confirm the fix holds even when `free_port` can never win the race
- [x] Confirmed the positive case is unaffected — a full `launch.sh` run with no port conflict reaches healthy state exactly as before, `/api/settings` returns `200`
- [x] CHANGELOG.md entry per CONTRIBUTING.md's documentation expectations

## Known limitation

This detects and clearly reports the conflict; it does not attempt to force-evict a service that keeps winning the race against `free_port` (e.g. truly supervised/restart-on-crash). That's the right call — killing an unrelated service the user didn't ask us to touch isn't something a launcher should do silently. The diagnostic message points at the `GHOSTLINK_API_PORT` override as the safe way forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)