### PR TITLE
fix(gui): repair model download/pull flow in Models tab

### DIFF
--- a/ghostlink_gui_modern/src/api.ts
+++ b/ghostlink_gui_modern/src/api.ts
@@ -576,7 +576,10 @@ export class GhostlinkAPI {
 
   async pullOllamaModel(modelName: string): Promise<{ success: boolean; error?: string }> {
     try {
-      await this.http.post('/api/ollama/pull', { model: modelName });
+      const response = await this.http.post('/api/ollama/pull', { model: modelName });
+      if (response.data?.error) {
+        return { success: false, error: response.data.error };
+      }
       return { success: true };
     } catch (error: any) {
       if (this.isNotFound(error)) {

--- a/ghostlink_gui_modern/src/components/ModelsTab.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.tsx
@@ -36,7 +36,8 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const [hfSearch, setHfSearch] = useState('');
   const [message, setMessage] = useState<string | null>(null);
   const [pendingActions, setPendingActions] = useState<Record<string, string>>({});
-  const [hfResults, setHfResults] = useState<{ id: string; name: string; downloads: number; likes: number }[]>(POPULAR_MODELS);
+  const [hfResults, setHfResults] = useState<{ id: string; name: string; downloads: number; likes: number }[]>([]);
+  const [hfLoading, setHfLoading] = useState(false);
   const [downloadProgress, setDownloadProgress] = useState<Record<string, number>>({});
   const [ollamaModels, setOllamaModels] = useState<any[]>([]);
   const [showModelfile, setShowModelfile] = useState<string | null>(null);
@@ -46,11 +47,14 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const [availableMemoryGb, setAvailableMemoryGb] = useState<number>(0);
 
   const searchHF = useCallback(async (query: string) => {
+    setHfLoading(true);
     try {
       const result = await api.searchHuggingFace(query || 'llama');
       if (result.models && result.models.length > 0) setHfResults(result.models);
     } catch {
       // silent
+    } finally {
+      setHfLoading(false);
     }
   }, [api]);
 
@@ -95,10 +99,9 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     fetchRecommendations();
   }, [fetchRecommendations]);
 
-  const filteredHfResults = hfResults.filter(model =>
-    model.name.toLowerCase().includes(hfSearch.toLowerCase()) ||
-    model.id.toLowerCase().includes(hfSearch.toLowerCase())
-  );
+  // hfResults already reflects the live server-side search for hfSearch (see searchHF),
+  // so no further client-side filtering is applied here.
+  const filteredHfResults = hfResults;
 
   const refreshModels = useCallback(async () => {
     setLoading(true);
@@ -479,11 +482,13 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                   // substring check also catches an equivalent local GGUF filed
                   // under a different name (e.g. "tinyllama" vs the local file
                   // "tinyllama-1.1b-chat-v1.0.Q2_K") so we don't offer a
-                  // redundant download for a model already on disk.
+                  // redundant download for a model already on disk. `usable` is
+                  // required so a never-downloaded catalog placeholder sharing
+                  // the name doesn't count as installed.
                   const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
                   const normId = normalize(m.id.split(':')[0]);
                   const isInstalled = ollamaModels.some(
-                    (om: any) => om.name === m.id || normalize(om.name).includes(normId)
+                    (om: any) => om.usable && (om.name === m.id || normalize(om.name).includes(normId))
                   );
                   const isPending = pendingActions[m.id] === 'downloading';
                   return (
@@ -652,7 +657,18 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
               </div>
             </div>
             <div className="space-y-2">
-              {filteredHfResults.map((m) => (
+              {hfLoading && filteredHfResults.length === 0 ? (
+                <div className="text-center py-12 text-slate-500">
+                  <Loader size={48} className="mx-auto mb-4 text-slate-700 animate-spin" />
+                  <p>Searching Hugging Face...</p>
+                </div>
+              ) : filteredHfResults.length === 0 ? (
+                <div className="text-center py-12 text-slate-500">
+                  <Layers size={48} className="mx-auto mb-4 text-slate-700" />
+                  <p>No models found.</p>
+                </div>
+              ) : (
+              filteredHfResults.map((m) => (
                 <div key={m.id} className="flex items-center justify-between px-4 py-3 hover:bg-slate-800/50 rounded-lg transition">
                   <div className="flex items-center gap-3 min-w-0">
                     <div className="flex items-center justify-center text-orange-500 bg-orange-500/10 h-10 w-10 rounded-lg shrink-0">
@@ -685,7 +701,8 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                     </button>
                   </div>
                 </div>
-              ))}
+              ))
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

Found and fixed while testing the Models tab against `launch.sh`-started servers (native inference backend). The core symptom: pulling/downloading models appeared to fail silently or reported false success.

- **False "Pulled" toasts on real failures** — `pullOllamaModel()` in [`api.ts`](ghostlink_gui_modern/src/api.ts) only treated network/HTTP-level errors as failures. The backend's `/api/ollama/pull` returns `200 OK` with a JSON `{"error": "..."}` body when the pull itself fails (e.g. the Ollama daemon isn't running). The frontend never inspected that field, so every failed pull showed `Pulled <model>` even though nothing happened. Now checks `response.data.error` and surfaces the real failure.
- **Already-downloadable models shown as installed** — the "Popular Ollama Models" grid in [`ModelsTab.tsx`](ghostlink_gui_modern/src/components/ModelsTab.tsx) treated any catalog entry matching a model's name as "installed" (hiding its Pull button), including catalog placeholders that were never actually downloaded (e.g. `llama3.2:1b`, `gemma2:2b`). Fixed to also require the model's `usable` flag, matching the check already used elsewhere in the file.
- **Hugging Face tab was unusable by design** — it defaulted to `POPULAR_MODELS`, a list of Ollama tag names (`llama3.2:3b`, `tinyllama`, etc.), which are not valid Hugging Face repo IDs. Every Download click failed with `Model 'tinyllama' not found on HuggingFace`. Now defaults to an empty list so the existing live HF-search effect populates it with real repo IDs on mount.
- **Real search results discarded** — after fixing the above, a leftover client-side substring filter re-applied the exact search string against results the server had *already* matched. A query like `"tinyllama gguf"` doesn't appear as a literal substring in a name like `TinyLlama-1.1B-Chat-v1.0-GGUF`, so legitimate server results got hidden and the UI showed "No models found." Removed the redundant filter (the server search already scopes the results) and added a loading/empty state for the tab.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npx vitest run src/components/ModelsTab.test.tsx` — 6/6 passed
- [x] Manual verification in the running GUI (`launch.sh`, native backend):
  - Confirmed a failed Ollama pull now shows the real error instead of a false "Pulled" toast
  - Confirmed `llama3.2:1b` / `gemma2:2b` show a "Pull" button again instead of being greyed out as installed
  - Searched "tinyllama gguf" in the Hugging Face tab and confirmed real GGUF repos (e.g. `TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF`) now appear instead of "No models found"
  - Downloaded `klosax/tinyllamas-stories-gguf` end to end through to a "Ready" model entry, then removed the test download via the API to leave no artifacts

## Risk / rollback

Frontend-only change, scoped to `ModelsTab.tsx` and one method in `api.ts`. No backend, schema, or route changes. Revert is a straightforward single-commit revert if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)