### PR TITLE
fix: correct GPU backend selection for DirectML/Vulkan/NPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.3.6] - 2026-07-22 (GPU Backend Selection: DirectML/NPU/Vulkan)
+
+### 🐛 GPU Backend Selection
+
+- `ComputeBackend` (the enum backing `/api/backends` and `/api/backends/switch`) had no representation at all for DirectML, Vulkan, or NPU. `BackendRegistry::discover()`'s mapping from the shared `GpuBackend` detection collapsed both `Directml` and `Vulkan` onto `OneAPI` (a real, distinct technology — genuine Intel oneAPI/SYCL — unrelated to either), and silently dropped `Npu` entirely. Confirmed this directly affects real Windows hardware: `probe_windows_wmi_gpu()` tags AMD GPUs as `GpuBackend::Directml` via PCI vendor ID whenever the `rocm` feature isn't compiled in, and NPU-equipped hosts (e.g. AMD Ryzen AI, Intel Core Ultra) never saw their NPU listed as selectable at all. Added proper `Directml`, `Vulkan`, and `Npu` variants mirroring `GpuBackend` one-to-one.
+- `discover()`'s backend-list dedup compared each new GPU's backend against `current` (which only ever held the *first* backend seen) instead of the GPU's own backend — silently dropping every subsequent distinct backend type on any host with more than one kind of accelerator. Now dedups correctly per-backend, with `current` set from the resulting list afterward.
+- Even when correctly listed, `POST /api/backends/switch` unconditionally failed for `metal`/`oneapi`/`directml`/`vulkan`/`npu` with "No environment configuration for backend: X" — `SwitchingConfig::default()`'s env-var table only ever had entries for `rocm`/`cuda`/`cpu`, and `EnvironmentManager::set_backend_env`/`restore_env` treated a missing entry as a hard error rather than "this backend needs no special env vars" (true for all five — none of them need ghost-link to set anything the way ROCm/CUDA do). A backend could be discovered and listed as available, but never actually selected.
+
+### ✅ Validation
+
+- `cargo fmt --all --check` / `cargo clippy --workspace --all-targets -- -D warnings` — clean
+- `cargo test -p ghost-link -p ghostlink-core` — 67 (+2 new) / 229 total passing, run 3x to confirm no new flakiness (the one observed failure was the pre-existing, already-tracked `test_environment_manager_set_env` race, untouched by this change — the new test here deliberately uses `Metal`, which touches no real env vars, to avoid adding to that surface)
+- Live end-to-end: simulated a DirectML GPU and an NPU via env override on a running instance — `GET /api/backends` now correctly reports `"directml"`/`"npu"` (previously `"oneapi"`/absent), and `POST /api/backends/switch` now succeeds for both (previously failed for both)
+- Confirmed VRAM flows correctly through the full pipeline once a GPU is properly detected: `/api/health`, `/api/metrics`, and `cargo run -- probe --full` all report the same VRAM figure consistently, and the auto-tuner responds to it correctly (256 max-inflight for a 12GB GPU vs. 128 for CPU-only, observed directly)
+
+---
+
 ## [1.3.4] - 2026-07-22 (Launch: Port-Conflict Detection)
 
 ### 🐛 Launch Reliability

--- a/crates/ghost-link/src/backend_registry.rs
+++ b/crates/ghost-link/src/backend_registry.rs
@@ -9,6 +9,9 @@ pub enum ComputeBackend {
     Cuda,
     OneAPI,
     Metal,
+    Directml,
+    Vulkan,
+    Npu,
     Cpu,
 }
 
@@ -19,6 +22,9 @@ impl ComputeBackend {
             Self::Cuda => "cuda",
             Self::OneAPI => "oneapi",
             Self::Metal => "metal",
+            Self::Directml => "directml",
+            Self::Vulkan => "vulkan",
+            Self::Npu => "npu",
             Self::Cpu => "cpu",
         }
     }
@@ -29,6 +35,9 @@ impl ComputeBackend {
             "cuda" => Some(Self::Cuda),
             "oneapi" => Some(Self::OneAPI),
             "metal" => Some(Self::Metal),
+            "directml" | "dml" => Some(Self::Directml),
+            "vulkan" => Some(Self::Vulkan),
+            "npu" => Some(Self::Npu),
             "cpu" => Some(Self::Cpu),
             _ => None,
         }
@@ -72,25 +81,29 @@ impl BackendRegistry {
         let mut current = ComputeBackend::Cpu;
 
         for gpu in &profile.gpus {
+            // Mirrors GpuBackend one-to-one — previously Directml and Vulkan
+            // were both collapsed onto OneAPI (a real, distinct technology,
+            // unrelated to either) and Npu was dropped entirely, so an
+            // NPU-equipped host (e.g. AMD Ryzen AI / Intel Core Ultra) never
+            // saw its NPU listed as a selectable backend at all, and a
+            // DirectML-only GPU (the common case on Windows without
+            // CUDA/ROCm) was mislabeled as "oneapi".
             let backend = match gpu.backend {
                 ghostlink_core::host::GpuBackend::Cuda => Some(ComputeBackend::Cuda),
                 ghostlink_core::host::GpuBackend::Rocm => Some(ComputeBackend::Rocm),
                 ghostlink_core::host::GpuBackend::Metal => Some(ComputeBackend::Metal),
-                ghostlink_core::host::GpuBackend::Directml => Some(ComputeBackend::OneAPI),
-                ghostlink_core::host::GpuBackend::Vulkan => Some(ComputeBackend::OneAPI),
-                ghostlink_core::host::GpuBackend::Npu | ghostlink_core::host::GpuBackend::Cpu => {
-                    None
-                }
+                ghostlink_core::host::GpuBackend::Directml => Some(ComputeBackend::Directml),
+                ghostlink_core::host::GpuBackend::Vulkan => Some(ComputeBackend::Vulkan),
+                ghostlink_core::host::GpuBackend::Npu => Some(ComputeBackend::Npu),
+                ghostlink_core::host::GpuBackend::Cpu => None,
             };
 
+            // Dedup against `b` (this GPU's backend), not `current` (which
+            // only ever reflected the first backend seen) — the old check
+            // silently dropped every subsequent distinct backend type on any
+            // host with more than one kind of accelerator.
             if let Some(b) = backend {
-                if backends.is_empty() {
-                    current = b;
-                }
-                if !backends
-                    .iter()
-                    .any(|bi: &BackendInfo| bi.backend == current)
-                {
+                if !backends.iter().any(|bi: &BackendInfo| bi.backend == b) {
                     backends.push(BackendInfo {
                         backend: b,
                         device_name: gpu.name.clone(),
@@ -101,6 +114,9 @@ impl BackendRegistry {
                     });
                 }
             }
+        }
+        if let Some(first) = backends.first() {
+            current = first.backend;
         }
 
         // CPU is always available as fallback
@@ -436,6 +452,26 @@ mod tests {
         assert_eq!(ComputeBackend::Rocm.as_str(), "rocm");
         assert_eq!(ComputeBackend::Cuda.as_str(), "cuda");
         assert_eq!(ComputeBackend::from_str("rocm"), Some(ComputeBackend::Rocm));
+    }
+
+    #[test]
+    fn test_backend_enum_covers_directml_vulkan_npu() {
+        // Regression: these three used to have no ComputeBackend representation
+        // at all (Directml/Vulkan were both mapped onto the unrelated OneAPI
+        // variant in discover(), Npu was silently dropped), so a DirectML GPU
+        // or an NPU could never actually be selected via the API.
+        for (variant, s) in [
+            (ComputeBackend::Directml, "directml"),
+            (ComputeBackend::Vulkan, "vulkan"),
+            (ComputeBackend::Npu, "npu"),
+        ] {
+            assert_eq!(variant.as_str(), s);
+            assert_eq!(ComputeBackend::from_str(s), Some(variant));
+        }
+        assert_eq!(
+            ComputeBackend::from_str("dml"),
+            Some(ComputeBackend::Directml)
+        );
     }
 
     #[test]

--- a/crates/ghost-link/src/runtime_switcher.rs
+++ b/crates/ghost-link/src/runtime_switcher.rs
@@ -119,14 +119,21 @@ impl EnvironmentManager {
         Self { config }
     }
 
-    /// Update environment variables for a backend
+    /// Update environment variables for a backend.
+    ///
+    /// A backend with no entry in `backend_env_vars` (metal, oneapi,
+    /// directml, vulkan, npu — none of which need ghost-link to set special
+    /// env vars the way ROCm/CUDA do) is not an error: it just means there's
+    /// nothing to set. Previously this returned Err for any such backend,
+    /// which meant `/api/backends/switch` always failed for GPUs discovered
+    /// via any of those paths even though the registry correctly reported
+    /// them as available — the backend was listed but never actually
+    /// selectable.
     pub fn set_backend_env(&self, backend: &ComputeBackend) -> Result<(), String> {
         let backend_name = backend.as_str();
-        let env_vars = self
-            .config
-            .backend_env_vars
-            .get(backend_name)
-            .ok_or_else(|| format!("No environment configuration for backend: {backend_name}"))?;
+        let Some(env_vars) = self.config.backend_env_vars.get(backend_name) else {
+            return Ok(());
+        };
 
         for (key, value) in env_vars {
             std::env::set_var(key, value);
@@ -141,14 +148,13 @@ impl EnvironmentManager {
         self.config.backend_env_vars.get(backend_name).cloned()
     }
 
-    /// Restore previous environment variables (for rollback)
+    /// Restore previous environment variables (for rollback). Same "missing
+    /// entry means nothing to do" reasoning as set_backend_env.
     pub fn restore_env(&self, backend: &ComputeBackend) -> Result<(), String> {
         let backend_name = backend.as_str();
-        let env_vars = self
-            .config
-            .backend_env_vars
-            .get(backend_name)
-            .ok_or_else(|| format!("No environment configuration for backend: {backend_name}"))?;
+        let Some(env_vars) = self.config.backend_env_vars.get(backend_name) else {
+            return Ok(());
+        };
 
         for key in env_vars.keys() {
             std::env::remove_var(key);
@@ -385,6 +391,26 @@ mod tests {
         // Should drain after waiting
         let result = tracker.drain(Duration::from_secs(5)).await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_backend_without_env_config_is_not_an_error() {
+        // Regression: metal/oneapi/directml/vulkan/npu have no entry in
+        // SwitchingConfig::default()'s backend_env_vars (none of them need
+        // ghost-link to set special env vars the way ROCm/CUDA do). This used
+        // to make set_backend_env/restore_env return Err for any of them,
+        // which meant switching to a GPU discovered via those paths always
+        // failed even though the registry correctly listed it as available.
+        // Uses Metal specifically (never touches real env vars) so this
+        // doesn't add to the process-global env var surface other tests
+        // in this file race on.
+        let config = SwitchingConfig::default();
+        assert!(!config.backend_env_vars.contains_key("metal"));
+        let manager = EnvironmentManager::new(config);
+
+        assert!(manager.set_backend_env(&ComputeBackend::Metal).is_ok());
+        assert!(manager.restore_env(&ComputeBackend::Metal).is_ok());
+        assert!(manager.get_backend_env(&ComputeBackend::Metal).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Investigated "GPU probe unavailable, GPU not selectable, VRAM not detected, auto-tuning inference?" and found a real, significant bug cluster in `ComputeBackend` (the enum backing `/api/backends` and `/api/backends/switch`) — separate from the earlier `system_profile.rs` auto-discovery fix (#144).

1. **`ComputeBackend` had no variant for DirectML, Vulkan, or NPU at all.** `discover()`'s mapping from the shared `GpuBackend` detection collapsed both `Directml` and `Vulkan` onto `OneAPI` (a real, distinct technology — genuine Intel oneAPI/SYCL — unrelated to either), and silently dropped `Npu` entirely. Confirmed this directly affects real Windows hardware: `probe_windows_wmi_gpu()` tags AMD GPUs as `GpuBackend::Directml` via PCI vendor ID whenever the `rocm` feature isn't compiled in, and NPU-equipped hosts (AMD Ryzen AI, Intel Core Ultra) never saw their NPU listed as selectable at all — exactly the hardware profile discussed throughout recent testing on this repo. Added proper `Directml`, `Vulkan`, and `Npu` variants mirroring `GpuBackend` one-to-one.
2. **`discover()`'s dedup check compared against the wrong value** — each GPU's backend was checked against `current` (which only ever held the *first* backend seen) instead of the GPU's own backend, silently dropping every subsequent distinct backend type on any host with more than one kind of accelerator. Fixed to dedup per-backend.
3. **Even when correctly listed, switching always failed.** `POST /api/backends/switch` unconditionally errored for `metal`/`oneapi`/`directml`/`vulkan`/`npu` with `"No environment configuration for backend: X"` — `SwitchingConfig::default()`'s env-var table only ever had `rocm`/`cuda`/`cpu` entries, and a missing entry was treated as a hard error instead of "this backend needs no special env vars" (true for all five — none of them need ghost-link to set anything the way ROCm/CUDA do). A backend could be discovered and listed as available, but never actually selected. This is likely the most direct match for "GPU not selectable."

## Test plan

- [x] `cargo fmt --all --check` / `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p ghost-link -p ghostlink-core` — 67 (+2 new tests) / 229 total passing, run 3x to confirm no new flakiness (the one observed failure across those runs was the pre-existing, already-tracked `test_environment_manager_set_env` race — untouched by this change; the new test here deliberately uses `Metal`, which touches no real env vars, to avoid adding to that surface)
- [x] Live end-to-end: simulated a DirectML GPU and an NPU via env override on a running instance — `GET /api/backends` now correctly reports `"directml"`/`"npu"` (previously `"oneapi"`/absent), and `POST /api/backends/switch` now succeeds for both (previously failed for both)
- [x] Confirmed VRAM flows correctly through the full pipeline once a GPU is properly detected: `/api/health`, `/api/metrics`, and `probe --full` all report the same figure consistently, and the auto-tuner responds to it correctly (256 max-inflight for a 12GB GPU vs. 128 for CPU-only, observed directly) — auto-tuning itself was never broken, the GPU info just never reached it
- [x] CHANGELOG.md entry per CONTRIBUTING.md

## Known caveat

Not verified against real DirectML/NPU hardware — simulated via `GHOSTLINK_GPU_NAME`/`GHOSTLINK_COMPUTE_CAPABILITY` env overrides on a CPU-only test machine, which exercises the exact same downstream code path a real WMI-detected GPU would, but isn't a substitute for testing on the actual hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)