### PR TITLE
fix(launch): show real Node/npm version in System Info panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.3.8] - 2026-07-23 (Launch: Accurate Node/npm Version Display)
+
+### 🐛 Launch Script
+
+- The System Information banner's `Node.js`/`npm` lines used a bare `node -v`/`npm -v`, independent of `resolve_node_bin()` (the function actually used moments later to start the dev server). On a host where Node is only reachable via nvm (not on the bare `PATH` a non-interactive script starts with), this showed `Node.js: not installed` / `npm: not installed` even though the script goes on to successfully find and use a working Node install seconds later — directly contradicting itself in the same output. Now resolves the same binary `resolve_node_bin()` would use and reports its real version; falls back to the bare commands only when that resolution itself finds nothing.
+- The `npm` symlink at a resolved Node install's `bin/` typically points to a `#!/usr/bin/env node`-shebang JS file, which needs `node`'s directory on `PATH` to resolve — same requirement `start_services()` already handles when actually invoking npm. Missed this on the first pass (shipped `npm: not installed` despite Node resolving correctly); caught by re-testing after the fix rather than assuming a `-x` check alone was sufficient, and fixed by prepending `PATH` the same way.
+
+### ✅ Validation
+
+- `bash -n launch.sh` — syntax OK
+- Live-tested against a real nvm-only Node install (no bare `node`/`npm` on default `PATH`): confirmed both the initial fix attempt's `npm: not installed` regression and the corrected `npm: 10.8.2` output, via a debug-instrumented run showing the exact resolved paths and exit code before removing the instrumentation
+- Confirmed positive case unaffected: full launch reaches healthy state, `/api/health` returns `200`
+
+---
+
 ## [1.3.7] - 2026-07-23 (Repo-Wide Correctness Review)
 
 A broad review pass across backend handlers, cluster/health/load-balance logic, a launch script, and the frontend — dispatched as three independent research agents scanning previously-unreviewed areas, then triaged and fixed directly. Every fix below is a confirmed, reproducible bug, not a style nitpick.

--- a/launch.sh
+++ b/launch.sh
@@ -188,8 +188,32 @@ echo -e "${BLUE}│${NC}  ${WHITE}OS:${NC}           $(uname -s) $(uname -r) ($(
 echo -e "${BLUE}│${NC}  ${WHITE}Shell:${NC}         $SHELL"
 echo -e "${BLUE}│${NC}  ${WHITE}Rust:${NC}          $(rustc --version 2>/dev/null | cut -d' ' -f2 || echo 'not installed')"
 echo -e "${BLUE}│${NC}  ${WHITE}Cargo:${NC}         $(cargo --version 2>/dev/null | cut -d' ' -f2 || echo 'not installed')"
-echo -e "${BLUE}│${NC}  ${WHITE}Node.js:${NC}       $(node -v 2>/dev/null || echo 'not installed')"
-echo -e "${BLUE}│${NC}  ${WHITE}npm:${NC}           $(npm -v 2>/dev/null || echo 'not installed')"
+_display_node_bin="$(resolve_node_bin 2>/dev/null)"
+if [ -n "$_display_node_bin" ]; then
+    echo -e "${BLUE}│${NC}  ${WHITE}Node.js:${NC}       $("$_display_node_bin" -v 2>/dev/null || echo 'not installed')"
+    _display_npm_bin="$(dirname "$_display_node_bin")/npm"
+    if [ -x "$_display_npm_bin" ]; then
+        # npm is typically a symlink to a `#!/usr/bin/env node`-shebang JS
+        # file — that shebang needs `node` resolvable on PATH, so it must be
+        # prepended here too (same pattern start_services() already uses
+        # when actually invoking npm), or this silently fails to "not
+        # installed" even though a perfectly good npm was just found.
+        echo -e "${BLUE}│${NC}  ${WHITE}npm:${NC}           $(PATH="$(dirname "$_display_node_bin"):$PATH" "$_display_npm_bin" -v 2>/dev/null || echo 'not installed')"
+    else
+        echo -e "${BLUE}│${NC}  ${WHITE}npm:${NC}           $(npm -v 2>/dev/null || echo 'not installed')"
+    fi
+else
+    # Same reasoning as resolve_node_bin/resolve_llama_server_bin elsewhere in
+    # this script: a bare `node -v`/`npm -v` here can silently succeed against
+    # a wrong-platform binary reached via WSL interop (e.g. Windows' npm.exe
+    # under /mnt/c), showing a version for a binary the script would later
+    # reject outright — misleading the user into thinking Node "is installed"
+    # when the actual dependency-install/dev-server step will fail to find a
+    # usable one. Falls back to the bare commands only when resolve_node_bin
+    # itself found nothing, for a still-useful (if less precise) display.
+    echo -e "${BLUE}│${NC}  ${WHITE}Node.js:${NC}       $(node -v 2>/dev/null || echo 'not installed')"
+    echo -e "${BLUE}│${NC}  ${WHITE}npm:${NC}           $(npm -v 2>/dev/null || echo 'not installed')"
+fi
 if [[ "$(uname -s)" == "Darwin" ]]; then
     local _ram=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%.0f", $1/1073741824}' || echo '?')
     echo -e "${BLUE}│${NC}  ${WHITE}RAM:${NC}          ${_ram} GB"


### PR DESCRIPTION
## Summary

Spotted while reviewing a user-supplied launch log: the System Information banner showed `Node.js: not installed` on a host where Node was only reachable via nvm (not on the bare `PATH` a non-interactive script starts with) — while the same script's `start_services()`, moments later, correctly resolved and used a working Node install via `resolve_node_bin()`. The banner directly contradicted the script's own subsequent behavior, which is confusing for anyone debugging a "Node not found"-shaped problem that isn't actually happening.

## Fix

- The `Node.js:` line now uses `resolve_node_bin()` (the same function `start_services()` uses) instead of a bare `node -v`, so the banner reflects what the script will actually use.
- **Caught and fixed my own bug mid-pass**: my first attempt at the `npm:` line only checked `[ -x "$npm_bin" ]` and called it directly — missed that `npm` is typically a symlink to a `#!/usr/bin/env node`-shebang JS file, which needs `node`'s directory on `PATH` to resolve (the same requirement `start_services()` already handles when it actually invokes npm). Shipped `npm: not installed` despite Node resolving correctly right above it. Caught this by re-testing after the "fix" rather than assuming it worked, root-caused with a debug-instrumented run, and corrected by prepending `PATH` the same way `start_services()` does.

## Test plan

- [x] `bash -n launch.sh` — syntax OK
- [x] Live-tested against a real nvm-only Node install (no bare `node`/`npm` on default `PATH`) — reproduced both the initial regression (`npm: not installed`) and confirmed the fix (`npm: 10.8.2`) via a debug-instrumented run showing the exact resolved paths and exit code, then removed the instrumentation
- [x] Confirmed the positive case is unaffected — full launch reaches healthy state, `/api/health` returns `200`
- [x] CHANGELOG.md entry per CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)