### PR TITLE
feat: real MCP server support for Ghostlink chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,11 @@ models/
 models.json
 ghostlink_gui_modern/dist/
 .ghostlink-npm-platform
+
+# mcp_servers.toml is a per-install copy of mcp_servers.example.toml (same
+# pattern as ghostlink.toml/ghostlink.example.toml) — the GUI's MCP tab writes
+# enable/disable toggles back to it, so it shouldn't be tracked.
+mcp_servers.toml
+
+# Runtime data created by MCP servers (see mcp_servers.toml) — not source
+mcp_workspace/ghostlink.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,91 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.4.0] - 2026-07-23 (Real MCP Server Support for Chat)
+
+Ghostlink chat's "Tools & MCP" feature was entirely fake: the 8 tool checkboxes
+dispatched to a hardcoded `ToolDispatcher` that always returned canned strings
+(calculator always said "42"), with no real execution, no argument passing,
+and no model involvement in deciding to call a tool. This replaces it with
+real [MCP](https://modelcontextprotocol.io) server integration end to end.
+
+### ✨ Backend
+
+- **New native Rust MCP client** (`crates/ghost-link/src/mcp/`, built on the
+  official `rmcp` SDK) spawns real MCP servers over stdio, with a Windows
+  `cmd /C` fix for `.cmd`-shim commands (`npx`/`uvx`) and real process-tree
+  teardown (`rmcp`'s own cleanup only kills the direct child; a `cmd /C
+  npx ...`-spawned server's own children would otherwise be orphaned).
+- **Model-driven tool-calling loop**: the model decides whether and which
+  tool to call via a ReAct-style prompt (works with any local GGUF/Ollama
+  model), with real arguments extracted from the model's own output and fed
+  back as an "Observation" for up to 3 round-trips per turn. Ollama models
+  whose chat template declares native tool-calling support use Ollama's
+  `tools` API directly instead, when available.
+- **Confirmation gate**: tools marked `requires_confirmation` in
+  `mcp_servers.toml` (terminal, code_execution) pause and return a
+  `pending_tool_call` instead of executing; a new
+  `POST /api/inference/chat/tool-confirm` endpoint resumes the same turn on
+  approval or denial.
+- **All 8 chat tool slots now have real backing servers**: `filesystem`,
+  `fetch`, a new custom `mcp-calculator` server (`evalexpr`-backed, replacing
+  the old "42" stub), and `sqlite` are enabled by default; `brave-search`
+  (needs `BRAVE_API_KEY`), Docker MCP Toolkit-routed `terminal`/
+  `code_execution` (needs Docker Desktop — deliberately never backed by a raw
+  host-shell server), and `image_generation` (no backend chosen yet) ship
+  disabled.
+- **Two standalone additions**: the official `sequential-thinking` reference
+  server (enabled by default), and a new custom `mcp-vision` server wrapping
+  a local Ollama vision model (llava/moondream/...) — stays local-model-first
+  instead of adding a cloud dependency.
+- `mcp_servers.toml` follows the existing `ghostlink.toml`/
+  `ghostlink.example.toml` pattern: the real file is gitignored (the GUI
+  writes enable/disable toggles back to it) and auto-bootstraps from the
+  checked-in `mcp_servers.example.toml` on first run.
+
+### ✨ Frontend
+
+- New **MCP tab** listing every configured server with live connected/
+  disabled status and working enable/disable toggles that take effect
+  immediately (no restart needed).
+- `ChatTab`'s tool checklist now reflects real configured servers instead of
+  a hardcoded 8-tool array; messages show a trace of which tool actually ran
+  and its real result, plus an inline approve/deny card for tool calls
+  awaiting confirmation. Tool-enabled turns skip token streaming, since tool
+  traces and confirmation cards only ever arrive on the plain JSON response.
+
+### ✅ Validation
+
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo test --workspace`, `cargo audit` — all clean (workspace now includes
+  the new `mcp-calculator` and `mcp-vision` crates).
+- `tsc --noEmit`, `npx vitest run` (104 tests) — all clean.
+- Live-verified end to end, not just unit-tested: real filesystem/fetch/
+  calculator/sqlite/sequential-thinking servers connecting and executing for
+  real; the full tool loop (parse → execute → feed back → final answer) with
+  both a scripted mock model and a real loaded model (`gemma-4-E4B-it-Q4_K_M`);
+  the confirmation approve/deny round-trip; the MCP tab's toggle causing an
+  immediate live reconnect in the browser; clean process teardown (no
+  orphaned `node.exe`/`cmd.exe`) after graceful shutdown.
+- A smaller model (`Llama-3.2-1B-Instruct-IQ3_M`) followed the tool-call
+  format inconsistently during testing — a known limitation of ~1B-class
+  models with structured-output prompting, not a bug in the mechanism itself;
+  noted here as an operational caveat rather than something this PR can fix.
+
+### ⚠️ Operational caveats
+
+- Requires `npx`/`node` (bundled MCP servers) and `uvx`/`python` (Python-
+  distributed ones) on `PATH`; Docker Desktop for the terminal/code_execution
+  slots. None of these are vendored — a fresh checkout without them will see
+  those specific servers fail to connect (logged and skipped), not a crash.
+- Docker MCP Toolkit and the native-Ollama-tool-calling path could not be
+  live-verified in the development sandbox (no running Docker daemon / no
+  Ollama instance with a tool-capable model pulled there) — both share code
+  paths already proven live for other servers, but call this out per the
+  pre-push checklist's platform-awareness guidance.
+
+---
+
 ## [1.3.9] - 2026-07-22 (Launch Verification: GUI UX Fixes)
 
 A full end-to-end verification pass of both launch entrypoints (`launch.sh` directly under WSL, and `launch.bat` on Windows delegating to WSL) — driven through the real browser UI, not just curl — surfaced two real, reproducible GUI bugs. (A third finding from the same pass, the System Info panel misreporting Node.js/npm as "not installed," turned out to already be fixed on `main` by [1.3.8] via a parallel effort; no change needed here.)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -140,7 +140,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -254,6 +254,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -506,7 +507,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -517,7 +518,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -539,7 +540,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -582,7 +583,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -593,6 +594,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -615,6 +622,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "evalexpr"
+version = "13.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25929004897f2bbab309121a60400d36992f6d911d09baa6c172f6cc55706601"
 
 [[package]]
 name = "fastrand"
@@ -705,7 +718,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -796,7 +809,8 @@ dependencies = [
  "futures",
  "ghostlink-core",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "sysinfo",
@@ -1153,7 +1167,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1284,10 +1298,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "mcp-calculator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "evalexpr",
+ "rmcp",
+ "serde",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "mcp-vision"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "reqwest 0.12.28",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "memchr"
@@ -1311,6 +1362,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1380,6 +1443,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1452,6 +1521,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -1712,6 +1795,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1884,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1929,46 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "http",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest 0.13.4",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1904,6 +2081,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,7 +2145,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2070,6 +2284,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,7 +2333,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2120,6 +2347,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2143,7 +2381,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2157,7 +2395,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -2199,7 +2437,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2210,7 +2448,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2282,7 +2520,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2454,7 +2692,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2484,10 +2722,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2671,7 +2913,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2682,6 +2924,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -2755,6 +3010,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2780,6 +3056,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,7 +3074,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2798,7 +3085,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2809,7 +3096,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2820,7 +3107,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2828,6 +3115,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -2897,6 +3194,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2987,7 +3293,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3008,7 +3314,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3028,7 +3334,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3068,7 +3374,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/ghost-link", "crates/ghostlink-core"]
+members = ["crates/ghost-link", "crates/ghostlink-core", "crates/mcp-calculator", "crates/mcp-vision"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -267,8 +267,41 @@ crates/
 │   ├── accelerator.rs       # NPU acceleration detection
 │   └── xdp.rs               # AF_XDP kernel bypass (fallback-safe)
 ├── ghost-link/              # CLI demo & API server
+│   └── src/mcp/              # MCP client (rmcp): registry, config, tool-calling loop
+├── mcp-calculator/          # Custom MCP server backing the calculator chat tool
+├── mcp-vision/              # Custom MCP server backing the vision chat tool (local Ollama)
 ghostlink_gui_modern/        # React frontend (Vite + Tailwind)
 ```
+
+## MCP Tools (Model Context Protocol)
+
+Ghostlink chat can call real tools via [MCP](https://modelcontextprotocol.io) servers,
+configured in `mcp_servers.toml` (a gitignored, per-install copy of
+`mcp_servers.example.toml`, auto-created on first run — same pattern as
+`ghostlink.toml`/`ghostlink.example.toml`).
+
+Default servers:
+
+| Chat tool slot | Backing server | Enabled by default |
+|---|---|---|
+| `file_operations` | `@modelcontextprotocol/server-filesystem` (npx) | ✅ |
+| `api_call` | `mcp-server-fetch` (uvx) | ✅ |
+| `calculator` | `mcp-calculator` (this repo, `evalexpr`-backed) | ✅ |
+| `database_query` | `mcp-server-sqlite` (uvx) | ✅ |
+| `web_search` | `@modelcontextprotocol/server-brave-search` (npx) | needs `BRAVE_API_KEY` |
+| `code_execution` / `terminal` | Docker MCP Toolkit gateway | needs Docker Desktop running |
+| `image_generation` | *(not yet configured — no default backend picked)* | ❌ |
+| — | `sequential-thinking` (npx) | ✅ |
+| — | `vision` (this repo, wraps local Ollama) | needs a pulled vision model |
+
+The model decides whether and which tool to call (a ReAct-style prompt works
+with any local GGUF/Ollama model; Ollama models whose chat template declares
+native tool-calling support use that automatically instead). Tools marked
+`requires_confirmation` in `mcp_servers.toml` (terminal, code_execution) pause
+for explicit user approval before executing — see the MCP tab in the GUI.
+
+Requires `npx`/`node` (bundled MCP servers) and `uvx`/`python` (Python-distributed
+ones) on `PATH`; Docker Desktop for the terminal/code_execution slots.
 
 ## Testing
 

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -52,3 +52,10 @@ uuid = { version = "1", features = ["v4"] }
 
 # Host CPU / memory sampling for /api/metrics
 sysinfo = "0.33"
+
+# MCP (Model Context Protocol) client — spawns/connects to tool servers
+rmcp = { version = "2", default-features = false, features = [
+    "client",
+    "transport-child-process",
+    "transport-streamable-http-client-reqwest",
+] }

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1467,6 +1467,8 @@ struct BackendState {
     ollama_client: ollama::OllamaClient,
     ollama_available: Arc<tokio::sync::Mutex<bool>>,
     settings: RuntimeSettings,
+    mcp_registry: Arc<mcp::McpRegistry>,
+    pending_tool_calls: Arc<tokio::sync::Mutex<HashMap<String, PendingToolCall>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1526,41 +1528,6 @@ impl Default for RuntimeSettings {
             discovery_auth_token: String::new(),
             tcp_auth_token: String::new(),
             xdp_interface: "eth0".to_string(),
-        }
-    }
-}
-
-struct ToolDispatcher;
-
-impl ToolDispatcher {
-    fn dispatch(tool_name: &str, _args: &serde_json::Value) -> ToolResult {
-        match tool_name {
-            "calculator" => ToolResult {
-                tool: tool_name.to_string(),
-                result: "42 (Calculated via Rust built-in tool)".to_string(),
-                success: true,
-            },
-            "web_search" => ToolResult {
-                tool: tool_name.to_string(),
-                result: "Ghostlink is a high-performance distributed LLM inference fabric."
-                    .to_string(),
-                success: true,
-            },
-            "terminal" => ToolResult {
-                tool: tool_name.to_string(),
-                result: "System: All nodes operational. Kernel bypass active.".to_string(),
-                success: true,
-            },
-            "code_execution" => ToolResult {
-                tool: tool_name.to_string(),
-                result: "Output: Processed tensor batch in 2.4ms".to_string(),
-                success: true,
-            },
-            _ => ToolResult {
-                tool: tool_name.to_string(),
-                result: format!("Tool '{}' executed successfully.", tool_name),
-                success: true,
-            },
         }
     }
 }
@@ -1718,7 +1685,6 @@ struct GuiChatRequest {
     penalty: Option<f32>,
     #[allow(dead_code)]
     max_tokens: Option<usize>,
-    #[allow(dead_code)]
     system_prompt: Option<String>,
     #[allow(dead_code)]
     ollama_url: Option<String>,
@@ -1831,11 +1797,52 @@ struct Choice {
     message: serde_json::Value,
     finish_reason: String,
 }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ToolResult {
     tool: String,
+    server: String,
     result: String,
     success: bool,
+}
+
+/// Generation parameters captured once per chat request so the tool-calling loop
+/// (see `run_tool_loop`) can call the same backend repeatedly across iterations —
+/// and so a confirmation round-trip (`handle_gui_chat_tool_confirm`) can resume
+/// generation later using the exact same settings the original request used.
+#[derive(Debug, Clone)]
+struct GenerationParams {
+    inference_backend: InferenceBackend,
+    current_model: String,
+    native_engine_client: native_engine::NativeEngineClient,
+    ollama_client: ollama::OllamaClient,
+    settings: RuntimeSettings,
+    temperature: f32,
+    top_p: f32,
+    top_k: usize,
+    repeat_penalty: f32,
+    exec_tokens: usize,
+    /// Enabled tools, offered to the Ollama backend's native `tools` API
+    /// (`generate_once` prefers this over ReAct-marker parsing for models that
+    /// declare tool support; the native backend has no equivalent API today, so
+    /// it always uses the ReAct prompt fallback regardless of this field).
+    tool_schemas: Vec<mcp::McpToolSchema>,
+}
+
+/// A tool call the model requested that requires explicit user approval
+/// (`McpServerConfig.requires_confirmation`) before it runs — e.g. terminal or
+/// code_execution once Docker MCP Toolkit backs them. Stored server-side, keyed by
+/// a request id, so the GUI's approve/deny click can resume the same chat turn.
+#[derive(Debug, Clone)]
+struct PendingToolCall {
+    gen: GenerationParams,
+    effective_prompt: String,
+    iteration: usize,
+    tool_owner: HashMap<String, String>,
+    enabled_tool_names: Vec<String>,
+    tool_results_so_far: Vec<ToolResult>,
+    tool: String,
+    server: String,
+    args: serde_json::Value,
 }
 
 fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
@@ -1858,6 +1865,15 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
     fn lock_state(state: &Arc<Mutex<BackendState>>) -> std::sync::MutexGuard<'_, BackendState> {
         state.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    /// Waits for Ctrl+C, then force-tears-down every connected MCP server before
+    /// `axum::serve`'s graceful shutdown lets the process exit. Without this, a
+    /// `cmd /C npx ...`-spawned server's child processes (see mcp::client) would
+    /// otherwise be orphaned when Ghostlink exits.
+    async fn mcp_shutdown_on_ctrl_c(mcp_registry: Arc<mcp::McpRegistry>) {
+        let _ = tokio::signal::ctrl_c().await;
+        mcp_registry.shutdown_all().await;
     }
 
     fn chat_exec_micro_batch() -> usize {
@@ -3466,6 +3482,7 @@ InferenceBackend::Native => match native_engine_client
                 Some(ollama::ChatMessage {
                     role: role.to_string(),
                     content: content.to_string(),
+                    tool_calls: None,
                 })
             })
             .collect::<Vec<_>>();
@@ -3488,6 +3505,7 @@ InferenceBackend::Native => match native_engine_client
                 req.top_k,
                 req.repeat_penalty,
                 req.max_tokens,
+                None,
             )
             .await
         {
@@ -3498,69 +3516,41 @@ InferenceBackend::Native => match native_engine_client
         }
     }
 
-    async fn handle_gui_chat(
-        State(state): State<Arc<Mutex<BackendState>>>,
-        Json(req): Json<GuiChatRequest>,
-    ) -> axum::response::Response {
-        let started = Instant::now();
-
-        let mut tool_results = Vec::new();
-        // Performance optimization: avoid cloning potentially large MCP payloads
-        // and dispatch tools without async-await state machine overhead.
-        // Expected impact: lower per-request CPU and latency for tool-heavy chat calls.
-        let empty_tool_args = serde_json::Value::Null;
-        if let Some(mcp) = req.mcp.as_ref() {
-            if let Some(tools) = mcp.get("tools").and_then(|t| t.as_array()) {
-                tool_results = Vec::with_capacity(tools.len());
-                for tool_val in tools {
-                    if let Some(tool_name) = tool_val.as_str() {
-                        tool_results.push(ToolDispatcher::dispatch(tool_name, &empty_tool_args));
+    /// Single inference call against whichever backend is active. Pulled out of
+    /// `handle_gui_chat` so the tool-calling loop (`run_tool_loop`) can call it
+    /// repeatedly across iterations with a growing prompt, instead of once.
+    /// Converts our MCP tool schemas into Ollama's OpenAI-style function-tool
+    /// format so models with native tool-calling support in their chat template
+    /// can use it directly, instead of relying solely on the ReAct text marker.
+    fn ollama_tools_json(schemas: &[mcp::McpToolSchema]) -> Vec<serde_json::Value> {
+        schemas
+            .iter()
+            .map(|schema| {
+                serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": schema.name,
+                        "description": schema.description,
+                        "parameters": schema.input_schema,
                     }
-                }
-            }
-        }
+                })
+            })
+            .collect()
+    }
 
-        let (
-            current_model,
-            _cluster,
-            ollama_client,
-            ollama_available,
-            inference_backend,
-            native_engine_client,
-            settings,
-        ) = {
-            let backend = lock_state(&state);
-            let inference_backend = InferenceBackend::parse(&backend.settings.inference_backend);
-            (
-                backend.current_model.clone(),
-                Arc::clone(&backend.cluster),
-                backend.ollama_client.clone(),
-                Arc::clone(&backend.ollama_available),
-                inference_backend,
-                backend.native_engine_client.clone(),
-                backend.settings.clone(),
-            )
-        };
-
-        let token_estimate = req.message.split_whitespace().count().clamp(1, 1024);
-        let temp = req.temperature.unwrap_or(settings.temperature);
-        let top_p = req.top_p.unwrap_or(settings.top_p);
-        let top_k = req.top_k.unwrap_or(settings.top_k);
-        let penalty = req.penalty.unwrap_or(settings.repeat_penalty);
-        let requested_exec_tokens = req
-            .max_tokens
-            .unwrap_or(settings.max_tokens)
-            .clamp(16, 4096);
-        let exec_tokens = chat_exec_token_budget(requested_exec_tokens);
-        let exec_micro_batch = chat_exec_micro_batch();
-        let request_tracker = active_runtime_switcher().request_tracker().clone();
-        request_tracker.increment().await;
-
-        let mut gen_tokens: Option<u32> = None;
-        let mut gen_tps: Option<f32> = None;
-        let mut gen_latency_ms: Option<f32> = None;
-
-        let (response_text, real_inference, backend_used) = match inference_backend {
+    async fn generate_once(
+        state: &Arc<Mutex<BackendState>>,
+        gen: &GenerationParams,
+        prompt: &str,
+    ) -> (
+        String,
+        bool,
+        &'static str,
+        Option<u32>,
+        Option<f32>,
+        Option<f32>,
+    ) {
+        match gen.inference_backend {
             InferenceBackend::Ollama => {
                 let resolve_model = |requested: &str, available: &[String]| -> Option<String> {
                     if available.iter().any(|m| m == requested) {
@@ -3586,43 +3576,145 @@ InferenceBackend::Native => match native_engine_client
                     None
                 };
 
-                let available_models_result: Result<Vec<String>, String> = ollama_client
+                let available_models_result: Result<Vec<String>, String> = gen
+                    .ollama_client
                     .list_models()
                     .await
                     .map_err(|err| err.to_string());
 
                 match available_models_result {
                     Ok(available_models) => {
-                        let effective_model = resolve_model(&current_model, &available_models);
+                        let effective_model = resolve_model(&gen.current_model, &available_models);
                         if let Some(model_name) = effective_model {
-                            match ollama_client
-                                .generate(
-                                    &model_name,
-                                    &req.message,
-                                    temp,
-                                    top_p,
-                                    top_k,
-                                    penalty,
-                                    exec_tokens,
-                                )
-                                .await
-                            {
-                                Ok(text) => {
-                                    if model_name != current_model {
-                                        let mut backend = lock_state(&state);
-                                        backend.current_model = model_name;
+                            if gen.tool_schemas.is_empty() {
+                                match gen
+                                    .ollama_client
+                                    .generate(
+                                        &model_name,
+                                        prompt,
+                                        gen.temperature,
+                                        gen.top_p,
+                                        gen.top_k,
+                                        gen.repeat_penalty,
+                                        gen.exec_tokens,
+                                    )
+                                    .await
+                                {
+                                    Ok(text) => {
+                                        if model_name != gen.current_model {
+                                            let mut backend = lock_state(state);
+                                            backend.current_model = model_name;
+                                        }
+                                        let text = text.trim().to_string();
+                                        let gen_tokens =
+                                            Some((text.split_whitespace().count() as u32).max(1));
+                                        (
+                                            text,
+                                            true,
+                                            InferenceBackend::Ollama.as_str(),
+                                            gen_tokens,
+                                            None,
+                                            None,
+                                        )
                                     }
-                                    let text = text.trim().to_string();
-                                    gen_tokens =
-                                        Some((text.split_whitespace().count() as u32).max(1));
-                                    (text, true, InferenceBackend::Ollama.as_str())
+                                    Err(err) => {
+                                        let fallback = format!(
+                                            "Ollama generate failed for model '{}': {}",
+                                            model_name, err
+                                        );
+                                        (
+                                            fallback,
+                                            false,
+                                            InferenceBackend::Ollama.as_str(),
+                                            None,
+                                            None,
+                                            None,
+                                        )
+                                    }
                                 }
-                                Err(err) => {
-                                    let fallback = format!(
-                                        "Ollama generate failed for model '{}': {}",
-                                        model_name, err
-                                    );
-                                    (fallback, false, InferenceBackend::Ollama.as_str())
+                            } else {
+                                // Native tool-calling path: offer Ollama's `tools` param
+                                // (best-effort — only models whose chat template
+                                // declares tool support will actually populate
+                                // `message.tool_calls`). When present, synthesize our
+                                // internal `TOOL_CALL: {...}` marker so the existing
+                                // ReAct parser in `run_tool_loop` handles it identically
+                                // either way; otherwise fall back to the model's plain
+                                // text (which may itself contain a ReAct-style marker).
+                                let messages = vec![ollama::ChatMessage {
+                                    role: "user".to_string(),
+                                    content: prompt.to_string(),
+                                    tool_calls: None,
+                                }];
+                                let tools_json = ollama_tools_json(&gen.tool_schemas);
+
+                                match gen
+                                    .ollama_client
+                                    .chat(
+                                        &model_name,
+                                        &messages,
+                                        Some(gen.temperature),
+                                        Some(gen.top_p),
+                                        Some(gen.top_k),
+                                        Some(gen.repeat_penalty),
+                                        Some(gen.exec_tokens),
+                                        Some(tools_json),
+                                    )
+                                    .await
+                                {
+                                    Ok(response) => {
+                                        if model_name != gen.current_model {
+                                            let mut backend = lock_state(state);
+                                            backend.current_model = model_name;
+                                        }
+                                        let native_call = response
+                                            .message
+                                            .tool_calls
+                                            .as_ref()
+                                            .and_then(|calls| calls.first());
+                                        let text = match native_call {
+                                            Some(call) => {
+                                                let name = call
+                                                    .get("function")
+                                                    .and_then(|f| f.get("name"))
+                                                    .and_then(|n| n.as_str())
+                                                    .unwrap_or_default();
+                                                let args = call
+                                                    .get("function")
+                                                    .and_then(|f| f.get("arguments"))
+                                                    .cloned()
+                                                    .unwrap_or(serde_json::Value::Null);
+                                                format!(
+                                                    "TOOL_CALL: {{\"tool\": \"{name}\", \"args\": {args}}}"
+                                                )
+                                            }
+                                            None => response.message.content.trim().to_string(),
+                                        };
+                                        let gen_tokens =
+                                            Some((text.split_whitespace().count() as u32).max(1));
+                                        (
+                                            text,
+                                            true,
+                                            InferenceBackend::Ollama.as_str(),
+                                            gen_tokens,
+                                            None,
+                                            None,
+                                        )
+                                    }
+                                    Err(err) => {
+                                        let fallback = format!(
+                                            "Ollama chat failed for model '{}': {}",
+                                            model_name, err
+                                        );
+                                        (
+                                            fallback,
+                                            false,
+                                            InferenceBackend::Ollama.as_str(),
+                                            None,
+                                            None,
+                                            None,
+                                        )
+                                    }
                                 }
                             }
                         } else {
@@ -3636,10 +3728,11 @@ InferenceBackend::Native => match native_engine_client
                             (
                                 format!(
                                     "Configured model '{}' is not installed in Ollama. Available: {}. Pull/select an exact tag and retry.",
-                                    current_model, available_hint
+                                    gen.current_model, available_hint
                                 ),
                                 false,
                                 InferenceBackend::Ollama.as_str(),
+                                None, None, None,
                             )
                         }
                     }
@@ -3649,48 +3742,229 @@ InferenceBackend::Native => match native_engine_client
                             InferenceBackend::Ollama.as_str(),
                             err_text
                         );
-                        (fallback, false, InferenceBackend::Ollama.as_str())
+                        (
+                            fallback,
+                            false,
+                            InferenceBackend::Ollama.as_str(),
+                            None,
+                            None,
+                            None,
+                        )
                     }
                 }
             }
             InferenceBackend::Native => {
-                match native_engine_client
+                match gen
+                    .native_engine_client
                     .generate(
-                        &current_model,
-                        &req.message,
-                        exec_tokens,
-                        temp,
-                        top_p,
-                        top_k,
-                        penalty,
-                        &settings.native_engine,
+                        &gen.current_model,
+                        prompt,
+                        gen.exec_tokens,
+                        gen.temperature,
+                        gen.top_p,
+                        gen.top_k,
+                        gen.repeat_penalty,
+                        &gen.settings.native_engine,
                     )
                     .await
                 {
-                    Ok(gen) => {
-                        gen_tokens = gen.tokens_generated.or_else(|| {
-                            Some((gen.text.split_whitespace().count() as u32).max(1))
+                    Ok(native_gen) => {
+                        let gen_tokens = native_gen.tokens_generated.or_else(|| {
+                            Some((native_gen.text.split_whitespace().count() as u32).max(1))
                         });
-                        gen_tps = gen.tokens_per_sec;
-                        gen_latency_ms = gen.latency_ms;
                         (
-                            gen.text,
-                            gen.real_inference,
+                            native_gen.text,
+                            native_gen.real_inference,
                             InferenceBackend::Native.as_str(),
+                            gen_tokens,
+                            native_gen.tokens_per_sec,
+                            native_gen.latency_ms,
                         )
                     }
                     Err(err) => (
                         format!(
                             "Ghostlink native fabric backend processed model '{}' with {} estimated tokens. Native error: {}",
-                            current_model, exec_tokens, err
+                            gen.current_model, gen.exec_tokens, err
                         ),
                         false,
                         InferenceBackend::Native.as_str(),
+                        None, None, None,
                     ),
                 }
             }
-        };
+        }
+    }
 
+    enum ToolLoopOutcome {
+        Final {
+            response_text: String,
+            real_inference: bool,
+            backend_used: &'static str,
+            gen_tokens: Option<u32>,
+            gen_tps: Option<f32>,
+            gen_latency_ms: Option<f32>,
+            tool_results: Vec<ToolResult>,
+        },
+        PendingConfirmation {
+            request_id: String,
+            tool: String,
+            server: String,
+            args: serde_json::Value,
+        },
+    }
+
+    /// The model-driven tool-calling loop: generate, check whether the model asked
+    /// for a tool (`mcp::toolcall::extract_tool_call`), execute it for real via the
+    /// MCP registry, feed the result back as an "Observation", and repeat — capped
+    /// at `MAX_TOOL_ITERATIONS` round-trips. Replaces the old behavior of
+    /// unconditionally dispatching every checked tool regardless of what the model
+    /// actually needed.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_tool_loop(
+        state: &Arc<Mutex<BackendState>>,
+        mcp_registry: &Arc<mcp::McpRegistry>,
+        gen: &GenerationParams,
+        tool_owner: &HashMap<String, String>,
+        enabled_tool_names: &[String],
+        mut effective_prompt: String,
+        mut iteration: usize,
+        mut tool_results: Vec<ToolResult>,
+    ) -> ToolLoopOutcome {
+        loop {
+            let (text, real_inference, backend_used, gen_tokens, gen_tps, gen_latency_ms) =
+                generate_once(state, gen, &effective_prompt).await;
+
+            let Some(call) = mcp::toolcall::extract_tool_call(&text) else {
+                return ToolLoopOutcome::Final {
+                    response_text: text,
+                    real_inference,
+                    backend_used,
+                    gen_tokens,
+                    gen_tps,
+                    gen_latency_ms,
+                    tool_results,
+                };
+            };
+
+            iteration += 1;
+            if iteration > mcp::toolcall::MAX_TOOL_ITERATIONS {
+                return ToolLoopOutcome::Final {
+                    response_text: text,
+                    real_inference,
+                    backend_used,
+                    gen_tokens,
+                    gen_tps,
+                    gen_latency_ms,
+                    tool_results,
+                };
+            }
+
+            let Some(server) = tool_owner.get(&call.tool).cloned() else {
+                effective_prompt.push_str(&mcp::toolcall::format_observation(
+                    &call.tool,
+                    &serde_json::json!({
+                        "error": format!("unknown tool '{}': not one of the enabled tools", call.tool)
+                    }),
+                ));
+                continue;
+            };
+
+            if mcp_registry.requires_confirmation(&server).await {
+                let request_id = uuid::Uuid::new_v4().to_string();
+                let pending = PendingToolCall {
+                    gen: gen.clone(),
+                    effective_prompt,
+                    iteration,
+                    tool_owner: tool_owner.clone(),
+                    enabled_tool_names: enabled_tool_names.to_vec(),
+                    tool_results_so_far: tool_results,
+                    tool: call.tool.clone(),
+                    server: server.clone(),
+                    args: call.args.clone(),
+                };
+
+                let pending_map = {
+                    let backend = lock_state(state);
+                    Arc::clone(&backend.pending_tool_calls)
+                };
+                pending_map.lock().await.insert(request_id.clone(), pending);
+
+                return ToolLoopOutcome::PendingConfirmation {
+                    request_id,
+                    tool: call.tool,
+                    server,
+                    args: call.args,
+                };
+            }
+
+            let (tool_result, observation_json) = match mcp_registry
+                .call_tool(&server, &call.tool, call.args.clone())
+                .await
+            {
+                Some(outcome) => {
+                    let result_str = if outcome.success {
+                        serde_json::to_string(&outcome.result)
+                            .unwrap_or_else(|_| "<unserializable result>".to_string())
+                    } else {
+                        outcome
+                            .error
+                            .clone()
+                            .unwrap_or_else(|| "tool call failed".to_string())
+                    };
+                    (
+                        ToolResult {
+                            tool: outcome.tool.clone(),
+                            server: outcome.server.clone(),
+                            result: result_str,
+                            success: outcome.success,
+                        },
+                        outcome.result.clone(),
+                    )
+                }
+                None => {
+                    let msg = format!("no MCP server available for tool '{}'", call.tool);
+                    (
+                        ToolResult {
+                            tool: call.tool.clone(),
+                            server: server.clone(),
+                            result: msg.clone(),
+                            success: false,
+                        },
+                        serde_json::json!({ "error": msg }),
+                    )
+                }
+            };
+
+            effective_prompt.push_str(&mcp::toolcall::format_observation(
+                &call.tool,
+                &observation_json,
+            ));
+            tool_results.push(tool_result);
+        }
+    }
+
+    /// Shared response assembly (metrics recording, session bookkeeping, streaming
+    /// vs. plain JSON) for a finished chat turn — used both by a fresh request and
+    /// by one resumed after a tool-confirmation round-trip.
+    #[allow(clippy::too_many_arguments)]
+    async fn finish_chat_response(
+        state: &Arc<Mutex<BackendState>>,
+        ollama_available: &Arc<tokio::sync::Mutex<bool>>,
+        started: Instant,
+        current_model: &str,
+        token_estimate: usize,
+        exec_tokens: usize,
+        exec_micro_batch: usize,
+        mcp_echo: Option<serde_json::Value>,
+        stream_response: bool,
+        response_text: String,
+        real_inference: bool,
+        backend_used: &'static str,
+        gen_tokens: Option<u32>,
+        gen_tps: Option<f32>,
+        gen_latency_ms: Option<f32>,
+        tool_results: Vec<ToolResult>,
+    ) -> axum::response::Response {
         {
             let mut available_flag = ollama_available.lock().await;
             *available_flag = real_inference;
@@ -3709,7 +3983,7 @@ InferenceBackend::Native => match native_engine_client
         });
 
         let (request_id, session_id, metrics_json) = {
-            let mut backend = lock_state(&state);
+            let mut backend = lock_state(state);
             backend.chat_requests = backend.chat_requests.saturating_add(1);
             let request_seq = backend.chat_requests;
 
@@ -3733,7 +4007,7 @@ InferenceBackend::Native => match native_engine_client
                 session.tokens = session.tokens.saturating_add(tokens_out as usize);
                 session.throughput = throughput_u;
                 session.latency = latency_u;
-                session.model = current_model.clone();
+                session.model = current_model.to_string();
                 session.status = if real_inference {
                     "Running".to_string()
                 } else {
@@ -3744,7 +4018,7 @@ InferenceBackend::Native => match native_engine_client
                 let session_id = "sess_local_001".to_string();
                 backend.sessions.push(SessionRecord {
                     id: session_id.clone(),
-                    model: current_model.clone(),
+                    model: current_model.to_string(),
                     status: if real_inference {
                         "Running".to_string()
                     } else {
@@ -3794,7 +4068,7 @@ InferenceBackend::Native => match native_engine_client
             "metrics": metrics_json
         });
 
-        if let Some(mcp) = req.mcp {
+        if let Some(mcp) = mcp_echo {
             if let Some(response_object) = response.as_object_mut() {
                 response_object.insert("tool_access".to_string(), serde_json::json!(true));
                 response_object.insert("mcp".to_string(), mcp);
@@ -3809,9 +4083,7 @@ InferenceBackend::Native => match native_engine_client
             }
         }
 
-        request_tracker.decrement().await;
-
-        if req.stream.unwrap_or(false) {
+        if stream_response {
             let tokens: Vec<String> = final_response
                 .split_whitespace()
                 .map(|s| format!("{} ", s))
@@ -3829,6 +4101,395 @@ InferenceBackend::Native => match native_engine_client
             Sse::new(stream).into_response()
         } else {
             Json(response).into_response()
+        }
+    }
+
+    fn pending_tool_call_response(
+        outcome: &str,
+        tool: &str,
+        server: &str,
+        args: &serde_json::Value,
+        request_id: &str,
+    ) -> axum::response::Response {
+        Json(serde_json::json!({
+            "pending_tool_call": {
+                "request_id": request_id,
+                "tool": tool,
+                "server": server,
+                "args": args,
+            },
+            "response": format!(
+                "This turn wants to run '{tool}' on MCP server '{server}', which requires your approval before it executes.",
+            ),
+            "outcome": outcome,
+        }))
+        .into_response()
+    }
+
+    async fn handle_gui_chat(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Json(req): Json<GuiChatRequest>,
+    ) -> axum::response::Response {
+        let started = Instant::now();
+
+        let (
+            current_model,
+            _cluster,
+            ollama_client,
+            ollama_available,
+            inference_backend,
+            native_engine_client,
+            settings,
+            mcp_registry,
+        ) = {
+            let backend = lock_state(&state);
+            let inference_backend = InferenceBackend::parse(&backend.settings.inference_backend);
+            (
+                backend.current_model.clone(),
+                Arc::clone(&backend.cluster),
+                backend.ollama_client.clone(),
+                Arc::clone(&backend.ollama_available),
+                inference_backend,
+                backend.native_engine_client.clone(),
+                backend.settings.clone(),
+                Arc::clone(&backend.mcp_registry),
+            )
+        };
+
+        let token_estimate = req.message.split_whitespace().count().clamp(1, 1024);
+        let temp = req.temperature.unwrap_or(settings.temperature);
+        let top_p = req.top_p.unwrap_or(settings.top_p);
+        let top_k = req.top_k.unwrap_or(settings.top_k);
+        let penalty = req.penalty.unwrap_or(settings.repeat_penalty);
+        let requested_exec_tokens = req
+            .max_tokens
+            .unwrap_or(settings.max_tokens)
+            .clamp(16, 4096);
+        let exec_tokens = chat_exec_token_budget(requested_exec_tokens);
+        let exec_micro_batch = chat_exec_micro_batch();
+
+        // Gather real tool schemas for every enabled tool identifier — a legacy
+        // "slot" name (calculator, file_operations, ...) or, for standalone
+        // additions with no slot (sequential-thinking, Docker gateway), the
+        // server's own name — so the model can see real schemas and decide for
+        // itself whether and which tool to call.
+        let enabled_tool_names: Vec<String> = req
+            .mcp
+            .as_ref()
+            .and_then(|mcp| mcp.get("tools"))
+            .and_then(|t| t.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut enabled_schemas = Vec::new();
+        let mut tool_owner: HashMap<String, String> = HashMap::new();
+        for identifier in &enabled_tool_names {
+            let server_name = match mcp_registry.server_for_slot(identifier).await {
+                Some(name) => Some(name),
+                None => {
+                    let schemas = mcp_registry.tool_schemas_for_server(identifier).await;
+                    if schemas.is_empty() {
+                        None
+                    } else {
+                        Some(identifier.clone())
+                    }
+                }
+            };
+            if let Some(server_name) = server_name {
+                for schema in mcp_registry.tool_schemas_for_server(&server_name).await {
+                    tool_owner.insert(schema.name.clone(), schema.server.clone());
+                    enabled_schemas.push(schema);
+                }
+            }
+        }
+
+        let gen = GenerationParams {
+            inference_backend,
+            current_model: current_model.clone(),
+            native_engine_client,
+            ollama_client,
+            settings,
+            temperature: temp,
+            top_p,
+            top_k,
+            repeat_penalty: penalty,
+            exec_tokens,
+            tool_schemas: enabled_schemas.clone(),
+        };
+
+        let tool_instructions = mcp::toolcall::build_tool_instructions(&enabled_schemas);
+        let effective_prompt = if tool_instructions.is_empty() {
+            req.message.clone()
+        } else {
+            let user_system_prompt = req.system_prompt.clone().unwrap_or_default();
+            format!(
+                "{tool_instructions}\n{user_system_prompt}\n\nUser: {}",
+                req.message
+            )
+        };
+
+        let request_tracker = active_runtime_switcher().request_tracker().clone();
+        request_tracker.increment().await;
+
+        let outcome = run_tool_loop(
+            &state,
+            &mcp_registry,
+            &gen,
+            &tool_owner,
+            &enabled_tool_names,
+            effective_prompt,
+            0,
+            Vec::new(),
+        )
+        .await;
+
+        request_tracker.decrement().await;
+
+        match outcome {
+            ToolLoopOutcome::Final {
+                response_text,
+                real_inference,
+                backend_used,
+                gen_tokens,
+                gen_tps,
+                gen_latency_ms,
+                tool_results,
+            } => {
+                finish_chat_response(
+                    &state,
+                    &ollama_available,
+                    started,
+                    &current_model,
+                    token_estimate,
+                    exec_tokens,
+                    exec_micro_batch,
+                    req.mcp,
+                    req.stream.unwrap_or(false),
+                    response_text,
+                    real_inference,
+                    backend_used,
+                    gen_tokens,
+                    gen_tps,
+                    gen_latency_ms,
+                    tool_results,
+                )
+                .await
+            }
+            ToolLoopOutcome::PendingConfirmation {
+                request_id,
+                tool,
+                server,
+                args,
+            } => pending_tool_call_response(
+                "awaiting_confirmation",
+                &tool,
+                &server,
+                &args,
+                &request_id,
+            ),
+        }
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct ToolConfirmRequest {
+        request_id: String,
+        approve: bool,
+    }
+
+    /// Resumes a chat turn that paused for tool-call approval (see
+    /// `run_tool_loop`'s confirmation gate): executes (or records the denial of)
+    /// the pending tool, feeds the result back as an Observation, and continues
+    /// generating from exactly where the original request left off.
+    async fn handle_gui_chat_tool_confirm(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Json(req): Json<ToolConfirmRequest>,
+    ) -> axum::response::Response {
+        let (pending_map, mcp_registry, ollama_available) = {
+            let backend = lock_state(&state);
+            (
+                Arc::clone(&backend.pending_tool_calls),
+                Arc::clone(&backend.mcp_registry),
+                Arc::clone(&backend.ollama_available),
+            )
+        };
+
+        let pending = pending_map.lock().await.remove(&req.request_id);
+        let Some(pending) = pending else {
+            return Json(serde_json::json!({
+                "error": format!("no pending tool call with request_id '{}'", req.request_id),
+            }))
+            .into_response();
+        };
+
+        let PendingToolCall {
+            gen,
+            mut effective_prompt,
+            iteration,
+            tool_owner,
+            enabled_tool_names,
+            mut tool_results_so_far,
+            tool,
+            server,
+            args,
+        } = pending;
+
+        if req.approve {
+            let (tool_result, observation_json) =
+                match mcp_registry.call_tool(&server, &tool, args).await {
+                    Some(outcome) => {
+                        let result_str = if outcome.success {
+                            serde_json::to_string(&outcome.result)
+                                .unwrap_or_else(|_| "<unserializable result>".to_string())
+                        } else {
+                            outcome
+                                .error
+                                .clone()
+                                .unwrap_or_else(|| "tool call failed".to_string())
+                        };
+                        (
+                            ToolResult {
+                                tool: outcome.tool.clone(),
+                                server: outcome.server.clone(),
+                                result: result_str,
+                                success: outcome.success,
+                            },
+                            outcome.result.clone(),
+                        )
+                    }
+                    None => {
+                        let msg = format!("no MCP server available for tool '{tool}'");
+                        (
+                            ToolResult {
+                                tool: tool.clone(),
+                                server: server.clone(),
+                                result: msg.clone(),
+                                success: false,
+                            },
+                            serde_json::json!({ "error": msg }),
+                        )
+                    }
+                };
+            effective_prompt.push_str(&mcp::toolcall::format_observation(&tool, &observation_json));
+            tool_results_so_far.push(tool_result);
+        } else {
+            effective_prompt.push_str(&mcp::toolcall::format_denial(&tool));
+            tool_results_so_far.push(ToolResult {
+                tool: tool.clone(),
+                server: server.clone(),
+                result: "denied by user".to_string(),
+                success: false,
+            });
+        }
+
+        let started = Instant::now();
+        let request_tracker = active_runtime_switcher().request_tracker().clone();
+        request_tracker.increment().await;
+
+        let current_model = gen.current_model.clone();
+        let exec_tokens = gen.exec_tokens;
+
+        let outcome = run_tool_loop(
+            &state,
+            &mcp_registry,
+            &gen,
+            &tool_owner,
+            &enabled_tool_names,
+            effective_prompt,
+            iteration,
+            tool_results_so_far,
+        )
+        .await;
+
+        request_tracker.decrement().await;
+
+        match outcome {
+            ToolLoopOutcome::Final {
+                response_text,
+                real_inference,
+                backend_used,
+                gen_tokens,
+                gen_tps,
+                gen_latency_ms,
+                tool_results,
+            } => {
+                finish_chat_response(
+                    &state,
+                    &ollama_available,
+                    started,
+                    &current_model,
+                    0,
+                    exec_tokens,
+                    chat_exec_micro_batch(),
+                    None,
+                    false,
+                    response_text,
+                    real_inference,
+                    backend_used,
+                    gen_tokens,
+                    gen_tps,
+                    gen_latency_ms,
+                    tool_results,
+                )
+                .await
+            }
+            ToolLoopOutcome::PendingConfirmation {
+                request_id,
+                tool,
+                server,
+                args,
+            } => pending_tool_call_response(
+                "awaiting_confirmation",
+                &tool,
+                &server,
+                &args,
+                &request_id,
+            ),
+        }
+    }
+
+    /// Every server configured in `mcp_servers.toml` plus its live connection
+    /// status — backs the GUI's MCP tab (replacing the old hardcoded 8-tool list).
+    async fn handle_list_mcp_servers(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let mcp_registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+
+        match mcp_registry.list_all_servers().await {
+            Ok(servers) => Json(serde_json::json!({ "servers": servers })),
+            Err(err) => Json(serde_json::json!({ "error": err })),
+        }
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct ToggleMcpServerRequest {
+        enabled: bool,
+    }
+
+    /// Enables or disables one MCP server, taking effect immediately (connects or
+    /// tears it down right away — see `McpRegistry::set_enabled`).
+    async fn handle_toggle_mcp_server(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Path(name): Path<String>,
+        Json(req): Json<ToggleMcpServerRequest>,
+    ) -> Json<serde_json::Value> {
+        let mcp_registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+
+        match mcp_registry.set_enabled(&name, req.enabled).await {
+            Ok(()) => match mcp_registry.list_all_servers().await {
+                Ok(servers) => Json(serde_json::json!({ "success": true, "servers": servers })),
+                Err(err) => Json(serde_json::json!({ "success": true, "error": err })),
+            },
+            Err(err) => Json(serde_json::json!({ "success": false, "error": err })),
         }
     }
 
@@ -4402,12 +5063,25 @@ InferenceBackend::Native => match native_engine_client
         ollama_client,
         ollama_available,
         settings,
+        mcp_registry: Arc::new(mcp::McpRegistry::new(mcp::McpConfigManager::new(
+            mcp::default_config_path(),
+        ))),
+        pending_tool_calls: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
     }));
 
     // Background CPU/RAM/GPU sampler — keeps /api/metrics non-blocking.
     host_metrics::ensure_host_sampler();
 
     rt.block_on(async {
+        // Connect every `enabled` MCP server before the API starts serving chat
+        // requests. A misconfigured server is logged and skipped (see
+        // McpRegistry::connect_enabled), so this never blocks Ghostlink from launching.
+        let mcp_registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+        mcp_registry.connect_enabled().await;
+
         let app = Router::new()
             .route("/v1/chat/completions", post(handle_chat_completions))
             .route("/v1/models", get(handle_models))
@@ -4475,6 +5149,10 @@ InferenceBackend::Native => match native_engine_client
             .route("/api/security/pqc/state", get(handle_gui_pqc_state))
             .route("/api/security/audit-log", get(handle_gui_audit_log))
             .route("/api/inference/chat", post(handle_gui_chat))
+            .route(
+                "/api/inference/chat/tool-confirm",
+                post(handle_gui_chat_tool_confirm),
+            )
             // Accept GET/POST/PUT for settings — some clients issue PUT and previously got 405.
             .route(
                 "/api/settings",
@@ -4497,6 +5175,11 @@ InferenceBackend::Native => match native_engine_client
                 "/api/backends/:name/status",
                 get(backend_api::handle_backend_status),
             )
+            .route("/api/mcp/servers", get(handle_list_mcp_servers))
+            .route(
+                "/api/mcp/servers/:name/toggle",
+                post(handle_toggle_mcp_server),
+            )
             .with_state(state)
             .layer(CorsLayer::permissive());
 
@@ -4510,6 +5193,7 @@ API Server Online. Ready for connections."
         );
 
         axum::serve(listener, app)
+            .with_graceful_shutdown(mcp_shutdown_on_ctrl_c(mcp_registry))
             .await
             .map_err(|err| anyhow::anyhow!("API server terminated with error: {}", err))
     })?;
@@ -6511,6 +7195,7 @@ mod backend_api;
 mod backend_config;
 mod backend_registry;
 mod host_metrics;
+mod mcp;
 mod native_engine;
 mod ollama;
 mod runtime;

--- a/crates/ghost-link/src/mcp/client.rs
+++ b/crates/ghost-link/src/mcp/client.rs
@@ -1,0 +1,232 @@
+//! A single connected MCP server session, built on the `rmcp` SDK.
+//!
+//! Only the stdio (child-process) transport is implemented today; Docker MCP Toolkit
+//! and other stdio-spawned servers use it identically (`docker mcp gateway run` is
+//! just another command). HTTP/SSE transport is deferred until a remote server is
+//! actually needed.
+
+use std::time::Duration;
+
+use rmcp::{
+    model::CallToolRequestParams,
+    service::{RoleClient, RunningService, ServiceExt},
+    transport::TokioChildProcess,
+};
+use serde_json::Value;
+use tokio::process::Command;
+
+use super::config::{resolve_env_value, McpServerConfig, McpTransport};
+
+/// Builds the actual child-process command for a configured `command`/`args` pair.
+///
+/// On Windows, `CreateProcess` (which `tokio::process::Command` calls directly) does
+/// not resolve `PATHEXT`/shim scripts the way a shell does — `npx`/`npm`/`docker` are
+/// often `.cmd` shims, and spawning "npx" bare fails with "program not found" even
+/// though `npx` works fine when typed into a terminal. Routing through `cmd /C`
+/// reproduces the same resolution a user's shell performs, for any command.
+#[cfg(windows)]
+fn build_command(command: &str, args: &[String]) -> Command {
+    // `cmd.exe` treats an unquoted "/" in the program-name position as a switch
+    // separator (it tries to run "target" from "target/release/foo.exe" and
+    // fails with "'target' is not recognized..."), even though the same path
+    // works fine as an *argument* to another program. Backslashes are the only
+    // separator `cmd /C` reliably accepts there.
+    let normalized_command = command.replace('/', "\\");
+    let mut cmd = Command::new("cmd");
+    cmd.arg("/C").arg(normalized_command).args(args);
+    cmd
+}
+
+#[cfg(not(windows))]
+fn build_command(command: &str, args: &[String]) -> Command {
+    let mut cmd = Command::new(command);
+    cmd.args(args);
+    cmd
+}
+
+#[derive(Debug, Clone)]
+pub struct McpToolSchema {
+    pub server: String,
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolCallOutcome {
+    pub server: String,
+    pub tool: String,
+    pub result: Value,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+pub struct McpServerHandle {
+    name: String,
+    slot: String,
+    requires_confirmation: bool,
+    timeout: Duration,
+    session: RunningService<RoleClient, ()>,
+    tools: Vec<McpToolSchema>,
+    /// PID of the directly-spawned child (e.g. `cmd.exe` on Windows, or the server
+    /// binary itself elsewhere). `rmcp`'s own Drop-time cleanup only kills this one
+    /// process, which is not enough when it's a shim that spawned its own children
+    /// (e.g. `cmd /C npx ...` → node.exe) — see `shutdown()`.
+    child_pid: Option<u32>,
+}
+
+impl std::fmt::Debug for McpServerHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpServerHandle")
+            .field("name", &self.name)
+            .field("slot", &self.slot)
+            .field("tools", &self.tools.len())
+            .finish()
+    }
+}
+
+impl McpServerHandle {
+    pub async fn connect(config: &McpServerConfig) -> Result<Self, String> {
+        let (session, child_pid) = match &config.transport {
+            McpTransport::Stdio { command, args, env } => {
+                let mut cmd = build_command(command, args);
+                for (key, value) in env {
+                    cmd.env(key, resolve_env_value(value));
+                }
+                let transport = TokioChildProcess::new(cmd).map_err(|err| {
+                    format!("failed to spawn MCP server '{}': {err}", config.name)
+                })?;
+                let child_pid = transport.id();
+
+                let session = ().serve(transport).await.map_err(|err| {
+                    format!("failed to initialize MCP server '{}': {err}", config.name)
+                })?;
+                (session, child_pid)
+            }
+            McpTransport::Http { .. } => {
+                return Err(format!(
+                    "MCP server '{}': HTTP/SSE transport is not implemented yet",
+                    config.name
+                ));
+            }
+        };
+
+        let tools_result = session
+            .list_tools(Default::default())
+            .await
+            .map_err(|err| {
+                format!(
+                    "failed to list tools for MCP server '{}': {err}",
+                    config.name
+                )
+            })?;
+
+        let tools = tools_result
+            .tools
+            .into_iter()
+            .map(|tool| McpToolSchema {
+                server: config.name.clone(),
+                name: tool.name.to_string(),
+                description: tool.description.as_deref().unwrap_or_default().to_string(),
+                input_schema: serde_json::to_value(&tool.input_schema).unwrap_or(Value::Null),
+            })
+            .collect();
+
+        Ok(Self {
+            name: config.name.clone(),
+            slot: config.slot.clone(),
+            requires_confirmation: config.requires_confirmation,
+            timeout: Duration::from_secs(config.timeout_secs.max(1)),
+            session,
+            tools,
+            child_pid,
+        })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn slot(&self) -> &str {
+        &self.slot
+    }
+
+    pub fn requires_confirmation(&self) -> bool {
+        self.requires_confirmation
+    }
+
+    pub fn tools(&self) -> &[McpToolSchema] {
+        &self.tools
+    }
+
+    pub async fn call_tool(&self, tool_name: &str, args: Value) -> ToolCallOutcome {
+        let request = match args.as_object() {
+            Some(map) => {
+                CallToolRequestParams::new(tool_name.to_string()).with_arguments(map.clone())
+            }
+            None => CallToolRequestParams::new(tool_name.to_string()),
+        };
+
+        match tokio::time::timeout(self.timeout, self.session.call_tool(request)).await {
+            Ok(Ok(result)) => ToolCallOutcome {
+                server: self.name.clone(),
+                tool: tool_name.to_string(),
+                result: serde_json::to_value(&result).unwrap_or(Value::Null),
+                success: true,
+                error: None,
+            },
+            Ok(Err(err)) => ToolCallOutcome {
+                server: self.name.clone(),
+                tool: tool_name.to_string(),
+                result: Value::Null,
+                success: false,
+                error: Some(err.to_string()),
+            },
+            Err(_) => ToolCallOutcome {
+                server: self.name.clone(),
+                tool: tool_name.to_string(),
+                result: Value::Null,
+                success: false,
+                error: Some(format!("tool call timed out after {:?}", self.timeout)),
+            },
+        }
+    }
+
+    pub async fn shutdown(self) {
+        let pid = self.child_pid;
+        let name = self.name.clone();
+        // Best-effort graceful shutdown first (lets the server flush/exit cleanly).
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.session.cancel()).await;
+
+        // `rmcp`'s own cleanup only kills the directly-spawned process. On Windows
+        // that's `cmd.exe` (see `build_command`), whose own children (e.g. the
+        // node.exe processes an `npx`-launched server spawns) are not part of any
+        // Windows job object and would otherwise be orphaned. Force-kill the whole
+        // tree the same way `native_engine.rs` tears down llama-server.
+        if let Some(pid) = pid {
+            kill_process_tree(pid, &name).await;
+        }
+    }
+}
+
+#[cfg(windows)]
+async fn kill_process_tree(pid: u32, server_name: &str) {
+    let output = tokio::process::Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .output()
+        .await;
+    if let Err(err) = output {
+        tracing::warn!("mcp: failed to taskkill server '{server_name}' (pid {pid}): {err}");
+    }
+}
+
+#[cfg(not(windows))]
+async fn kill_process_tree(pid: u32, server_name: &str) {
+    let output = tokio::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .output()
+        .await;
+    if let Err(err) = output {
+        tracing::warn!("mcp: failed to kill server '{server_name}' (pid {pid}): {err}");
+    }
+}

--- a/crates/ghost-link/src/mcp/config.rs
+++ b/crates/ghost-link/src/mcp/config.rs
@@ -1,0 +1,362 @@
+//! Configuration for MCP (Model Context Protocol) servers Ghostlink connects to.
+//!
+//! Mirrors `backend_config::ConfigManager`'s load-as-`toml::Value`-then-extract pattern
+//! (rather than the simpler one-shot `FileConfig`) since the GUI needs to toggle
+//! `enabled` per server and persist that back to disk.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "transport", rename_all = "lowercase")]
+pub enum McpTransport {
+    Stdio {
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        /// Values written as `"${VAR_NAME}"` are resolved from the host process
+        /// environment at connect time — never stored here as literal secrets.
+        #[serde(default)]
+        env: HashMap<String, String>,
+    },
+    Http {
+        url: String,
+        #[serde(default)]
+        headers: HashMap<String, String>,
+    },
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_timeout_secs() -> u64 {
+    30
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerConfig {
+    pub name: String,
+    /// Legacy chat "tool slot" this server backs (web_search, calculator, ...),
+    /// or empty for standalone additions (sequential-thinking, Docker gateway, ...).
+    #[serde(default)]
+    pub slot: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(flatten)]
+    pub transport: McpTransport,
+    /// Risky tools (terminal, code_execution) require an explicit user approval
+    /// round-trip before the tool-calling loop executes them.
+    #[serde(default)]
+    pub requires_confirmation: bool,
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct McpServersFile {
+    #[serde(default, rename = "mcp_servers")]
+    servers: Vec<McpServerConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct McpConfigManager {
+    config_path: PathBuf,
+}
+
+impl McpConfigManager {
+    pub fn new(config_path: impl AsRef<Path>) -> Self {
+        Self {
+            config_path: config_path.as_ref().to_path_buf(),
+        }
+    }
+
+    /// `mcp_servers.toml` is gitignored (the GUI writes per-install enable/disable
+    /// toggles back to it — same pattern as `ghostlink.toml`/`ghostlink.example.toml`).
+    /// On a fresh checkout it won't exist yet; copy the checked-in
+    /// `mcp_servers.example.toml` template so real servers connect out of the box
+    /// instead of silently connecting zero tools until someone copies it by hand.
+    fn bootstrap_from_example(&self) {
+        let example_path = self.config_path.with_file_name("mcp_servers.example.toml");
+        if example_path.exists() {
+            if let Err(err) = std::fs::copy(&example_path, &self.config_path) {
+                tracing::warn!(
+                    "mcp: failed to bootstrap {} from {}: {err}",
+                    self.config_path.display(),
+                    example_path.display()
+                );
+            }
+        }
+    }
+
+    pub fn load(&self) -> Result<Vec<McpServerConfig>, String> {
+        if !self.config_path.exists() {
+            self.bootstrap_from_example();
+        }
+        if !self.config_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let content = std::fs::read_to_string(&self.config_path)
+            .map_err(|err| format!("failed to read {}: {err}", self.config_path.display()))?;
+        let file: McpServersFile = toml::from_str(&content)
+            .map_err(|err| format!("failed to parse {}: {err}", self.config_path.display()))?;
+
+        for server in &file.servers {
+            validate_server(server)?;
+        }
+
+        Ok(file.servers)
+    }
+
+    pub fn save(&self, servers: &[McpServerConfig]) -> Result<(), String> {
+        for server in servers {
+            validate_server(server)?;
+        }
+
+        let file = McpServersFile {
+            servers: servers.to_vec(),
+        };
+        let output = toml::to_string_pretty(&file)
+            .map_err(|err| format!("failed to serialize mcp_servers.toml: {err}"))?;
+        std::fs::write(&self.config_path, output)
+            .map_err(|err| format!("failed to write {}: {err}", self.config_path.display()))?;
+        Ok(())
+    }
+
+    pub fn set_enabled(&self, name: &str, enabled: bool) -> Result<(), String> {
+        let mut servers = self.load()?;
+        let server = servers
+            .iter_mut()
+            .find(|s| s.name == name)
+            .ok_or_else(|| format!("no MCP server named '{name}'"))?;
+        server.enabled = enabled;
+        self.save(&servers)
+    }
+}
+
+/// Rejects a config whose `env` map contains a literal-looking secret instead of an
+/// `${VAR_NAME}` reference — secrets must come from the host environment, never from
+/// `mcp_servers.toml` itself.
+fn validate_server(server: &McpServerConfig) -> Result<(), String> {
+    if let McpTransport::Stdio { env, .. } = &server.transport {
+        for (key, value) in env {
+            if looks_like_literal_secret(value) {
+                return Err(format!(
+                    "mcp server '{}': env var '{}' looks like a literal secret; use \"${{{}}}\" to reference a host environment variable instead",
+                    server.name, key, key
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn looks_like_literal_secret(value: &str) -> bool {
+    if value.starts_with("${") && value.ends_with('}') {
+        return false;
+    }
+    // Ordinary config values (URLs, model names, paths) are exempt — this
+    // heuristic only targets bare, contiguous, key-shaped tokens.
+    if value.starts_with("http://")
+        || value.starts_with("https://")
+        || value.contains(['/', ':', ' ', '\\'])
+    {
+        return false;
+    }
+    value.len() >= 20
+        && value.chars().any(|c| c.is_ascii_digit())
+        && value.chars().any(|c| c.is_ascii_alphabetic())
+}
+
+/// Resolves `${VAR_NAME}` to the host process environment; returns the value
+/// unchanged otherwise (used for non-secret values).
+pub fn resolve_env_value(raw: &str) -> String {
+    if let Some(var_name) = raw.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
+        std::env::var(var_name).unwrap_or_default()
+    } else {
+        raw.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_config_path() -> PathBuf {
+        let suffix = format!(
+            "ghostlink-mcp-{}-{}.toml",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        std::env::temp_dir().join(suffix)
+    }
+
+    #[test]
+    fn missing_file_yields_empty_list() {
+        let manager = McpConfigManager::new(temp_config_path());
+        assert!(manager.load().unwrap().is_empty());
+    }
+
+    #[test]
+    fn missing_config_bootstraps_from_sibling_example() {
+        let dir = std::env::temp_dir().join(format!(
+            "ghostlink-mcp-bootstrap-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let example_path = dir.join("mcp_servers.example.toml");
+        std::fs::write(
+            &example_path,
+            r#"[[mcp_servers]]
+name = "filesystem"
+slot = "file_operations"
+enabled = true
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "./mcp_workspace"]
+"#,
+        )
+        .unwrap();
+
+        let config_path = dir.join("mcp_servers.toml");
+        assert!(!config_path.exists());
+
+        let manager = McpConfigManager::new(&config_path);
+        let servers = manager.load().unwrap();
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "filesystem");
+        assert!(
+            config_path.exists(),
+            "load() should have copied the example into place"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_and_load_round_trip() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        let servers = vec![McpServerConfig {
+            name: "filesystem".to_string(),
+            slot: "file_operations".to_string(),
+            enabled: true,
+            transport: McpTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec![
+                    "-y".to_string(),
+                    "@modelcontextprotocol/server-filesystem".to_string(),
+                ],
+                env: HashMap::new(),
+            },
+            requires_confirmation: false,
+            timeout_secs: 30,
+        }];
+
+        manager.save(&servers).unwrap();
+        let loaded = manager.load().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "filesystem");
+        assert!(loaded[0].enabled);
+
+        manager.set_enabled("filesystem", false).unwrap();
+        let loaded = manager.load().unwrap();
+        assert!(!loaded[0].enabled);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn literal_secret_is_rejected() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        let servers = vec![McpServerConfig {
+            name: "brave-search".to_string(),
+            slot: "web_search".to_string(),
+            enabled: false,
+            transport: McpTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec![],
+                env: HashMap::from([(
+                    "BRAVE_API_KEY".to_string(),
+                    "BSAxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1234".to_string(),
+                )]),
+            },
+            requires_confirmation: false,
+            timeout_secs: 30,
+        }];
+
+        assert!(manager.save(&servers).is_err());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn env_reference_is_accepted() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        let servers = vec![McpServerConfig {
+            name: "brave-search".to_string(),
+            slot: "web_search".to_string(),
+            enabled: false,
+            transport: McpTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec![],
+                env: HashMap::from([("BRAVE_API_KEY".to_string(), "${BRAVE_API_KEY}".to_string())]),
+            },
+            requires_confirmation: false,
+            timeout_secs: 30,
+        }];
+
+        assert!(manager.save(&servers).is_ok());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn url_shaped_value_is_not_flagged_as_a_secret() {
+        // Regression test: an env value like an Ollama base URL was previously
+        // (wrongly) rejected by the literal-secret heuristic just for being long
+        // and containing both letters and digits.
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        let servers = vec![McpServerConfig {
+            name: "vision".to_string(),
+            slot: "".to_string(),
+            enabled: false,
+            transport: McpTransport::Stdio {
+                command: "mcp-vision".to_string(),
+                args: vec![],
+                env: HashMap::from([(
+                    "OLLAMA_URL".to_string(),
+                    "http://127.0.0.1:11434".to_string(),
+                )]),
+            },
+            requires_confirmation: false,
+            timeout_secs: 30,
+        }];
+
+        assert!(manager.save(&servers).is_ok());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn resolve_env_value_reads_process_env() {
+        std::env::set_var("GHOSTLINK_MCP_TEST_VAR", "resolved-value");
+        assert_eq!(
+            resolve_env_value("${GHOSTLINK_MCP_TEST_VAR}"),
+            "resolved-value"
+        );
+        assert_eq!(resolve_env_value("literal"), "literal");
+        std::env::remove_var("GHOSTLINK_MCP_TEST_VAR");
+    }
+}

--- a/crates/ghost-link/src/mcp/mod.rs
+++ b/crates/ghost-link/src/mcp/mod.rs
@@ -1,0 +1,305 @@
+//! Real MCP (Model Context Protocol) client support for Ghostlink chat.
+//!
+//! Replaces the old `ToolDispatcher` stub (canned strings) with genuine connections
+//! to MCP servers spawned over stdio (or, for Docker MCP Toolkit / remote servers, HTTP).
+
+mod client;
+mod config;
+mod registry;
+pub mod toolcall;
+
+pub use client::McpToolSchema;
+pub use config::McpConfigManager;
+pub use registry::McpRegistry;
+
+/// Default path for the MCP server registry file, alongside `ghostlink.toml`.
+pub fn default_config_path() -> std::path::PathBuf {
+    std::env::var("GHOSTLINK_MCP_CONFIG")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("mcp_servers.toml"))
+}
+
+/// End-to-end proof that the stdio transport really spawns a server, calls a real
+/// tool, and gets real (non-canned) data back. Requires `npx`/Node on the host and
+/// network access to fetch `@modelcontextprotocol/server-filesystem` on first run,
+/// so it's `#[ignore]`d by default — run explicitly with `cargo test -- --ignored`.
+#[cfg(test)]
+mod integration_tests {
+    use super::client::McpServerHandle;
+    use super::config::{McpServerConfig, McpTransport};
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    #[ignore]
+    async fn filesystem_server_lists_real_directory_contents() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("crates/ghost-link should be two levels below the repo root");
+        let workspace = repo_root
+            .join("mcp_workspace")
+            .canonicalize()
+            .expect("repo root should contain mcp_workspace/");
+
+        let config = McpServerConfig {
+            name: "filesystem".to_string(),
+            slot: "file_operations".to_string(),
+            enabled: true,
+            transport: McpTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec![
+                    "-y".to_string(),
+                    "@modelcontextprotocol/server-filesystem".to_string(),
+                    workspace.display().to_string(),
+                ],
+                env: HashMap::new(),
+            },
+            requires_confirmation: false,
+            timeout_secs: 60,
+        };
+
+        let handle = McpServerHandle::connect(&config)
+            .await
+            .expect("filesystem MCP server should connect over stdio");
+
+        assert!(
+            !handle.tools().is_empty(),
+            "filesystem server should expose at least one tool"
+        );
+
+        let list_tool = handle
+            .tools()
+            .iter()
+            .find(|t| t.name.contains("list_directory"))
+            .expect("filesystem server should expose a list_directory-style tool");
+
+        let outcome = handle
+            .call_tool(
+                &list_tool.name,
+                serde_json::json!({ "path": workspace.display().to_string() }),
+            )
+            .await;
+
+        assert!(outcome.success, "tool call failed: {:?}", outcome.error);
+        let rendered = serde_json::to_string(&outcome.result).unwrap();
+        assert!(
+            rendered.contains("hello.txt"),
+            "expected real directory listing to contain hello.txt, got: {rendered}"
+        );
+
+        handle.shutdown().await;
+    }
+
+    /// Proves the custom in-repo `mcp-calculator` server (built via
+    /// `cargo build --release -p mcp-calculator`) computes a real result instead of
+    /// the old hardcoded "42" stub.
+    #[tokio::test]
+    #[ignore]
+    async fn calculator_server_evaluates_real_expression() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("crates/ghost-link should be two levels below the repo root");
+        let binary = repo_root
+            .join("target")
+            .join("release")
+            .join(if cfg!(windows) {
+                "mcp-calculator.exe"
+            } else {
+                "mcp-calculator"
+            });
+        assert!(
+            binary.exists(),
+            "run `cargo build --release -p mcp-calculator` first ({})",
+            binary.display()
+        );
+
+        let config = McpServerConfig {
+            name: "calculator".to_string(),
+            slot: "calculator".to_string(),
+            enabled: true,
+            transport: McpTransport::Stdio {
+                command: binary.display().to_string(),
+                args: vec![],
+                env: HashMap::new(),
+            },
+            requires_confirmation: false,
+            timeout_secs: 30,
+        };
+
+        let handle = McpServerHandle::connect(&config)
+            .await
+            .expect("calculator MCP server should connect over stdio");
+
+        let outcome = handle
+            .call_tool("calculate", serde_json::json!({ "expression": "17 * 23" }))
+            .await;
+
+        assert!(outcome.success, "tool call failed: {:?}", outcome.error);
+        let rendered = serde_json::to_string(&outcome.result).unwrap();
+        assert!(
+            rendered.contains("391"),
+            "expected real evaluation of 17*23=391, got: {rendered}"
+        );
+
+        handle.shutdown().await;
+    }
+
+    /// Proves the official sequential-thinking reference server (a standalone
+    /// addition with no legacy "slot", addressed by server name — see
+    /// `McpRegistry::server_for_slot`/`tool_schemas_for_server`) connects and
+    /// exposes its `sequentialthinking` tool for real.
+    #[tokio::test]
+    #[ignore]
+    async fn sequential_thinking_server_exposes_real_tool() {
+        let config = McpServerConfig {
+            name: "sequential-thinking".to_string(),
+            slot: "".to_string(),
+            enabled: true,
+            transport: McpTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec![
+                    "-y".to_string(),
+                    "@modelcontextprotocol/server-sequential-thinking".to_string(),
+                ],
+                env: HashMap::new(),
+            },
+            requires_confirmation: false,
+            timeout_secs: 60,
+        };
+
+        let handle = McpServerHandle::connect(&config)
+            .await
+            .expect("sequential-thinking MCP server should connect over stdio");
+
+        assert!(
+            !handle.tools().is_empty(),
+            "sequential-thinking server should expose at least one tool"
+        );
+        assert!(handle.tools().iter().any(|t| t.name.contains("thinking")));
+
+        let tool_name = handle.tools()[0].name.clone();
+        let outcome = handle
+            .call_tool(
+                &tool_name,
+                serde_json::json!({
+                    "thought": "Step 1: verify the MCP pipe works end to end.",
+                    "thoughtNumber": 1,
+                    "totalThoughts": 1,
+                    "nextThoughtNeeded": false
+                }),
+            )
+            .await;
+
+        assert!(outcome.success, "tool call failed: {:?}", outcome.error);
+
+        handle.shutdown().await;
+    }
+
+    /// Proves the custom in-repo `mcp-vision` server (built via
+    /// `cargo build --release -p mcp-vision`) connects, exposes `analyze_image`,
+    /// and — since this environment has no vision model pulled/running — reports
+    /// a real, specific connection failure rather than crashing or hanging.
+    #[tokio::test]
+    #[ignore]
+    async fn vision_server_reports_real_ollama_error_when_unreachable() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("crates/ghost-link should be two levels below the repo root");
+        let binary = repo_root
+            .join("target")
+            .join("release")
+            .join(if cfg!(windows) {
+                "mcp-vision.exe"
+            } else {
+                "mcp-vision"
+            });
+        assert!(
+            binary.exists(),
+            "run `cargo build --release -p mcp-vision` first ({})",
+            binary.display()
+        );
+
+        let config = McpServerConfig {
+            name: "vision".to_string(),
+            slot: "".to_string(),
+            enabled: true,
+            transport: McpTransport::Stdio {
+                command: binary.display().to_string(),
+                args: vec![],
+                env: HashMap::from([(
+                    "OLLAMA_URL".to_string(),
+                    "http://127.0.0.1:1".to_string(), // deliberately unreachable
+                )]),
+            },
+            requires_confirmation: false,
+            timeout_secs: 30,
+        };
+
+        let handle = McpServerHandle::connect(&config)
+            .await
+            .expect("vision MCP server should connect over stdio");
+
+        assert!(handle.tools().iter().any(|t| t.name == "analyze_image"));
+
+        let image_path = repo_root.join("mcp_workspace").join("hello.txt");
+        let outcome = handle
+            .call_tool(
+                "analyze_image",
+                serde_json::json!({ "image_path": image_path.display().to_string(), "prompt": "describe" }),
+            )
+            .await;
+
+        assert!(outcome.success);
+        let rendered = serde_json::to_string(&outcome.result).unwrap();
+        assert!(
+            rendered.contains("failed to reach Ollama"),
+            "expected a real connection-failure message, got: {rendered}"
+        );
+
+        handle.shutdown().await;
+    }
+
+    /// Proves a Python-distributed (`uvx`-launched) MCP server also works through the
+    /// same Windows `cmd /C` shim-resolution path used for `npx`-launched servers.
+    #[tokio::test]
+    #[ignore]
+    async fn fetch_server_retrieves_real_content() {
+        let config = McpServerConfig {
+            name: "fetch".to_string(),
+            slot: "api_call".to_string(),
+            enabled: true,
+            transport: McpTransport::Stdio {
+                command: "uvx".to_string(),
+                args: vec!["mcp-server-fetch".to_string()],
+                env: HashMap::new(),
+            },
+            requires_confirmation: false,
+            timeout_secs: 60,
+        };
+
+        let handle = McpServerHandle::connect(&config)
+            .await
+            .expect("fetch MCP server should connect over stdio");
+
+        assert!(!handle.tools().is_empty());
+        let fetch_tool = &handle.tools()[0];
+
+        let outcome = handle
+            .call_tool(
+                &fetch_tool.name,
+                serde_json::json!({ "url": "https://example.com" }),
+            )
+            .await;
+
+        assert!(outcome.success, "tool call failed: {:?}", outcome.error);
+        let rendered = serde_json::to_string(&outcome.result).unwrap();
+        assert!(
+            rendered.to_lowercase().contains("example domain"),
+            "expected real fetched content from example.com, got: {rendered}"
+        );
+
+        handle.shutdown().await;
+    }
+}

--- a/crates/ghost-link/src/mcp/registry.rs
+++ b/crates/ghost-link/src/mcp/registry.rs
@@ -1,0 +1,173 @@
+//! Aggregates every configured MCP server behind one registry held in `BackendState`.
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::RwLock;
+
+use super::client::{McpServerHandle, McpToolSchema, ToolCallOutcome};
+use super::config::McpConfigManager;
+
+pub struct McpRegistry {
+    config_manager: McpConfigManager,
+    servers: RwLock<HashMap<String, McpServerHandle>>,
+}
+
+impl std::fmt::Debug for McpRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpRegistry").finish_non_exhaustive()
+    }
+}
+
+/// One row for the GUI's MCP server list — every server *configured* in
+/// `mcp_servers.toml`, not just the ones currently connected, so a user can see
+/// (and enable) a disabled server from the UI.
+#[derive(Debug, Clone, Serialize)]
+pub struct McpServerStatus {
+    pub name: String,
+    pub slot: String,
+    pub enabled: bool,
+    pub connected: bool,
+    pub tool_count: usize,
+    pub requires_confirmation: bool,
+}
+
+impl McpRegistry {
+    pub fn new(config_manager: McpConfigManager) -> Self {
+        Self {
+            config_manager,
+            servers: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Connects every `enabled` server from `mcp_servers.toml`. A server that fails
+    /// to spawn or initialize is logged and skipped — one misconfigured server must
+    /// never prevent chat (or the rest of the registry) from working.
+    pub async fn connect_enabled(&self) {
+        let configs = match self.config_manager.load() {
+            Ok(configs) => configs,
+            Err(err) => {
+                tracing::warn!("mcp: failed to load mcp_servers.toml: {err}");
+                return;
+            }
+        };
+
+        for config in configs.into_iter().filter(|c| c.enabled) {
+            match McpServerHandle::connect(&config).await {
+                Ok(handle) => {
+                    tracing::info!(
+                        "mcp: connected server '{}' ({} tools)",
+                        config.name,
+                        handle.tools().len()
+                    );
+                    self.servers
+                        .write()
+                        .await
+                        .insert(config.name.clone(), handle);
+                }
+                Err(err) => {
+                    tracing::warn!("mcp: failed to connect server '{}': {err}", config.name);
+                }
+            }
+        }
+    }
+
+    /// Finds the server bound to a legacy chat "tool slot" (web_search,
+    /// calculator, ...). Standalone servers (sequential-thinking, Docker gateway)
+    /// have an empty slot and are addressed directly by name instead — see
+    /// `tool_schemas_for_server`.
+    pub async fn server_for_slot(&self, slot: &str) -> Option<String> {
+        self.servers
+            .read()
+            .await
+            .values()
+            .find(|handle| handle.slot() == slot)
+            .map(|handle| handle.name().to_string())
+    }
+
+    pub async fn tool_schemas_for_server(&self, server_name: &str) -> Vec<McpToolSchema> {
+        self.servers
+            .read()
+            .await
+            .get(server_name)
+            .map(|handle| handle.tools().to_vec())
+            .unwrap_or_default()
+    }
+
+    /// Every server configured in `mcp_servers.toml`, merged with live
+    /// connection status — used to render the GUI's MCP server list.
+    pub async fn list_all_servers(&self) -> Result<Vec<McpServerStatus>, String> {
+        let configs = self.config_manager.load()?;
+        let connected = self.servers.read().await;
+
+        Ok(configs
+            .into_iter()
+            .map(|config| {
+                let live = connected.get(&config.name);
+                McpServerStatus {
+                    name: config.name,
+                    slot: config.slot,
+                    enabled: config.enabled,
+                    connected: live.is_some(),
+                    tool_count: live.map(|handle| handle.tools().len()).unwrap_or(0),
+                    requires_confirmation: config.requires_confirmation,
+                }
+            })
+            .collect())
+    }
+
+    /// Toggles a server's `enabled` flag in `mcp_servers.toml` and takes effect
+    /// immediately: connects it now if enabling, or tears it down now if
+    /// disabling — so the GUI doesn't need a Ghostlink restart to see the change.
+    pub async fn set_enabled(&self, name: &str, enabled: bool) -> Result<(), String> {
+        self.config_manager.set_enabled(name, enabled)?;
+
+        if enabled {
+            let configs = self.config_manager.load()?;
+            let config = configs
+                .into_iter()
+                .find(|c| c.name == name)
+                .ok_or_else(|| format!("no MCP server named '{name}'"))?;
+            let handle = McpServerHandle::connect(&config).await?;
+            tracing::info!(
+                "mcp: connected server '{}' ({} tools)",
+                name,
+                handle.tools().len()
+            );
+            self.servers.write().await.insert(name.to_string(), handle);
+        } else if let Some(handle) = self.servers.write().await.remove(name) {
+            handle.shutdown().await;
+            tracing::info!("mcp: disconnected server '{name}'");
+        }
+
+        Ok(())
+    }
+
+    pub async fn call_tool(
+        &self,
+        server_name: &str,
+        tool_name: &str,
+        args: Value,
+    ) -> Option<ToolCallOutcome> {
+        let servers = self.servers.read().await;
+        let handle = servers.get(server_name)?;
+        Some(handle.call_tool(tool_name, args).await)
+    }
+
+    pub async fn requires_confirmation(&self, server_name: &str) -> bool {
+        self.servers
+            .read()
+            .await
+            .get(server_name)
+            .map(|handle| handle.requires_confirmation())
+            .unwrap_or(false)
+    }
+
+    pub async fn shutdown_all(&self) {
+        let mut servers = self.servers.write().await;
+        for (_, handle) in servers.drain() {
+            handle.shutdown().await;
+        }
+    }
+}

--- a/crates/ghost-link/src/mcp/toolcall.rs
+++ b/crates/ghost-link/src/mcp/toolcall.rs
@@ -1,0 +1,172 @@
+//! Model-driven tool-calling: schema injection into the prompt, ReAct-style parsing
+//! of the model's tool-call intent, and the observation text fed back on the next
+//! turn. Works with any local model (no reliance on a model-specific tool-calling
+//! chat template) since Ghostlink runs arbitrary GGUF/Ollama models.
+
+use serde_json::Value;
+
+use super::client::McpToolSchema;
+
+/// Hard cap on tool round-trips per user turn, so a model that keeps requesting
+/// tools (or misunderstands the marker) can't loop forever.
+pub const MAX_TOOL_ITERATIONS: usize = 3;
+
+const MARKER: &str = "TOOL_CALL:";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedToolCall {
+    pub tool: String,
+    pub args: Value,
+}
+
+/// Builds the instructions block describing every enabled tool, meant to be
+/// prefixed onto the system/user prompt actually sent to the model. Returns an
+/// empty string when there are no tools to offer (so callers can skip injection
+/// entirely rather than sending a pointless empty header).
+pub fn build_tool_instructions(tools: &[McpToolSchema]) -> String {
+    if tools.is_empty() {
+        return String::new();
+    }
+
+    let mut block = String::from(
+        "You have access to tools. To call one, reply with ONLY a single line of the \
+         EXACT form below (not a function-call-looking expression, not any other syntax):\n\
+         TOOL_CALL: {\"tool\": \"<tool_name>\", \"args\": { ... }}\n\
+         Nothing else on that line — no other text before or after it.\n\n\
+         Example:\n\
+         User: What is 9 times 6?\n\
+         Assistant: TOOL_CALL: {\"tool\": \"calculate\", \"args\": {\"expression\": \"9 * 6\"}}\n\
+         (the tool result is then given to you as \"Observation: ...\")\n\
+         Assistant: 9 times 6 is 54.\n\n\
+         Rules:\n\
+         - As soon as you receive an Observation, write your final answer in plain text \
+         using that result. Do not call the same tool again for the same question.\n\
+         - If no tool is needed, just answer normally in plain text.\n\n\
+         Available tools:\n",
+    );
+
+    for tool in tools {
+        let description = if tool.description.is_empty() {
+            "(no description)"
+        } else {
+            tool.description.as_str()
+        };
+        block.push_str(&format!(
+            "- {} — {}\n  input schema: {}\n",
+            tool.name, description, tool.input_schema
+        ));
+    }
+
+    block
+}
+
+/// Parses a `TOOL_CALL: {...}` marker out of the model's generated text. Tracks
+/// brace depth (rather than trying to `serde_json::from_str` the whole remainder)
+/// so trailing commentary after the JSON object doesn't break parsing.
+pub fn extract_tool_call(text: &str) -> Option<ParsedToolCall> {
+    let marker_pos = text.find(MARKER)?;
+    let after_marker = &text[marker_pos + MARKER.len()..];
+    let json_start_rel = after_marker.find('{')?;
+    let json_region = &after_marker[json_start_rel..];
+
+    let mut depth = 0i32;
+    let mut end = None;
+    for (i, ch) in json_region.char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = Some(i + ch.len_utf8());
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let end = end?;
+    let json_str = &json_region[..end];
+
+    let parsed: Value = serde_json::from_str(json_str).ok()?;
+    let tool = parsed.get("tool")?.as_str()?.to_string();
+    let args = parsed.get("args").cloned().unwrap_or(Value::Null);
+    Some(ParsedToolCall { tool, args })
+}
+
+/// Formats a tool result as an "Observation" turn appended to the running prompt
+/// before asking the model to continue.
+pub fn format_observation(tool: &str, result_json: &Value) -> String {
+    format!("\nObservation ({tool}): {result_json}\n")
+}
+
+/// Formats a denial (confirmation gate rejected by the user) as an observation.
+pub fn format_denial(tool: &str) -> String {
+    format!("\nObservation ({tool}): the user denied permission to run this tool.\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_marker_returns_none() {
+        assert_eq!(extract_tool_call("just a normal answer"), None);
+    }
+
+    #[test]
+    fn parses_simple_call() {
+        let text = r#"TOOL_CALL: {"tool": "calculate", "args": {"expression": "2+2"}}"#;
+        let call = extract_tool_call(text).unwrap();
+        assert_eq!(call.tool, "calculate");
+        assert_eq!(call.args, serde_json::json!({"expression": "2+2"}));
+    }
+
+    #[test]
+    fn tolerates_leading_and_trailing_commentary() {
+        let text = "Sure, let me check that.\nTOOL_CALL: {\"tool\": \"read_text_file\", \"args\": {\"path\": \"a.txt\"}}\nI'll wait for the result.";
+        let call = extract_tool_call(text).unwrap();
+        assert_eq!(call.tool, "read_text_file");
+        assert_eq!(call.args, serde_json::json!({"path": "a.txt"}));
+    }
+
+    #[test]
+    fn handles_nested_braces_in_args() {
+        let text = r#"TOOL_CALL: {"tool": "api_call", "args": {"body": {"nested": {"a": 1}}}}"#;
+        let call = extract_tool_call(text).unwrap();
+        assert_eq!(call.tool, "api_call");
+        assert_eq!(call.args, serde_json::json!({"body": {"nested": {"a": 1}}}));
+    }
+
+    #[test]
+    fn missing_tool_field_returns_none() {
+        let text = r#"TOOL_CALL: {"args": {}}"#;
+        assert_eq!(extract_tool_call(text), None);
+    }
+
+    #[test]
+    fn no_args_defaults_to_null() {
+        let text = r#"TOOL_CALL: {"tool": "list_allowed_directories"}"#;
+        let call = extract_tool_call(text).unwrap();
+        assert_eq!(call.tool, "list_allowed_directories");
+        assert_eq!(call.args, Value::Null);
+    }
+
+    #[test]
+    fn instructions_block_is_empty_for_no_tools() {
+        assert_eq!(build_tool_instructions(&[]), "");
+    }
+
+    #[test]
+    fn instructions_block_lists_each_tool() {
+        let tools = vec![McpToolSchema {
+            server: "calculator".to_string(),
+            name: "calculate".to_string(),
+            description: "Evaluate a math expression".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }];
+        let block = build_tool_instructions(&tools);
+        assert!(block.contains("TOOL_CALL:"));
+        assert!(block.contains("calculate"));
+        assert!(block.contains("Evaluate a math expression"));
+    }
+}

--- a/crates/ghost-link/src/ollama.rs
+++ b/crates/ghost-link/src/ollama.rs
@@ -49,6 +49,11 @@ pub struct OllamaModelsResponse {
 pub struct ChatMessage {
     pub role: String,
     pub content: String,
+    /// Only ever populated by Ollama on an incoming response (when the model
+    /// natively supports tool-calling and decides to call one) — never set on
+    /// an outgoing message we build ourselves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<Value>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +64,11 @@ pub struct ChatRequest {
     pub stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<OllamaOptions>,
+    /// OpenAI-style function-tool definitions:
+    /// `{"type": "function", "function": {"name", "description", "parameters"}}`.
+    /// Only sent to models that declare tool-calling support in their template.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Value>>,
 }
 
 /// Sampling parameters accepted by Ollama's `/api/generate` and `/api/chat`
@@ -330,6 +340,7 @@ impl OllamaClient {
 
     /// Chat with Ollama (non-streaming)
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn chat(
         &self,
         model: &str,
@@ -339,6 +350,7 @@ impl OllamaClient {
         top_k: Option<usize>,
         repeat_penalty: Option<f32>,
         max_tokens: Option<usize>,
+        tools: Option<Vec<Value>>,
     ) -> Result<ChatResponse, Box<dyn Error>> {
         let request = ChatRequest {
             model: model.to_string(),
@@ -351,6 +363,7 @@ impl OllamaClient {
                 repeat_penalty,
                 num_predict: max_tokens,
             }),
+            tools,
         };
 
         let resp = self
@@ -390,6 +403,7 @@ impl OllamaClient {
                 repeat_penalty,
                 num_predict: max_tokens,
             }),
+            tools: None,
         };
 
         let resp = self
@@ -755,6 +769,7 @@ mod tests {
                 repeat_penalty: Some(1.2),
                 num_predict: Some(256),
             }),
+            tools: None,
         };
         let value = serde_json::to_value(&request).expect("serialize ChatRequest");
         assert!(

--- a/crates/mcp-calculator/Cargo.toml
+++ b/crates/mcp-calculator/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mcp-calculator"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Local stdio MCP server exposing a safe expression-evaluator 'calculate' tool for Ghostlink chat's calculator tool slot."
+
+[dependencies]
+rmcp = { version = "2", features = ["transport-io", "schemars"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+evalexpr = "13"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+anyhow = "1"

--- a/crates/mcp-calculator/src/main.rs
+++ b/crates/mcp-calculator/src/main.rs
@@ -1,0 +1,50 @@
+//! Minimal stdio MCP server exposing one `calculate` tool, backed by `evalexpr`'s
+//! sandboxed expression evaluator (no shell, no arbitrary code execution) — this is
+//! the real backend for Ghostlink chat's `calculator` tool slot, replacing the old
+//! hardcoded "42 (Calculated via Rust built-in tool)" stub.
+
+use rmcp::{
+    handler::server::wrapper::Parameters, schemars, tool, tool_router, transport::stdio, ServiceExt,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct CalculateRequest {
+    #[schemars(description = "A math expression to evaluate, e.g. \"17 * 23\" or \"(4 + 5) / 3\"")]
+    expression: String,
+}
+
+#[derive(Debug, Clone)]
+struct Calculator;
+
+#[tool_router(server_handler)]
+impl Calculator {
+    #[tool(description = "Evaluate a math expression and return the numeric result")]
+    fn calculate(
+        &self,
+        Parameters(CalculateRequest { expression }): Parameters<CalculateRequest>,
+    ) -> String {
+        match evalexpr::eval(&expression) {
+            Ok(value) => value.to_string(),
+            Err(err) => format!("error: {err}"),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into()),
+        )
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    let service = Calculator.serve(stdio()).await.inspect_err(|err| {
+        tracing::error!("mcp-calculator serving error: {err:?}");
+    })?;
+
+    service.waiting().await?;
+    Ok(())
+}

--- a/crates/mcp-vision/Cargo.toml
+++ b/crates/mcp-vision/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mcp-vision"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Local stdio MCP server exposing an analyze_image tool backed by a local Ollama vision model, for Ghostlink chat's vision tool."
+
+[dependencies]
+rmcp = { version = "2", features = ["transport-io", "schemars"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+base64 = "0.22"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+anyhow = "1"

--- a/crates/mcp-vision/src/main.rs
+++ b/crates/mcp-vision/src/main.rs
@@ -1,0 +1,95 @@
+//! Minimal stdio MCP server exposing one `analyze_image` tool backed by a local
+//! Ollama vision model (llava/moondream/...) — the real backend for Ghostlink
+//! chat's "vision" addition. Stays local-model-first: no cloud vision API calls.
+
+use base64::Engine;
+use rmcp::{
+    handler::server::wrapper::Parameters, schemars, tool, tool_router, transport::stdio, ServiceExt,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct AnalyzeImageRequest {
+    #[schemars(description = "Path to a local image file (png/jpg/webp) to analyze")]
+    image_path: String,
+    #[schemars(
+        description = "What to ask about the image, e.g. \"describe this image\" or \"read the text in this image\""
+    )]
+    prompt: String,
+}
+
+#[derive(Debug, Clone)]
+struct Vision {
+    ollama_url: String,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl Vision {
+    fn new() -> Self {
+        Self {
+            ollama_url: std::env::var("OLLAMA_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string()),
+            model: std::env::var("OLLAMA_VISION_MODEL").unwrap_or_else(|_| "llava".to_string()),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[tool_router(server_handler)]
+impl Vision {
+    #[tool(
+        description = "Analyze a local image with a vision-capable local model and answer a question about it"
+    )]
+    async fn analyze_image(
+        &self,
+        Parameters(AnalyzeImageRequest { image_path, prompt }): Parameters<AnalyzeImageRequest>,
+    ) -> String {
+        let bytes = match std::fs::read(&image_path) {
+            Ok(b) => b,
+            Err(err) => return format!("error: failed to read image '{image_path}': {err}"),
+        };
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+
+        let payload = serde_json::json!({
+            "model": self.model,
+            "prompt": prompt,
+            "images": [encoded],
+            "stream": false,
+        });
+
+        let url = format!("{}/api/generate", self.ollama_url.trim_end_matches('/'));
+        match self.client.post(&url).json(&payload).send().await {
+            Ok(resp) => match resp.json::<serde_json::Value>().await {
+                Ok(body) => body
+                    .get("response")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("error: no 'response' field in Ollama's reply")
+                    .to_string(),
+                Err(err) => format!("error: invalid JSON from Ollama: {err}"),
+            },
+            Err(err) => format!(
+                "error: failed to reach Ollama at {url}: {err} (is `ollama serve` running, and has `{}` been pulled?)",
+                self.model
+            ),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into()),
+        )
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    let service = Vision::new().serve(stdio()).await.inspect_err(|err| {
+        tracing::error!("mcp-vision serving error: {err:?}");
+    })?;
+
+    service.waiting().await?;
+    Ok(())
+}

--- a/ghostlink_gui_modern/src/App.test.tsx
+++ b/ghostlink_gui_modern/src/App.test.tsx
@@ -11,6 +11,7 @@ vi.mock('./api', () => ({
     getSessions: vi.fn().mockResolvedValue({ sessions: [] }),
     listSessions: vi.fn().mockResolvedValue({ sessions: [] }),
     getWorkers: vi.fn().mockResolvedValue({ workers: [] }),
+    listMcpServers: vi.fn().mockResolvedValue({ servers: [] }),
   })),
 }));
 

--- a/ghostlink_gui_modern/src/App.tsx
+++ b/ghostlink_gui_modern/src/App.tsx
@@ -13,6 +13,7 @@ import {
   Cpu,
   Zap,
   Wifi,
+  Plug,
 } from 'lucide-react';
 import { useAppStore } from './store';
 import { GhostlinkAPI } from './api';
@@ -23,6 +24,7 @@ import { SessionsTab } from './components/SessionsTab';
 import { WorkersTab } from './components/WorkersTab';
 import { SecurityTab } from './components/SecurityTab';
 import { SettingsTab } from './components/SettingsTab';
+import { McpTab } from './components/McpTab';
 import { ErrorBoundary, OfflineBanner, useOnlineStatus } from './components/ErrorBoundary';
 import { resolveApiBase } from './config';
 
@@ -32,6 +34,7 @@ const tabs = [
   { label: 'Metrics', icon: BarChart3, id: 2 },
   { label: 'Sessions', icon: Clock, id: 3 },
   { label: 'Workers', icon: Network, id: 4 },
+  { label: 'MCP', icon: Plug, id: 7 },
   { label: 'Security', icon: Shield, id: 5 },
   { label: 'Settings', icon: Settings, id: 6 },
 ];
@@ -229,6 +232,8 @@ function App() {
         return <SecurityTab api={api} />;
       case 6:
         return <SettingsTab api={api} />;
+      case 7:
+        return <McpTab api={api} />;
       default:
         return null;
     }

--- a/ghostlink_gui_modern/src/api.ts
+++ b/ghostlink_gui_modern/src/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { Model, Metric, Session, Worker, Settings } from './store';
+import { Model, Metric, Session, Worker, Settings, McpServer } from './store';
 
 type CircuitState = 'closed' | 'open' | 'half-open';
 
@@ -273,6 +273,49 @@ export class GhostlinkAPI {
         const response = await this.http.post('/api/inference/chat', payload);
         return { success: true, data: response.data };
       }
+    } catch (error: any) {
+      return { success: false, error: error.response?.data?.error || error.message };
+    }
+  }
+
+  /** Approves or denies a tool call the model requested that needed confirmation
+   *  first (see the `pending_tool_call` field `sendMessage` can return) — resumes
+   *  the same chat turn on the backend. */
+  async confirmToolCall(requestId: string, approve: boolean) {
+    try {
+      const response = await this.http.post('/api/inference/chat/tool-confirm', {
+        request_id: requestId,
+        approve,
+      });
+      return { success: true, data: response.data };
+    } catch (error: any) {
+      return { success: false, error: error.response?.data?.error || error.message };
+    }
+  }
+
+  async listMcpServers(): Promise<{ servers: McpServer[]; error?: string }> {
+    try {
+      const response = await this.http.get('/api/mcp/servers');
+      return { servers: response.data.servers || [], error: response.data.error };
+    } catch (error: any) {
+      return { servers: [], error: error.response?.data?.error || error.message };
+    }
+  }
+
+  async toggleMcpServer(
+    name: string,
+    enabled: boolean
+  ): Promise<{ success: boolean; servers?: McpServer[]; error?: string }> {
+    try {
+      const response = await this.http.post(
+        `/api/mcp/servers/${encodeURIComponent(name)}/toggle`,
+        { enabled }
+      );
+      return {
+        success: response.data.success !== false,
+        servers: response.data.servers,
+        error: response.data.error,
+      };
     } catch (error: any) {
       return { success: false, error: error.response?.data?.error || error.message };
     }

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -23,9 +23,25 @@ import {
   FolderOpen,
   Trash2,
   Database,
+  Wrench,
+  ShieldAlert,
 } from 'lucide-react';
 import { useAppStore } from '../store';
 import { GhostlinkAPI } from '../api';
+
+interface ToolCallTrace {
+  tool: string;
+  server: string;
+  result: string;
+  success: boolean;
+}
+
+interface PendingToolCall {
+  request_id: string;
+  tool: string;
+  server: string;
+  args: unknown;
+}
 
 interface Message {
   role: 'user' | 'assistant';
@@ -33,6 +49,8 @@ interface Message {
   id: string;
   timestamp: string;
   model?: string;
+  toolCalls?: ToolCallTrace[];
+  pendingToolCall?: PendingToolCall;
 }
 
 interface Session {
@@ -63,19 +81,8 @@ interface Tool {
   enabled: boolean;
 }
 
-const AVAILABLE_TOOLS: Tool[] = [
-  { name: 'web_search', description: 'Search the web', enabled: false },
-  { name: 'calculator', description: 'Basic math', enabled: false },
-  { name: 'code_execution', description: 'Run Python', enabled: false },
-  { name: 'file_operations', description: 'File I/O', enabled: false },
-  { name: 'terminal', description: 'Shell access', enabled: false },
-  { name: 'database_query', description: 'SQL query', enabled: false },
-  { name: 'api_call', description: 'HTTP request', enabled: false },
-  { name: 'image_generation', description: 'AI images', enabled: false },
-];
-
 export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
-  const { currentModel, models, setCurrentModel } = useAppStore();
+  const { currentModel, models, setCurrentModel, mcpServers, setMcpServers } = useAppStore();
   const [messages, setMessages] = useState<Message[]>(loadMessages);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -93,9 +100,41 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const [showModelSelector, setShowModelSelector] = useState(false);
   const [showSessions, setShowSessions] = useState(false);
   const [sessionName, setSessionName] = useState(`Session ${new Date().toLocaleDateString()}`);
-  const [tools, setTools] = useState<Tool[]>(AVAILABLE_TOOLS);
+  const [tools, setTools] = useState<Tool[]>([]);
   const [sessions, setSessions] = useState<Session[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+
+  // One checkbox per legacy "tool slot" (calculator, file_operations, ...) that
+  // has a real MCP server configured for it — replaces the old hardcoded
+  // 8-fake-tool list with whatever `mcp_servers.toml` actually defines.
+  const availableTools: Tool[] = useMemo(() => {
+    const bySlot = new Map<string, Tool>();
+    mcpServers.forEach((s) => {
+      if (s.slot) {
+        bySlot.set(s.slot, {
+          name: s.slot,
+          description: s.connected ? s.name : `${s.name} (disconnected)`,
+          enabled: false,
+        });
+      }
+    });
+    return Array.from(bySlot.values());
+  }, [mcpServers]);
+
+  useEffect(() => {
+    setTools((prev) => {
+      const prevEnabled = new Map(prev.map((t) => [t.name, t.enabled]));
+      return availableTools.map((t) => ({ ...t, enabled: prevEnabled.get(t.name) ?? false }));
+    });
+  }, [availableTools]);
+
+  useEffect(() => {
+    api.listMcpServers().then((result) => {
+      if (!result.error) setMcpServers(result.servers);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const modelSelectorRef = useRef<HTMLDivElement>(null);
@@ -208,6 +247,11 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     setMessages((prev) => [...prev, { role: 'assistant', content: '', id: assistantId, timestamp: '', model: currentModel || undefined }]);
 
     const enabledTools = tools.filter((t) => t.enabled).map((t) => t.name);
+    // Tool calls, their real results, and any pending-confirmation card only ever
+    // arrive on the plain JSON response — the token-streaming SSE path only ever
+    // sends {token} chunks. So a turn with tools enabled skips streaming in
+    // exchange for seeing what actually happened.
+    const useStreaming = enabledTools.length === 0;
 
     const result = await api.sendMessage({
       message: messageText,
@@ -218,7 +262,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
       max_tokens: maxTokens,
       system_prompt: systemPrompt,
       mcp: { tools: enabledTools },
-      stream: true,
+      stream: useStreaming,
       model: currentModel === 'none' ? undefined : currentModel,
     }, (token: string) => {
       setMessages((prev) => prev.map(m =>
@@ -230,14 +274,44 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     setStreamingId(null);
 
     if (result.success) {
+      const data = result.data || {};
       setMessages((prev) => prev.map(m =>
         m.id === assistantId
-          ? { ...m, timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) }
+          ? {
+              ...m,
+              content: useStreaming ? m.content : (data.response ?? m.content),
+              toolCalls: data.tool_results,
+              pendingToolCall: data.pending_tool_call,
+              timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+            }
           : m
       ));
     } else {
       setMessages((prev) => prev.filter(m => m.id !== assistantId));
       setError(result.error || 'Failed to send message');
+    }
+  };
+
+  const handleConfirmToolCall = async (messageId: string, requestId: string, approve: boolean) => {
+    setConfirmingId(requestId);
+    const result = await api.confirmToolCall(requestId, approve);
+    setConfirmingId(null);
+
+    if (result.success) {
+      const data = result.data || {};
+      setMessages((prev) => prev.map(m =>
+        m.id === messageId
+          ? {
+              ...m,
+              content: data.response ?? m.content,
+              toolCalls: data.tool_results,
+              pendingToolCall: data.pending_tool_call,
+              timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+            }
+          : m
+      ));
+    } else {
+      setError(result.error || 'Failed to resolve tool call');
     }
   };
 
@@ -441,6 +515,61 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                             </span>
                             <span className="text-[10px] text-slate-500">{msg.timestamp}</span>
                         </div>
+
+                        {msg.toolCalls && msg.toolCalls.length > 0 && (
+                            <div className="flex flex-col gap-1 px-1 w-full">
+                                {msg.toolCalls.map((call, i) => (
+                                    <div
+                                        key={i}
+                                        className={`flex items-start gap-2 px-3 py-1.5 rounded-xl text-[11px] font-mono border ${
+                                            call.success
+                                                ? 'bg-slate-900/50 border-slate-800 text-slate-400'
+                                                : 'bg-red-950/30 border-red-900/50 text-red-400'
+                                        }`}
+                                    >
+                                        <Wrench size={12} className="mt-0.5 shrink-0" />
+                                        <span className="truncate">
+                                            <span className="font-bold">{call.tool}</span>
+                                            {call.server && <span className="text-slate-600"> @ {call.server}</span>}
+                                            {' → '}
+                                            <span className="break-all">{call.result}</span>
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+
+                        {msg.pendingToolCall && (
+                            <div className="flex flex-col gap-2 px-4 py-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 w-full max-w-md">
+                                <div className="flex items-center gap-2 text-amber-400 text-xs font-bold">
+                                    <ShieldAlert size={14} />
+                                    Approval needed
+                                </div>
+                                <p className="text-xs text-slate-300">
+                                    Run <span className="font-mono font-bold">{msg.pendingToolCall.tool}</span> on server{' '}
+                                    <span className="font-mono font-bold">{msg.pendingToolCall.server}</span>?
+                                </p>
+                                <pre className="text-[10px] text-slate-500 bg-slate-950/50 rounded-lg p-2 overflow-x-auto">
+                                    {JSON.stringify(msg.pendingToolCall.args, null, 2)}
+                                </pre>
+                                <div className="flex gap-2">
+                                    <button
+                                        onClick={() => handleConfirmToolCall(msg.id, msg.pendingToolCall!.request_id, true)}
+                                        disabled={confirmingId === msg.pendingToolCall.request_id}
+                                        className="flex-1 px-3 py-1.5 bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white text-xs font-bold rounded-lg transition"
+                                    >
+                                        Approve
+                                    </button>
+                                    <button
+                                        onClick={() => handleConfirmToolCall(msg.id, msg.pendingToolCall!.request_id, false)}
+                                        disabled={confirmingId === msg.pendingToolCall.request_id}
+                                        className="flex-1 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 disabled:opacity-50 text-slate-300 text-xs font-bold rounded-lg transition"
+                                    >
+                                        Deny
+                                    </button>
+                                </div>
+                            </div>
+                        )}
 
                         <div className={`px-4 py-3 rounded-2xl text-sm leading-relaxed ${
                             msg.role === 'user'

--- a/ghostlink_gui_modern/src/components/McpTab.tsx
+++ b/ghostlink_gui_modern/src/components/McpTab.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useEffect } from 'react';
+import { RefreshCw, Plug, ShieldAlert } from 'lucide-react';
+import { useAppStore } from '../store';
+import { GhostlinkAPI } from '../api';
+
+export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
+  const { mcpServers, setMcpServers } = useAppStore();
+  const [loading, setLoading] = useState(false);
+  const [toggling, setToggling] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setLoading(true);
+    const result = await api.listMcpServers();
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setError(null);
+      setMcpServers(result.servers);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, 10000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api]);
+
+  const handleToggle = async (name: string, enabled: boolean) => {
+    setToggling(name);
+    const result = await api.toggleMcpServer(name, enabled);
+    if (result.servers) {
+      setMcpServers(result.servers);
+    }
+    if (!result.success && result.error) {
+      setError(result.error);
+    }
+    setToggling(null);
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-slate-950">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-slate-900 sticky top-0 bg-slate-950/50 backdrop-blur-md z-10">
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-bold text-white">MCP Servers</h2>
+          <div className="px-2 py-0.5 bg-blue-600/20 text-blue-400 rounded text-[10px] font-bold uppercase tracking-wider">
+            {mcpServers.filter((s) => s.connected).length} / {mcpServers.length} connected
+          </div>
+        </div>
+        <button
+          onClick={refresh}
+          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition"
+        >
+          <RefreshCw size={18} className={loading ? 'animate-spin' : ''} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="max-w-4xl mx-auto">
+          {error && (
+            <div className="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-xl text-sm text-red-400">
+              {error}
+            </div>
+          )}
+
+          {mcpServers.length === 0 && !loading && (
+            <div className="text-center py-16 text-slate-500 text-sm">
+              No MCP servers configured. Add entries to{' '}
+              <code className="text-slate-400">mcp_servers.toml</code> and refresh.
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 gap-3">
+            {mcpServers.map((server) => (
+              <div
+                key={server.name}
+                className="bg-slate-900/50 border border-slate-800 rounded-2xl p-5 hover:border-slate-700 transition-all flex items-center gap-4"
+              >
+                <div
+                  className={`p-3 rounded-xl transition-colors ${
+                    server.connected ? 'bg-blue-600 text-white' : 'bg-slate-800 text-slate-500'
+                  }`}
+                >
+                  <Plug size={20} />
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h3 className="text-sm font-bold text-slate-100 truncate">{server.name}</h3>
+                    {server.slot && (
+                      <span className="px-1.5 py-0.5 bg-slate-800 text-slate-400 rounded text-[10px] font-mono">
+                        {server.slot}
+                      </span>
+                    )}
+                    {server.requires_confirmation && (
+                      <span
+                        className="flex items-center gap-1 px-1.5 py-0.5 bg-amber-500/10 text-amber-400 rounded text-[10px] font-bold uppercase tracking-wider"
+                        title="Tool calls to this server require your approval before they run"
+                      >
+                        <ShieldAlert size={10} /> confirm
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-slate-500 mt-0.5">
+                    {server.connected
+                      ? `${server.tool_count} tool${server.tool_count === 1 ? '' : 's'} available`
+                      : server.enabled
+                      ? 'Enabled but not connected'
+                      : 'Disabled'}
+                  </p>
+                </div>
+
+                <div
+                  className={`flex items-center gap-2 px-3 py-1 rounded-full text-[10px] font-bold ${
+                    server.connected
+                      ? 'bg-green-500/10 text-green-400'
+                      : server.enabled
+                      ? 'bg-amber-500/10 text-amber-400'
+                      : 'bg-slate-800 text-slate-500'
+                  }`}
+                >
+                  <div
+                    className={`w-1.5 h-1.5 rounded-full ${
+                      server.connected ? 'bg-green-400 animate-pulse' : 'bg-slate-600'
+                    }`}
+                  ></div>
+                  {server.connected ? 'Connected' : server.enabled ? 'Error' : 'Disabled'}
+                </div>
+
+                <button
+                  onClick={() => handleToggle(server.name, !server.enabled)}
+                  disabled={toggling === server.name}
+                  className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ${
+                    server.enabled ? 'bg-blue-600' : 'bg-slate-700'
+                  } ${toggling === server.name ? 'opacity-50' : ''}`}
+                  title={server.enabled ? 'Disable server' : 'Enable server'}
+                >
+                  <div
+                    className={`absolute top-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
+                      server.enabled ? 'translate-x-5' : 'translate-x-0.5'
+                    }`}
+                  ></div>
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ghostlink_gui_modern/src/store.ts
+++ b/ghostlink_gui_modern/src/store.ts
@@ -87,6 +87,15 @@ export interface BackendStatus {
   temperature: number | null;
 }
 
+export interface McpServer {
+  name: string;
+  slot: string;
+  enabled: boolean;
+  connected: boolean;
+  tool_count: number;
+  requires_confirmation: boolean;
+}
+
 interface AppState {
   apiBase: string;
   backendOnline: boolean;
@@ -101,7 +110,8 @@ interface AppState {
   backendStatus: BackendStatus | null;
   selectedModel: string | null;
   activeTab: number;
-  
+  mcpServers: McpServer[];
+
   setApiBase: (base: string) => void;
   setBackendOnline: (online: boolean) => void;
   setCurrentModel: (model: string) => void;
@@ -115,6 +125,7 @@ interface AppState {
   setBackendStatus: (status: BackendStatus | null) => void;
   setSelectedModel: (model: string | null) => void;
   setActiveTab: (tab: number) => void;
+  setMcpServers: (servers: McpServer[]) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -131,7 +142,8 @@ export const useAppStore = create<AppState>((set) => ({
   backendStatus: null,
   selectedModel: null,
   activeTab: 0,
-  
+  mcpServers: [],
+
   setApiBase: (base) => set({ apiBase: base }),
   setBackendOnline: (online) => set({ backendOnline: online }),
   setCurrentModel: (model) => set({ currentModel: model }),
@@ -145,4 +157,5 @@ export const useAppStore = create<AppState>((set) => ({
   setBackendStatus: (backendStatus) => set({ backendStatus }),
   setSelectedModel: (model) => set({ selectedModel: model }),
   setActiveTab: (tab) => set({ activeTab: tab }),
+  setMcpServers: (servers) => set({ mcpServers: servers }),
 }));

--- a/mcp_servers.example.toml
+++ b/mcp_servers.example.toml
@@ -1,0 +1,160 @@
+[[mcp_servers]]
+name = "filesystem"
+slot = "file_operations"
+enabled = true
+transport = "stdio"
+command = "npx"
+args = [
+    "-y",
+    "@modelcontextprotocol/server-filesystem",
+    "./mcp_workspace",
+]
+requires_confirmation = false
+timeout_secs = 30
+
+[mcp_servers.env]
+
+[[mcp_servers]]
+name = "fetch"
+slot = "api_call"
+enabled = true
+transport = "stdio"
+command = "uvx"
+args = ["mcp-server-fetch"]
+requires_confirmation = false
+timeout_secs = 30
+
+[mcp_servers.env]
+
+[[mcp_servers]]
+name = "calculator"
+slot = "calculator"
+enabled = true
+transport = "stdio"
+command = "target/release/mcp-calculator.exe"
+args = []
+requires_confirmation = false
+timeout_secs = 30
+
+[mcp_servers.env]
+
+[[mcp_servers]]
+name = "sqlite"
+slot = "database_query"
+enabled = true
+transport = "stdio"
+command = "uvx"
+args = [
+    "mcp-server-sqlite",
+    "--db-path",
+    "./mcp_workspace/ghostlink.db",
+]
+requires_confirmation = false
+timeout_secs = 30
+
+[mcp_servers.env]
+
+[[mcp_servers]]
+name = "brave-search"
+slot = "web_search"
+enabled = false
+transport = "stdio"
+command = "npx"
+args = [
+    "-y",
+    "@modelcontextprotocol/server-brave-search",
+]
+requires_confirmation = false
+timeout_secs = 30
+
+[mcp_servers.env]
+BRAVE_API_KEY = "${BRAVE_API_KEY}"
+
+[[mcp_servers]]
+name = "docker-code-execution"
+slot = "code_execution"
+enabled = false
+transport = "stdio"
+command = "docker"
+args = [
+    "mcp",
+    "gateway",
+    "run",
+]
+requires_confirmation = true
+timeout_secs = 30
+
+[mcp_servers.env]
+
+[[mcp_servers]]
+name = "docker-terminal"
+slot = "terminal"
+enabled = false
+transport = "stdio"
+command = "docker"
+args = [
+    "mcp",
+    "gateway",
+    "run",
+]
+requires_confirmation = true
+timeout_secs = 30
+
+[mcp_servers.env]
+
+[[mcp_servers]]
+name = "image-generation"
+slot = "image_generation"
+enabled = false
+transport = "stdio"
+command = "unconfigured"
+args = []
+requires_confirmation = false
+timeout_secs = 30
+
+[mcp_servers.env]
+
+# --- Standalone additions (no legacy tool slot; addressed by server name) ---
+
+[[mcp_servers]]
+name = "sequential-thinking"
+slot = ""
+enabled = true
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+requires_confirmation = false
+timeout_secs = 30
+
+[mcp_servers.env]
+
+[[mcp_servers]]
+name = "vision"
+slot = ""
+# Wraps Ghostlink's own local Ollama connection to call a vision-capable model
+# (llava, moondream, bakllava, ...) instead of adding a cloud dependency.
+# Disabled by default: enable once you've `ollama pull`ed a vision model.
+enabled = false
+transport = "stdio"
+command = "target/release/mcp-vision.exe"
+args = []
+requires_confirmation = false
+timeout_secs = 30
+
+[mcp_servers.env]
+OLLAMA_URL = "http://127.0.0.1:11434"
+OLLAMA_VISION_MODEL = "llava"
+
+[[mcp_servers]]
+name = "docker-mcp-gateway"
+slot = ""
+# Aggregates Docker MCP Toolkit's whole catalog behind one connection. Disabled
+# by default: requires Docker Desktop running.
+enabled = false
+transport = "stdio"
+command = "docker"
+args = ["mcp", "gateway", "run"]
+requires_confirmation = true
+timeout_secs = 30
+
+[mcp_servers.env]

--- a/mcp_workspace/README.md
+++ b/mcp_workspace/README.md
@@ -1,0 +1,10 @@
+# mcp_workspace
+
+Sandboxed root directory for the `filesystem` MCP server (see `mcp_servers.toml`).
+The `file_operations` chat tool can only read/write files inside this directory —
+that confinement is enforced by the `@modelcontextprotocol/server-filesystem`
+process itself (it's given this path as its only allowed directory), not just by
+convention.
+
+`ghostlink.db` (the `database_query` tool's SQLite database) is also created here
+at runtime and is gitignored.


### PR DESCRIPTION
## Summary

Ghostlink chat's "Tools & MCP" feature was entirely fake: the 8 tool checkboxes dispatched to a hardcoded `ToolDispatcher` that always returned canned strings (calculator always said "42"), with no real execution, no argument passing, and no model involvement in deciding to call a tool.

This replaces it with real [MCP](https://modelcontextprotocol.io) server integration end to end:

- A native Rust MCP client (`crates/ghost-link/src/mcp/`, built on the official `rmcp` SDK) that spawns real MCP servers over stdio, with a Windows `cmd /C` fix for `.cmd`-shim commands (`npx`/`uvx`) and real process-tree teardown.
- A model-driven, ReAct-style tool-calling loop that works with any local GGUF/Ollama model — the model decides whether/which tool to call, real arguments are extracted from its own output, results are fed back as an "Observation," capped at 3 round-trips per turn. Ollama models with native tool-calling support in their chat template use Ollama's `tools` API directly instead.
- A confirmation gate (`requires_confirmation` in config) for risky tools, with a `pending_tool_call` response and a `POST /api/inference/chat/tool-confirm` endpoint to resume the turn on approval/denial.
- Real backing servers for all 8 chat tool slots: `filesystem`, `fetch`, a new custom `mcp-calculator` crate (`evalexpr`-backed), and `sqlite` enabled by default; `brave-search` (needs an API key), Docker MCP Toolkit-routed `terminal`/`code_execution` (needs Docker Desktop — deliberately never a raw host-shell server), and `image_generation` (no backend chosen yet) ship disabled.
- Two standalone additions: the official `sequential-thinking` server, and a new custom `mcp-vision` crate wrapping a local Ollama vision model (local-model-first, no cloud dependency).
- A new MCP tab in the GUI (live server status, working enable/disable toggles) and real tool-call traces + confirmation cards in chat, replacing the hardcoded tool checkbox list.
- `mcp_servers.toml` follows the existing `ghostlink.toml`/`ghostlink.example.toml` pattern (gitignored, auto-bootstrapped from the checked-in `.example.toml` on first run).

## Scope note

Per `CONTRIBUTING.md`'s scope guidance: this is a single cohesive feature but it does cross runtime + GUI, since the fake tool stub existed on both sides and fixing one without the other would leave a half-real feature. Split into 3 commits (backend, frontend, docs) rather than a single monolith, and could be split into stacked PRs on request if preferred.

**Risk / rollback:** additive — no existing endpoints, config files, or GUI tabs were removed or renamed (the `/api/inference/chat` response shape gained new optional fields, `tool_results`/`tools_used`/`pending_tool_call`/`tool_access`, all additive). New MCP servers are opt-in via `mcp_servers.toml` and default to a safe subset (no raw shell/code-exec on host). Revert is a plain `git revert` of the 3 commits; no migrations or data changes involved.

## Validation

```bash
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
cargo audit
```
All clean (workspace now includes new `mcp-calculator` and `mcp-vision` crates). `cargo audit` reports only pre-existing unmaintained/unsound advisories on transitive deps, no actionable vulnerabilities.

```bash
cd ghostlink_gui_modern && npm run type-check && npx vitest run
```
Clean, 104/104 tests passing.

**Live-verified, not just unit-tested:**
- Real `filesystem`/`fetch`/`calculator`/`sqlite`/`sequential-thinking` servers connecting and executing for real (curl + browser).
- The full tool loop (parse → execute → feed back → final answer) against both a scripted mock model and a real loaded model (`gemma-4-E4B-it-Q4_K_M` via `llama-server`) — correct real arguments, real computed results, correct final answers for calculator and filesystem.
- The confirmation approve/deny round-trip end to end.
- The MCP tab's enable/disable toggle causing an immediate live reconnect, verified in the browser.
- Clean process teardown (no orphaned `node.exe`/`cmd.exe`) after graceful shutdown.

## Operational caveats

- Requires `npx`/`node` and `uvx`/`python` on `PATH` for the bundled servers, and Docker Desktop for `terminal`/`code_execution`. None are vendored — missing ones fail to connect (logged and skipped), not a crash.
- **Not live-verified in this sandbox** (noted per the pre-push checklist's platform-awareness guidance, not skipped silently):
  - Docker MCP Toolkit — no running Docker daemon available here.
  - Native Ollama tool-calling path — no Ollama instance with a tool-capable model pulled here. Shares the same synthetic-marker mechanism already proven live for the ReAct path.
  - A smaller model (`Llama-3.2-1B-Instruct-IQ3_M`) followed the tool-call format inconsistently during testing — a known limitation of ~1B-class models with structured-output prompting, not a bug in the mechanism.

## Test plan for reviewers

- [ ] Pull the branch, run `launch.bat` / `launch-native.ps1`, confirm no regression in the native launch path
- [ ] Open the GUI's new **MCP** tab, confirm the default servers show connected
- [ ] In Chat, enable `calculator`, ask a math question, confirm a real (non-"42") answer with a tool-call trace
- [ ] Toggle a server off/on in the MCP tab, confirm Chat's tool list updates without a restart
- [ ] If Docker Desktop is available: enable `docker-mcp-gateway`, confirm it connects and exposes its catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)