### PR TITLE
fix: real incremental streaming for chat and model pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,101 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.4.4] - 2026-07-24 (Real incremental streaming for chat and model pulls)
+
+Chat "streaming" and Ollama model-pull "streaming" both looked like streaming
+downstream but weren't upstream: the client-facing plumbing existed, but
+every path still waited for the entire backend response before relaying
+anything. Verified live against a real running `llama-server` throughout
+(a throwaway instance on a separate port, never touching the actual running
+server or its process — see Validation below).
+
+### ⚡ Performance / correctness
+
+- **`handle_gui_chat`'s SSE response was fake streaming.** It waited for
+  `run_tool_loop`/`generate_once` to fully finish generation (blocking on the
+  entire response, for both backends), *then* split the already-complete
+  text into word chunks and dripped them out over SSE. For a longer response,
+  a client saw zero output for the entire generation time, then everything
+  at once — the request explicitly asked for `stream: true` but got none of
+  the actual benefit (reduced time-to-first-token). Added
+  `NativeEngineClient::generate_chat_stream` (llama-server had no streaming
+  client method at all before this) and wired real streaming into
+  `handle_gui_chat` for the common case: `stream: true` with no MCP tools
+  enabled. Tool-calling requests still use the existing buffer-then-chunk
+  path — tool-call marker detection needs the complete text, so real-time
+  interleaving there is a separate, larger piece of work left for later
+  rather than rushed into this change.
+- **`ollama.rs`'s existing "streaming" methods buffered the whole response
+  first.** `generate_stream`/`chat_stream`/`stream_pull_progress` all called
+  `resp.bytes().await` — which waits for the entire HTTP body — before
+  processing any of it, then faked incremental delivery downstream via an
+  mpsc channel. Ghostlink itself never got any earlier data than a
+  non-streaming call would. `stream_pull_progress` is the one of the three
+  that's actually wired in and used (model download progress in the GUI),
+  which made this the more consequential half of the bug: a multi-minute
+  model pull would show a frozen progress bar for the entire download, then
+  jump straight to 100%. `generate_stream`/`chat_stream` are unwired dead
+  code today (confirmed via full-crate grep) but fixed for correctness and
+  in case they're wired in later. All three now use `bytes_stream()` with
+  explicit partial-line buffering across chunk boundaries (a network chunk
+  boundary rarely lines up with a JSON-line boundary).
+- Extracted `record_generation_metrics` (request counter, `inference_metrics`,
+  dashboard session record) out of `finish_chat_response` so the new
+  streaming path shares the exact same side effects instead of a second,
+  divergence-prone copy of this bookkeeping.
+- `reqwest`'s `stream` feature enabled in `ghost-link`'s `Cargo.toml` —
+  required for `bytes_stream()`; wasn't needed before since nothing actually
+  streamed incrementally.
+
+### ✅ Validation
+
+- Direct client-method test against the live `llama-server`: 10 chunks
+  arrived over 190ms (43ms, 54ms, 68ms, 80ms, 93ms, ...) — incremental
+  delivery, not one blob at the end.
+- Full HTTP path (`POST /api/inference/chat`, `stream: true`, no tools)
+  through a throwaway `ghost-link` instance on a separate port pointed at
+  the same live `llama-server`: 15 chunks arrived progressively from 0.27s
+  to 0.45s, correct generated text.
+- Regression-checked: non-streaming requests unchanged; streaming requests
+  with tools enabled still correctly fall back to the existing
+  buffer-then-chunk path.
+- Confirmed the live `ghost-link`/`llama-server` instances were completely
+  unaffected throughout (same `llama-server` PID before and after; the
+  Windows port-cleanup path (`taskkill /IM llama-server.exe`) that model
+  hot-swapping uses was checked and confirmed *not* reachable from plain
+  `serve` startup, only from explicit model-load/switch calls, before
+  running a second instance alongside the live one).
+- A found-and-fixed-before-shipping bug during this work: the new streaming
+  task's client-disconnect early-return bypassed releasing the
+  graceful-shutdown request-tracker counter (a real leak under concurrent
+  use). Restructured to a single exit point so the tracker release and
+  metrics recording can't be skipped by any of the three ways the stream
+  can end (normal completion, backend error, client disconnect).
+- `cargo build --workspace --all-targets`, `cargo clippy --workspace
+  --all-targets -- -D warnings` (zero warnings), `cargo fmt --all --check`,
+  `cargo test --workspace` (83+134+7+28+19, all passing) — checked 3x
+  consecutively for stability. Added one `#[ignore]`d test
+  (`generate_chat_stream_yields_incremental_chunks_against_live_server`,
+  run manually with `--ignored` against a live server) asserting more than
+  one chunk arrives, specifically to catch a regression back to buffering.
+
+### ⚠️ Operational caveats
+
+- Real streaming only covers the no-tools-enabled case for both backends.
+  Streaming *with* tool-calling enabled still uses the old buffer-then-chunk
+  behavior — implementing real-time streaming that also interleaves
+  tool-call detection mid-generation is a larger redesign, intentionally out
+  of scope here.
+- `generate_chat_stream`'s fallback-on-no-chat-template path (HTTP 400 from
+  the chat endpoint) degrades to the existing non-streaming `/completion`
+  call and presents the whole result as a single SSE chunk, rather than
+  duplicating a second incremental parser for llama.cpp's native
+  `/completion` streaming shape — an intentional scope boundary, not an
+  oversight.
+
+---
+
 ## [1.4.3] - 2026-07-24 (Correctness sweep, GPU offload fix, hardware-detection latency, flaky-test root cause)
 
 A broad correctness and performance pass across `ghostlink-core` and `ghost-link`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,12 +1873,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -1913,7 +1915,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -2924,6 +2926,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -43,7 +43,7 @@ futures = "0.3"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.5", features = ["cors"] }
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "stream"] }
 tokio-util = "0.7"
 tokio-stream = { version = "0.1", features = ["sync"] }
 

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -3921,6 +3921,76 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }
     }
 
+    /// Records a finished generation's metrics/session bookkeeping (request
+    /// counter, `inference_metrics`, dashboard session record) and returns
+    /// `(request_id, session_id, metrics_json)` for the caller's response body.
+    /// Extracted out of `finish_chat_response` so the real-streaming path
+    /// (`handle_gui_chat_stream`) can share the exact same side effects
+    /// instead of a second, divergence-prone copy of this bookkeeping.
+    fn record_generation_metrics(
+        state: &Arc<Mutex<BackendState>>,
+        current_model: &str,
+        latency_ms: f32,
+        tokens_out: u32,
+        tokens_per_sec: Option<f32>,
+        real_inference: bool,
+    ) -> (u64, String, serde_json::Value) {
+        let mut backend = lock_state(state);
+        backend.chat_requests = backend.chat_requests.saturating_add(1);
+        let request_seq = backend.chat_requests;
+
+        backend.last_latency_ms = latency_ms;
+        if let Some(tps) = tokens_per_sec {
+            backend.last_tokens_per_sec = tps;
+        }
+        backend
+            .inference_metrics
+            .record(latency_ms, tokens_out, tokens_per_sec, real_inference);
+        let snap = backend.inference_metrics.snapshot();
+
+        let latency_u = latency_ms.round() as u32;
+        let throughput_u = tokens_per_sec.unwrap_or(0.0).round().max(0.0) as usize;
+
+        let maybe_session = backend.sessions.first_mut();
+        let session_id = if let Some(session) = maybe_session {
+            session.tokens = session.tokens.saturating_add(tokens_out as usize);
+            session.throughput = throughput_u;
+            session.latency = latency_u;
+            session.model = current_model.to_string();
+            session.status = if real_inference {
+                "Running".to_string()
+            } else {
+                "Degraded".to_string()
+            };
+            session.id.clone()
+        } else {
+            let session_id = "sess_local_001".to_string();
+            backend.sessions.push(SessionRecord {
+                id: session_id.clone(),
+                model: current_model.to_string(),
+                status: if real_inference {
+                    "Running".to_string()
+                } else {
+                    "Degraded".to_string()
+                },
+                throughput: throughput_u,
+                latency: latency_u,
+                tokens: tokens_out as usize,
+            });
+            session_id
+        };
+
+        let metrics_json = serde_json::json!({
+            "throughput": snap.tokens_per_sec,
+            "p50_ms": snap.latency_p50_ms,
+            "p95_ms": snap.latency_p95_ms,
+            "latency_ms": latency_ms,
+            "tokens": tokens_out,
+            "real_inference": real_inference,
+        });
+        (request_seq, session_id, metrics_json)
+    }
+
     /// Shared response assembly (metrics recording, session bookkeeping, streaming
     /// vs. plain JSON) for a finished chat turn — used both by a fresh request and
     /// by one resumed after a tool-confirmation round-trip.
@@ -3960,65 +4030,14 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             }
         });
 
-        let (request_id, session_id, metrics_json) = {
-            let mut backend = lock_state(state);
-            backend.chat_requests = backend.chat_requests.saturating_add(1);
-            let request_seq = backend.chat_requests;
-
-            backend.last_latency_ms = latency_ms;
-            if let Some(tps) = tokens_per_sec {
-                backend.last_tokens_per_sec = tps;
-            }
-            backend.inference_metrics.record(
-                latency_ms,
-                tokens_out,
-                tokens_per_sec,
-                real_inference,
-            );
-            let snap = backend.inference_metrics.snapshot();
-
-            let latency_u = latency_ms.round() as u32;
-            let throughput_u = tokens_per_sec.unwrap_or(0.0).round().max(0.0) as usize;
-
-            let maybe_session = backend.sessions.first_mut();
-            let session_id = if let Some(session) = maybe_session {
-                session.tokens = session.tokens.saturating_add(tokens_out as usize);
-                session.throughput = throughput_u;
-                session.latency = latency_u;
-                session.model = current_model.to_string();
-                session.status = if real_inference {
-                    "Running".to_string()
-                } else {
-                    "Degraded".to_string()
-                };
-                session.id.clone()
-            } else {
-                let session_id = "sess_local_001".to_string();
-                backend.sessions.push(SessionRecord {
-                    id: session_id.clone(),
-                    model: current_model.to_string(),
-                    status: if real_inference {
-                        "Running".to_string()
-                    } else {
-                        "Degraded".to_string()
-                    },
-                    throughput: throughput_u,
-                    latency: latency_u,
-                    tokens: tokens_out as usize,
-                });
-                session_id
-            };
-
-            let metrics_json = serde_json::json!({
-                "throughput": snap.tokens_per_sec,
-                "p50_ms": snap.latency_p50_ms,
-                "p95_ms": snap.latency_p95_ms,
-                "latency_ms": latency_ms,
-                "tokens": tokens_out,
-                "real_inference": real_inference,
-            });
-            (request_seq, session_id, metrics_json)
-        };
+        let (request_id, session_id, metrics_json) = record_generation_metrics(
+            state,
+            current_model,
+            latency_ms,
+            tokens_out,
+            tokens_per_sec,
+            real_inference,
+        );
 
         let mut final_response = response_text;
         if !tool_results.is_empty() {
@@ -4102,6 +4121,171 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             "outcome": outcome,
         }))
         .into_response()
+    }
+
+    /// Real incremental streaming path for `handle_gui_chat`, used when the
+    /// caller requested `stream: true` and no MCP tools are enabled for this
+    /// turn (tool-call detection needs the complete text, so that case keeps
+    /// using the existing buffer-then-chunk path via `run_tool_loop` — see
+    /// the call site). Forwards text deltas to the client as the backend
+    /// produces them, instead of `handle_gui_chat`'s other path, which waits
+    /// for the entire generation to finish and then fakes streaming by
+    /// splitting the already-complete text into word chunks — meaning a
+    /// client saw zero output for the whole generation time before
+    /// (measured: tens of seconds for a longer response), regardless of the
+    /// `stream: true` request.
+    async fn handle_gui_chat_stream(
+        state: Arc<Mutex<BackendState>>,
+        ollama_available: Arc<tokio::sync::Mutex<bool>>,
+        started: Instant,
+        current_model: String,
+        gen: GenerationParams,
+        prompt: String,
+        request_tracker: runtime_switcher::RequestTracker,
+    ) -> axum::response::Response {
+        use axum::response::sse::{Event, Sse};
+
+        // Snapshot a session id to embed in each streamed chunk up front —
+        // the authoritative bookkeeping (record_generation_metrics) only runs
+        // once the full text is known, at stream end, and may create a new
+        // session if this is the very first request. That's a cosmetic
+        // identifier mismatch for that one request on a single-user desktop
+        // deployment, not a correctness issue worth blocking real streaming on.
+        let request_id = rand::random::<u32>();
+        let session_id = {
+            let backend = lock_state(&state);
+            backend
+                .sessions
+                .first()
+                .map(|s| s.id.clone())
+                .unwrap_or_else(|| "sess_local_001".to_string())
+        };
+
+        let backend_stream: Result<native_engine::NativeChatStream, String> =
+            match gen.inference_backend {
+                InferenceBackend::Native => {
+                    gen.native_engine_client
+                        .generate_chat_stream(
+                            &gen.current_model,
+                            &prompt,
+                            gen.exec_tokens,
+                            gen.temperature,
+                            gen.top_p,
+                            gen.top_k,
+                            gen.repeat_penalty,
+                        )
+                        .await
+                }
+                InferenceBackend::Ollama => gen
+                    .ollama_client
+                    .generate_stream(
+                        &gen.current_model,
+                        &prompt,
+                        gen.temperature,
+                        gen.top_p,
+                        gen.top_k,
+                        gen.repeat_penalty,
+                        gen.exec_tokens,
+                    )
+                    .await
+                    .map(|s| -> native_engine::NativeChatStream {
+                        Box::pin(StreamExt::map(s, |r| r.map_err(|e| e.to_string())))
+                    })
+                    .map_err(|e| e.to_string()),
+            };
+
+        let mut backend_stream = match backend_stream {
+            Ok(s) => s,
+            Err(err) => {
+                request_tracker.decrement().await;
+                let chunk = serde_json::json!({
+                    "token": format!("[stream error: {err}] "),
+                    "request_id": format!("req-{}", request_id),
+                    "session_id": session_id,
+                    "error": true,
+                });
+                let err_stream = futures::stream::once(async move {
+                    Ok::<Event, Infallible>(Event::default().data(chunk.to_string()))
+                });
+                return Sse::new(err_stream).into_response();
+            }
+        };
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, Infallible>>(100);
+        tokio::spawn(async move {
+            let mut accumulated = String::new();
+            let mut real_inference = true;
+            let mut client_disconnected = false;
+            while let Some(item) = backend_stream.next().await {
+                match item {
+                    Ok(text) => {
+                        accumulated.push_str(&text);
+                        let chunk = serde_json::json!({
+                            "token": text,
+                            "request_id": format!("req-{}", request_id),
+                            "session_id": session_id,
+                        });
+                        if tx
+                            .send(Ok(Event::default().data(chunk.to_string())))
+                            .await
+                            .is_err()
+                        {
+                            client_disconnected = true;
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        real_inference = false;
+                        let chunk = serde_json::json!({
+                            "token": format!("[stream error: {err}] "),
+                            "request_id": format!("req-{}", request_id),
+                            "session_id": session_id,
+                            "error": true,
+                        });
+                        let _ = tx.send(Ok(Event::default().data(chunk.to_string()))).await;
+                        break;
+                    }
+                }
+            }
+
+            // Runs exactly once regardless of how the loop above ended
+            // (normal completion, backend error, or client disconnect) so
+            // metrics/tracker release can't be skipped by an early exit.
+            {
+                let mut available_flag = ollama_available.lock().await;
+                *available_flag = real_inference;
+            }
+
+            let wall_ms = (started.elapsed().as_secs_f32() * 1000.0).max(0.1);
+            let tokens_out = (accumulated.split_whitespace().count() as u32).max(1);
+            let tokens_per_sec = if real_inference && wall_ms > 0.0 {
+                Some(tokens_out as f32 / (wall_ms / 1000.0))
+            } else {
+                None
+            };
+            record_generation_metrics(
+                &state,
+                &current_model,
+                wall_ms,
+                tokens_out,
+                tokens_per_sec,
+                real_inference,
+            );
+            request_tracker.decrement().await;
+
+            if client_disconnected {
+                return;
+            }
+
+            let done = serde_json::json!({
+                "done": true,
+                "request_id": format!("req-{}", request_id),
+                "session_id": session_id,
+            });
+            let _ = tx.send(Ok(Event::default().data(done.to_string()))).await;
+        });
+
+        Sse::new(tokio_stream::wrappers::ReceiverStream::new(rx)).into_response()
     }
 
     async fn handle_gui_chat(
@@ -4198,6 +4382,29 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             exec_tokens,
             tool_schemas: enabled_schemas.clone(),
         };
+
+        // Real incremental streaming only when there's no tool-call text to
+        // detect in the model's raw output (tool-call marker parsing needs
+        // the complete generation, so that case keeps the existing
+        // buffer-then-fake-stream path below via run_tool_loop).
+        if req.stream.unwrap_or(false) && enabled_schemas.is_empty() {
+            // Held for the generation's full duration (released inside the
+            // spawned streaming task once it finishes), matching how the
+            // non-streaming path below tracks in-flight work for graceful
+            // backend-switch draining.
+            let request_tracker = active_runtime_switcher().request_tracker().clone();
+            request_tracker.increment().await;
+            return handle_gui_chat_stream(
+                state,
+                ollama_available,
+                started,
+                current_model,
+                gen,
+                req.message.clone(),
+                request_tracker,
+            )
+            .await;
+        }
 
         let tool_instructions = mcp::toolcall::build_tool_instructions(&enabled_schemas);
         let effective_prompt = if tool_instructions.is_empty() {

--- a/crates/ghost-link/src/native_engine.rs
+++ b/crates/ghost-link/src/native_engine.rs
@@ -5,11 +5,17 @@
 
 #![allow(dead_code)]
 
+use futures::Stream;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
+use tokio::sync::mpsc;
 use tokio::time::sleep as tokio_sleep;
+
+/// Stream of incremental text deltas from a native backend's chat endpoint.
+pub type NativeChatStream = Pin<Box<dyn Stream<Item = Result<String, String>> + Send>>;
 
 #[derive(Debug, Clone)]
 pub struct NativeGeneration {
@@ -973,6 +979,151 @@ impl NativeEngineClient {
 
         Err("llama_server returned empty content".to_string())
     }
+
+    /// Real incremental streaming against llama-server's OpenAI-compatible
+    /// chat endpoint. Unlike `generate_with_llama_server` (which always sends
+    /// `"stream": false` and returns only the complete text), this forwards
+    /// text deltas to the caller as llama-server produces them.
+    ///
+    /// Only covers the chat-completions endpoint (the common case for models
+    /// with a chat template, which is what this project's models use in
+    /// practice). If the model has no chat template (chat endpoint returns
+    /// HTTP 400), falls back to the existing non-streaming `/completion`
+    /// path and yields the whole result as a single chunk rather than
+    /// duplicating a second incremental parser for an uncommon case.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn generate_chat_stream(
+        &self,
+        model: &str,
+        cleaned_prompt: &str,
+        max_tokens: usize,
+        temperature: f32,
+        top_p: f32,
+        top_k: usize,
+        repeat_penalty: f32,
+    ) -> Result<NativeChatStream, String> {
+        use futures::StreamExt;
+
+        let base_url = Self::get_llama_base_url();
+        let timeout_secs = std::env::var("GHOSTLINK_LLAMA_SERVER_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(60)
+            .clamp(5, 300);
+        let system_prompt = format!(
+            "You are a helpful assistant. Current local date and time: {}.",
+            chrono::Local::now().format("%A, %B %d, %Y, %H:%M")
+        );
+        let chat_url = format!("{base_url}/v1/chat/completions");
+        let chat_payload = serde_json::json!({
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": cleaned_prompt}
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature.clamp(0.0, 2.0),
+            "top_p": top_p.clamp(0.0, 1.0),
+            "top_k": top_k.clamp(1, 200),
+            "repeat_penalty": repeat_penalty.clamp(0.0, 2.0),
+            "stream": true
+        });
+
+        let client = self.http.clone();
+        let request_timeout = Duration::from_secs(timeout_secs);
+
+        let response = client
+            .post(&chat_url)
+            .header("Content-Type", "application/json")
+            .json(&chat_payload)
+            .timeout(request_timeout)
+            .send()
+            .await
+            .map_err(|e| format!("llama_server streaming request failed: {}", e))?;
+
+        if response.status().as_u16() == 400 {
+            // No chat template on this model: fall back to the existing
+            // non-streaming completion path and present it as one chunk.
+            let gen = self
+                .generate_with_llama_server(
+                    model,
+                    cleaned_prompt,
+                    max_tokens,
+                    temperature,
+                    top_p,
+                    top_k,
+                    repeat_penalty,
+                )
+                .await?;
+            let single = futures::stream::once(async move { Ok(gen.text) });
+            return Ok(Box::pin(single));
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!(
+                "llama_server streaming request failed with status {}: {}",
+                status, body
+            ));
+        }
+
+        let (tx, rx) = mpsc::channel::<Result<String, String>>(100);
+        tokio::spawn(async move {
+            let mut byte_stream = response.bytes_stream();
+            let mut buf = String::new();
+            while let Some(chunk) = byte_stream.next().await {
+                let chunk = match chunk {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx.send(Err(format!("stream read error: {e}"))).await;
+                        return;
+                    }
+                };
+                buf.push_str(&String::from_utf8_lossy(&chunk));
+                while let Some(pos) = buf.find('\n') {
+                    let line = buf[..pos].trim().to_string();
+                    buf.drain(..=pos);
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let payload = match line.strip_prefix("data: ") {
+                        Some(p) => p,
+                        None => continue,
+                    };
+                    if payload == "[DONE]" {
+                        return;
+                    }
+                    let data: serde_json::Value = match serde_json::from_str(payload) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                    let delta = data
+                        .get("choices")
+                        .and_then(|c| c.get(0))
+                        .and_then(|c| c.get("delta"))
+                        .and_then(|d| d.get("content"))
+                        .and_then(|v| v.as_str());
+                    if let Some(text) = delta {
+                        if !text.is_empty() && tx.send(Ok(text.to_string())).await.is_err() {
+                            return; // receiver dropped, stop reading
+                        }
+                    }
+                    let finished = data
+                        .get("choices")
+                        .and_then(|c| c.get(0))
+                        .and_then(|c| c.get("finish_reason"))
+                        .map(|v| !v.is_null())
+                        .unwrap_or(false);
+                    if finished {
+                        return;
+                    }
+                }
+            }
+        });
+
+        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+    }
 }
 
 fn generation_from_llama_json(parsed: &serde_json::Value) -> Option<NativeGeneration> {
@@ -1119,6 +1270,51 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    #[ignore] // requires a live llama-server; run manually with --ignored
+    fn generate_chat_stream_yields_incremental_chunks_against_live_server() {
+        use futures::StreamExt;
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        std::env::set_var("GHOSTLINK_LLAMA_SERVER_URL", "http://127.0.0.1:8080");
+
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let engine = NativeEngineClient::new();
+        rt.block_on(async {
+            let mut stream = engine
+                .generate_chat_stream(
+                    "test-model",
+                    "Count from one to five, one number per line.",
+                    64,
+                    0.7,
+                    0.9,
+                    40,
+                    1.1,
+                )
+                .await
+                .expect("stream should start");
+
+            let mut chunk_count = 0usize;
+            let mut chunk_times = Vec::new();
+            let start = std::time::Instant::now();
+            let mut full_text = String::new();
+            while let Some(item) = stream.next().await {
+                let text = item.expect("chunk should not error");
+                chunk_count += 1;
+                chunk_times.push(start.elapsed());
+                full_text.push_str(&text);
+            }
+            eprintln!("received {chunk_count} chunks over {:?}", start.elapsed());
+            eprintln!("first few chunk arrival times: {:?}", &chunk_times[..chunk_times.len().min(5)]);
+            eprintln!("accumulated text: {full_text:?}");
+            assert!(
+                chunk_count > 1,
+                "expected multiple incremental chunks, got {chunk_count} (looks like buffering, not streaming)"
+            );
+        });
+
+        std::env::remove_var("GHOSTLINK_LLAMA_SERVER_URL");
     }
 
     #[test]

--- a/crates/ghost-link/src/ollama.rs
+++ b/crates/ghost-link/src/ollama.rs
@@ -327,26 +327,46 @@ impl OllamaClient {
     ) -> Result<mpsc::Receiver<Result<String, Box<dyn Error + Send + Sync>>>, Box<dyn Error>> {
         let (tx, rx) = mpsc::channel(100);
 
-        let body = resp.bytes().await?;
-
+        // Process the response as it arrives over the wire (`bytes_stream()`)
+        // instead of `bytes().await` (which buffers the *entire* body before
+        // returning). The previous version only faked streaming downstream of
+        // this call — Ghostlink itself still waited for Ollama's whole
+        // response before relaying anything, defeating the actual purpose of
+        // streaming (reducing time-to-first-token).
         tokio::spawn(async move {
-            let text = String::from_utf8_lossy(&body);
-            for line in text.lines() {
-                if let Some(json_str) = line.strip_prefix("data: ") {
+            use futures::StreamExt;
+            let mut byte_stream = resp.bytes_stream();
+            let mut buf = String::new();
+            while let Some(chunk) = byte_stream.next().await {
+                let chunk = match chunk {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(Box::new(e) as Box<dyn Error + Send + Sync>))
+                            .await;
+                        return;
+                    }
+                };
+                buf.push_str(&String::from_utf8_lossy(&chunk));
+                // A network chunk boundary rarely lines up with a JSON-line
+                // boundary; only consume complete lines, keep any trailing
+                // partial line buffered for the next chunk.
+                while let Some(pos) = buf.find('\n') {
+                    let line = buf[..pos].trim().to_string();
+                    buf.drain(..=pos);
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let json_str = line.strip_prefix("data: ").unwrap_or(&line);
                     if let Ok(data) = serde_json::from_str::<Value>(json_str) {
                         if let Some(response) = data.get("response").and_then(|v| v.as_str()) {
-                            let _ = tx.send(Ok(response.to_string())).await;
+                            if tx.send(Ok(response.to_string())).await.is_err() {
+                                return; // receiver dropped, stop reading
+                            }
                         }
                         if data.get("done").and_then(|v| v.as_bool()).unwrap_or(false) {
                             return;
                         }
-                    }
-                } else if let Ok(data) = serde_json::from_str::<Value>(line) {
-                    if let Some(response) = data.get("response").and_then(|v| v.as_str()) {
-                        let _ = tx.send(Ok(response.to_string())).await;
-                    }
-                    if data.get("done").and_then(|v| v.as_bool()).unwrap_or(false) {
-                        return;
                     }
                 }
             }
@@ -469,24 +489,38 @@ impl OllamaClient {
     {
         let (tx, rx) = mpsc::channel(100);
 
-        let body = resp.bytes().await?;
-
+        // See stream_response's comment: process as bytes arrive rather than
+        // buffering the whole body first.
         tokio::spawn(async move {
-            let text = String::from_utf8_lossy(&body);
-            for line in text.lines() {
-                if let Some(json_str) = line.strip_prefix("data: ") {
+            use futures::StreamExt;
+            let mut byte_stream = resp.bytes_stream();
+            let mut buf = String::new();
+            while let Some(chunk) = byte_stream.next().await {
+                let chunk = match chunk {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(Box::new(e) as Box<dyn Error + Send + Sync>))
+                            .await;
+                        return;
+                    }
+                };
+                buf.push_str(&String::from_utf8_lossy(&chunk));
+                while let Some(pos) = buf.find('\n') {
+                    let line = buf[..pos].trim().to_string();
+                    buf.drain(..=pos);
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let json_str = line.strip_prefix("data: ").unwrap_or(&line);
                     if let Ok(data) = serde_json::from_str::<ChatResponse>(json_str) {
                         let done = data.done;
-                        let _ = tx.send(Ok(data)).await;
+                        if tx.send(Ok(data)).await.is_err() {
+                            return; // receiver dropped, stop reading
+                        }
                         if done {
                             return;
                         }
-                    }
-                } else if let Ok(data) = serde_json::from_str::<ChatResponse>(line) {
-                    let done = data.done;
-                    let _ = tx.send(Ok(data)).await;
-                    if done {
-                        return;
                     }
                 }
             }
@@ -585,16 +619,41 @@ impl OllamaClient {
     > {
         let (tx, rx) = mpsc::channel(100);
 
-        let body = resp.bytes().await?;
-
+        // Was `resp.bytes().await?` (buffers the whole response before
+        // processing any of it). A model pull can run for minutes; this made
+        // the GUI's progress bar sit frozen for the entire download and then
+        // jump straight to 100% instead of updating incrementally as Ollama
+        // reports real progress. `bytes_stream()` processes chunks as they
+        // arrive over the wire instead.
         tokio::spawn(async move {
-            let text = String::from_utf8_lossy(&body);
-            for line in text.lines() {
-                if let Ok(data) = serde_json::from_str::<PullProgressResponse>(line) {
-                    let status = data.status.clone();
-                    let _ = tx.send(Ok(data)).await;
-                    if status == "success" || status == "error" {
+            use futures::StreamExt;
+            let mut byte_stream = resp.bytes_stream();
+            let mut buf = String::new();
+            while let Some(chunk) = byte_stream.next().await {
+                let chunk = match chunk {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(Box::new(e) as Box<dyn Error + Send + Sync>))
+                            .await;
                         return;
+                    }
+                };
+                buf.push_str(&String::from_utf8_lossy(&chunk));
+                while let Some(pos) = buf.find('\n') {
+                    let line = buf[..pos].trim().to_string();
+                    buf.drain(..=pos);
+                    if line.is_empty() {
+                        continue;
+                    }
+                    if let Ok(data) = serde_json::from_str::<PullProgressResponse>(&line) {
+                        let status = data.status.clone();
+                        if tx.send(Ok(data)).await.is_err() {
+                            return; // receiver dropped, stop reading
+                        }
+                        if status == "success" || status == "error" {
+                            return;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Chat "streaming" and Ollama model-pull "streaming" both looked like streaming downstream but weren't upstream: the client-facing plumbing (SSE responses, channels) already existed, but every actual code path still waited for the entire backend response before relaying anything to the client. Full details and validation methodology are in `CHANGELOG.md`'s `[1.4.4]` entry — this body summarizes the highlights.

### The core bug: `handle_gui_chat`'s streaming was fake

It waited for `run_tool_loop`/`generate_once` to fully finish generation (blocking on the *entire* response, for both backends), **then** split the already-complete text into word chunks and dripped them out over SSE. A client requesting `stream: true` saw zero output for the whole generation time — potentially tens of seconds for a longer response — then everything appeared at once. This defeats the actual point of streaming: reducing perceived time-to-first-token.

**Fix**: added `NativeEngineClient::generate_chat_stream` — llama-server had no streaming client method at all before this — using `"stream": true` and `bytes_stream()` for genuine incremental SSE parsing (with graceful fallback to the existing non-streaming path for models without a chat template). Wired real streaming into `handle_gui_chat` for the common case: `stream: true` with no MCP tools enabled. Tool-calling requests keep the existing buffer-then-chunk path — tool-call marker detection genuinely needs the complete text, so real-time interleaving there is a larger, separate piece of work intentionally left out of this change.

### The related bug: `ollama.rs`'s existing "streaming" methods buffered the whole response first

`generate_stream`/`chat_stream`/`stream_pull_progress` all called `resp.bytes().await` — which waits for the entire HTTP body — before processing any of it, then faked incremental delivery downstream via an mpsc channel. Ghostlink itself never received any data earlier than a plain non-streaming call would have.

`stream_pull_progress` is the one of the three that's actually wired in and used (GUI model download progress), making this the more consequential half of the bug: a multi-minute model pull would show a **frozen progress bar for the entire download**, then jump straight to 100%. `generate_stream`/`chat_stream` are confirmed-dead code today (full-crate grep, zero callers) but fixed anyway for correctness and in case they're wired in later.

All three now use `bytes_stream()` with explicit partial-line buffering across chunk boundaries (a network chunk boundary rarely lines up with a JSON-line boundary).

### Supporting changes

- Extracted `record_generation_metrics` (request counter, `inference_metrics`, dashboard session record) out of `finish_chat_response` so the new streaming path shares the *exact* same side effects instead of a second, divergence-prone copy of this bookkeeping.
- Enabled `reqwest`'s `stream` feature in `ghost-link`'s `Cargo.toml` — required for `bytes_stream()`.

### Caught and fixed before shipping

While building this, the new streaming task's client-disconnect early-return bypassed releasing the graceful-shutdown request-tracker counter — a real leak under concurrent use that would have shipped if not caught in self-review. Restructured to a single exit point so the tracker release and metrics recording can't be skipped by any of the three ways the stream can end (normal completion, backend error, client disconnect).

## Live validation

Verified against a real running `llama-server` throughout, using a throwaway `ghost-link` instance on a separate port (`:8004`) pointed at the same live `llama-server` — confirmed this could not touch the actual running server or process before doing it (checked that the Windows port-cleanup path, `taskkill /IM llama-server.exe`, used during model hot-swapping, is only reachable from explicit model-load/switch calls, not from plain `serve` startup).

- Direct client-method test (`generate_chat_stream`): **10 chunks arrived over 190ms** (43ms, 54ms, 68ms, 80ms, 93ms, ...) — incremental delivery, not one blob.
- Full HTTP path (`POST /api/inference/chat`, `stream: true`, no tools) through the throwaway instance: **15 chunks arrived progressively from 0.27s to 0.45s**, correct generated text ("1 \n2 \n\n3 \n4 \n\n5 \n6 \n\n7 \n8" for a count-to-8 prompt).
- Regression-checked: non-streaming requests unchanged; streaming requests with tools enabled still correctly fall back to the existing buffer-then-chunk path.
- Confirmed the live `ghost-link`/`llama-server` instances were completely unaffected throughout (same `llama-server` PID before and after all testing).

## Validation (CONTRIBUTING.md pre-push checklist)

```
cargo fmt --all --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings       # clean, zero warnings
cargo test --workspace                                      # 83+134+7+28+19 passing, 3x consecutive clean runs
cargo audit                                                  # only pre-existing unmaintained/unsound transitive-dep advisories, no new ones
```

`cargo bench --package ghostlink-core` intentionally skipped — this change touches only `ghost-link`'s HTTP client/streaming code, not `ghostlink-core`, where the criterion benchmark suite lives.

Added one `#[ignore]`d test (`generate_chat_stream_yields_incremental_chunks_against_live_server`, run manually with `--ignored` against a live server) that asserts more than one chunk arrives — specifically to catch a future regression back to buffering.

## Operational caveats

- Real streaming only covers the no-tools-enabled case for both backends. Streaming *with* tool-calling enabled still uses the old buffer-then-chunk behavior — a larger, intentionally out-of-scope redesign.
- `generate_chat_stream`'s fallback-on-no-chat-template path (HTTP 400 from the chat endpoint) degrades to the existing non-streaming `/completion` call and presents the whole result as a single SSE chunk, rather than duplicating a second incremental parser for llama.cpp's native `/completion` streaming shape — an intentional scope boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)