### PR TITLE
fix(launch): detect port conflicts on llama-server's own health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.3.5] - 2026-07-22 (Launch: llama-server Port-Conflict Detection)
+
+### 🐛 Launch Reliability
+
+- Extended the port-conflict detection added in [1.3.4] to llama-server's own readiness check. A user hit a live chat failure — `Native error: llama_server request failed with status 405 Method Not Allowed: {"detail":"Method Not Allowed"}` — traced to `open-webui` (also FastAPI/uvicorn-based) already bound to `127.0.0.1:8080`, the same host:port llama-server wants. The old check (`GET /health` → `{"status":"ok"}`) was too generic to catch this: `open-webui` answers its own `/health` too, so `launch.sh` reported "llama-server ready" while the real llama.cpp process had actually failed to bind, and every native chat request silently went to `open-webui` instead.
+- The readiness check now targets `GET /v1/models` and requires `"llamacpp"` (from llama.cpp's own `"owned_by":"llamacpp"` field) to appear in the response — nothing else plausibly returns that. On mismatch, prints a diagnostic naming the real cause and pointing at `GHOSTLINK_LLAMA_SERVER_PORT=<port>` as the override.
+- Also fixed the diagnostic message itself to be accurate for whichever check failed: it previously always said "isn't Ghostlink" and suggested `GHOSTLINK_API_PORT`, which was wrong advice for the llama-server case (the correct override there is `GHOSTLINK_LLAMA_SERVER_PORT`, a different variable entirely). `wait_for_http()` now takes the expected-service label and the correct override variable as explicit arguments instead of hardcoding Ghostlink's own.
+
+### ✅ Validation
+
+- `bash -n launch.sh` — syntax OK
+- Confirmed real llama-server's actual `/v1/models` response includes `"owned_by":"llamacpp"` (checked directly against a running instance)
+- Reproduced the reported failure mode locally: a throwaway HTTP server on the llama-server port returning `{"status":"ok"}` to everything is now correctly rejected instead of accepted; a genuine llama-server on the same port is correctly recognized and accepted
+- Confirmed the positive case (no conflict) is unaffected — full `launch.sh` run reaches healthy state, real chat inference succeeds end to end
+
+---
+
 ## [1.3.4] - 2026-07-22 (Launch: Port-Conflict Detection)
 
 ### 🐛 Launch Reliability

--- a/launch.sh
+++ b/launch.sh
@@ -88,19 +88,24 @@ spinner() {
 
 # Wait for HTTP endpoint with animated spinner.
 # Optional 4th arg: a substring that must appear in the response BODY, not
-# just a 2xx status. A bare "curl -sf succeeded" is not proof that GHOSTLINK
-# is what answered — any unrelated service already bound to the same port
-# (a leftover dev server, a different project's process, anything) will
-# also return 200 and fool a status-only check, especially since free_port
-# can't do anything about a process that immediately respawns (a supervised
-# service, `--reload`, a cron job). Content-checking a marker unique to
-# Ghostlink's own response body closes that gap regardless of what's
-# supervising the conflicting process or how fast it respawns.
+# just a 2xx status. A bare "curl -sf succeeded" is not proof that the
+# service we WANT is what answered — any unrelated service already bound to
+# the same port (a leftover dev server, a different project's process,
+# anything) will also return 200 and fool a status-only check, especially
+# since free_port can't do anything about a process that immediately
+# respawns (a supervised service, `--reload`, a cron job). Content-checking
+# a marker unique to the expected service's response body closes that gap
+# regardless of what's supervising the conflicting process or how fast it
+# respawns.
+# Optional 5th arg: the env var to suggest as a port override in the
+# on-timeout diagnostic (e.g. "GHOSTLINK_API_PORT"). Omit for checks where
+# no such override applies.
 wait_for_http() {
     local url="$1"
     local label="$2"
     local timeout_s="${3:-120}"
     local body_marker="${4:-}"
+    local override_var="${5:-}"
     local start
     start=$(date +%s)
     local body
@@ -119,8 +124,12 @@ wait_for_http() {
         if (( $(date +%s) - start >= timeout_s )); then
             printf "\r${CLEAR_LINE}  ${RED}✗${NC} ${WHITE}%s${NC} ${RED}timeout${NC} after %ds: %s\n" "$label" "$timeout_s" "$url"
             if [ -n "$body_marker" ] && [ -n "${body:-}" ]; then
-                echo -e "  ${YELLOW}⚠${NC} ${DIM}Something answered ${url} but it isn't Ghostlink (missing '${body_marker}' in response).${NC}"
-                echo -e "  ${DIM}A different service is likely already bound to this port. Pick another with GHOSTLINK_API_PORT=<port> ./launch.sh${NC}"
+                echo -e "  ${YELLOW}⚠${NC} ${DIM}Something answered ${url} but it isn't ${label} (missing '${body_marker}' in response).${NC}"
+                if [ -n "$override_var" ]; then
+                    echo -e "  ${DIM}A different service is likely already bound to this port. Pick another with ${override_var}=<port> ./launch.sh${NC}"
+                else
+                    echo -e "  ${DIM}A different service is likely already bound to this port. Free it, or override the port for this service and retry.${NC}"
+                fi
             fi
             return 1
         fi
@@ -1042,8 +1051,15 @@ start_services() {
             >/tmp/ghostlink_llama_server.log 2>&1 &
         LLAMA_PID=$!
 
-        if ! wait_for_http "http://127.0.0.1:${LLAMA_PORT}/health" "llama-server" 90; then
+        # llama-server's own /health body is just {"status":"ok"} — too generic
+        # to prove it's actually llama.cpp (the exact same false-positive class
+        # fixed for the Ghostlink API's own health checks applies here too, e.g.
+        # any web app already bound to this port that happens to have its own
+        # /health route). /v1/models includes "owned_by":"llamacpp", which is
+        # distinctive enough that nothing else plausibly returns it.
+        if ! wait_for_http "http://127.0.0.1:${LLAMA_PORT}/v1/models" "llama-server" 90 "llamacpp" "GHOSTLINK_LLAMA_SERVER_PORT"; then
             echo -e "  ${RED}✗${NC} llama-server failed — see /tmp/ghostlink_llama_server.log"
+            echo -e "  ${DIM}Tip: ensure port ${LLAMA_PORT} is free (another web app there will fool a bare health check).${NC}"
             return 1
         fi
         NATIVE_ENGINE="llama_server"
@@ -1104,13 +1120,13 @@ start_services() {
     if is_wsl; then
         api_wait=180
     fi
-    if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/health" "Ghostlink API" "$api_wait" "inference_backend"; then
+    if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/health" "Ghostlink API" "$api_wait" "inference_backend" "GHOSTLINK_API_PORT"; then
         echo -e "  ${RED}✗${NC} API failed — see /tmp/ghostlink_api.log"
         echo -e "  ${DIM}Tip: ensure port ${BACKEND_PORT} is free and ghost-link is a Linux binary under WSL.${NC}"
         tail -40 /tmp/ghostlink_api.log 2>/dev/null || true
         return 1
     fi
-    if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health" 30 "inference_backend"; then
+    if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health" 30 "inference_backend" "GHOSTLINK_API_PORT"; then
         echo -e "  ${RED}✗${NC} /api/health failed — wrong process on :${BACKEND_PORT} or outdated binary"
         echo -e "  ${DIM}Check: curl -i http://${BACKEND_HOST}:${BACKEND_PORT}/api/health${NC}"
         tail -40 /tmp/ghostlink_api.log 2>/dev/null || true
@@ -1135,11 +1151,11 @@ start_services() {
             API_PID=$!
             API_LAUNCH_MODE="cargo"
 
-            if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/health" "Ghostlink API (cargo fallback)" 90 "inference_backend"; then
+            if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/health" "Ghostlink API (cargo fallback)" 90 "inference_backend" "GHOSTLINK_API_PORT"; then
                 echo -e "  ${RED}✗${NC} API failed after cargo fallback — see /tmp/ghostlink_api.log"
                 return 1
             fi
-            if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health (cargo fallback)" 30 "inference_backend"; then
+            if ! wait_for_http "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" "API /api/health (cargo fallback)" 30 "inference_backend" "GHOSTLINK_API_PORT"; then
                 echo -e "  ${RED}✗${NC} /api/health failed after cargo fallback"
                 return 1
             fi


### PR DESCRIPTION
## Summary

Follow-up to #146. A user hit a live chat failure after that fix landed:

```
Ghostlink native fabric backend processed model 'none' with 2048 estimated tokens.
Native error: llama_server request failed with status 405 Method Not Allowed: {"detail":"Method Not Allowed"}
```

**Root cause:** the same machine also runs `open-webui` (also FastAPI/uvicorn-based) on `127.0.0.1:8080` — the exact host:port llama-server wants. The `{"detail":"Method Not Allowed"}` body is the FastAPI/Starlette default 405 shape, not llama.cpp's — a strong tell that requests were landing on the wrong server. `#146` only content-verified the *Ghostlink API's* own health checks; llama-server's readiness check still just checked for a `2xx` on `/health`, whose real body (`{"status":"ok"}`) is too generic to tell apart from `open-webui`'s own `/health`. So `launch.sh` reported "llama-server ready" while the real llama.cpp process had actually failed to bind (`Address already in use`, confirmed in the log), and every native chat request silently landed on `open-webui` instead.

## Fix

- llama-server's readiness check now targets `GET /v1/models` and requires `"llamacpp"` (from llama.cpp's own `"owned_by":"llamacpp"` field) in the response body — confirmed against a real running instance, distinctive enough nothing else plausibly returns it.
- Fixed a bug in my own #146 diagnostic message while I was in there: it hardcoded "isn't Ghostlink" and suggested `GHOSTLINK_API_PORT` for *every* check, including this one — wrong advice for llama-server, whose actual override is `GHOSTLINK_LLAMA_SERVER_PORT`. `wait_for_http()` now takes the expected-service label and correct override variable as explicit arguments instead of assuming Ghostlink's own.

## Test plan

- [x] `bash -n launch.sh` — syntax OK
- [x] Confirmed real llama-server's `/v1/models` response includes `"owned_by":"llamacpp"` against a live instance
- [x] Reproduced the reported failure mode locally — a throwaway server on the llama-server port returning `{"status":"ok"}` to everything is now correctly rejected with the right diagnostic instead of silently accepted
- [x] Confirmed a genuine llama-server on the port is still correctly recognized (positive case)
- [x] Confirmed no regression — full `launch.sh` run with no conflict reaches healthy state, real chat inference succeeds end to end
- [x] CHANGELOG.md entry per CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)