### PR TITLE
perf: TCP bridge was buffering every batch instead of streaming it

### DIFF
--- a/crates/ghost-link/src/native_engine.rs
+++ b/crates/ghost-link/src/native_engine.rs
@@ -211,6 +211,7 @@ impl NativeEngineClient {
     fn get_llama_server_args() -> Vec<String> {
         if let Ok(v) = std::env::var("GHOSTLINK_LLAMA_SERVER_ARGS") {
             if !v.trim().is_empty() {
+                eprintln!("[perf-tier] Using explicit GHOSTLINK_LLAMA_SERVER_ARGS override: {v}");
                 return v.split_whitespace().map(|s| s.to_string()).collect();
             }
         }
@@ -247,15 +248,21 @@ impl NativeEngineClient {
             .ok()
             .and_then(|v| v.trim().parse::<f32>().ok())
             .unwrap_or(0.0);
-        let (batch, ubatch) = if vram >= 12.0 {
-            (2048, 512)
+        let (tier, batch, ubatch) = if vram >= 12.0 {
+            (">=12GB", 2048, 512)
         } else if vram >= 8.0 {
-            (1024, 512)
+            (">=8GB", 1024, 512)
         } else if vram >= 4.0 {
-            (512, 256)
+            (">=4GB", 512, 256)
         } else {
-            (512, 128)
+            ("<4GB", 512, 128)
         };
+        // Cheap, greppable proof at boot that the VRAM-scaled tuning table in
+        // docs/LOCAL_INFERENCE_TUNING.md actually landed for this hardware,
+        // instead of only being inferable later from slow generations.
+        eprintln!(
+            "[perf-tier] Detected VRAM={vram}GB -> tier {tier} (-b {batch} -ub {ubatch} -fa on -ctk/-ctv q8_0)"
+        );
         // q8_0 KV cuts cache memory ~2× vs f16 → more room for GPU layers / speed.
         vec![
             "-fa".to_string(),

--- a/crates/ghostlink-core/src/runtime.rs
+++ b/crates/ghostlink-core/src/runtime.rs
@@ -1208,6 +1208,16 @@ pub fn spawn_tcp_bridge(
                             &mut frame_buf,
                         )
                         .map_err(|_| ())?;
+                        // BufWriter only spills to the socket once its 64KB
+                        // buffer fills — for the small, sub-buffer-size frames
+                        // this bridge carries, that meant every batch sat in
+                        // userspace until the whole input channel drained, so
+                        // the receiver saw nothing until one final burst at
+                        // stream end instead of the pipelined, per-batch
+                        // delivery TCP_NODELAY above was set up to provide.
+                        // Flushing per frame is what actually puts NODELAY to
+                        // work for this latency-sensitive path.
+                        writer.flush().map_err(|_| ())?;
                         total_write_ms += write_start.elapsed().as_secs_f32() * 1000.0;
                         processed_batches += 1;
                     }
@@ -1222,6 +1232,7 @@ pub fn spawn_tcp_bridge(
                             &mut frame_buf,
                         )
                         .map_err(|_| ())?;
+                        writer.flush().map_err(|_| ())?;
                         total_write_ms += write_start.elapsed().as_secs_f32() * 1000.0;
                         processed_batches += 1;
                     }
@@ -1305,8 +1316,6 @@ impl BridgeAccumulator {
     }
 }
 
-/// Execute pipeline stages with real TCP loopback transport bridges between stages.
-/// Execute pipeline stages distributed across the LAN using TCP transport.
 /// Execute pipeline stages distributed across the LAN using TCP transport.
 pub fn execute_pipeline_distributed(
     plan: &PipelinePlan,

--- a/crates/ghostlink-core/src/xdp.rs
+++ b/crates/ghostlink-core/src/xdp.rs
@@ -1,10 +1,14 @@
-//! High_Performance_Transport/eBPF Socket Integration for Ghost-Link
+//! AF_XDP kernel-bypass scaffold for Ghost-Link (not a working transport yet).
 //!
-//! This module provides:
-//! - Raw socket binding with High_Performance_Transport
-//! - EtherType filtering (0x88B5)
-//! - Frame reception loop with zero-copy buffers
-//! - eBPF program loading helpers
+//! Every I/O path here — socket creation, bind, send, recv, the frame
+//! receiver — is a stub that either errors or returns `None`; see
+//! `TransportSocketHandle::new`, `TransportSocketManager::recv_frame`, and
+//! `XdpFrameReceiver::process_frame`. This module defines the shape a real
+//! AF_XDP backend would take (EtherType filtering, stats tracking, config)
+//! so that shape can be exercised by tests, but no kernel-bypass I/O
+//! actually happens. `docs/BENCHMARKS.md` is correct that AF_XDP is not
+//! currently implemented — treat that as authoritative over anything this
+//! module's naming implies.
 
 use std::os::raw::c_int;
 use std::path::Path;


### PR DESCRIPTION
## Summary

Executes the P0/P1/P3 items from the [performance fine-tuning plan](https://claude.ai/code/artifact/89f4660c-0d3d-4714-9f61-25d2f89cfc37) — the headline fix is a real bug in the inter-stage TCP transport, not a micro-optimization.

**The bug (P1 — TCP transport gap):** `spawn_tcp_bridge` in `crates/ghostlink-core/src/runtime.rs` wraps its socket in a 64KB `BufWriter` and only called `.flush()` once, after the *entire* input channel had drained. Individual frames are typically single-digit KB, so for any run with enough headroom under 64KB, nothing reached the actual socket until every batch had already been queued — the receiving stage sat blocked on `read_exact` the whole time, then got everything in one burst at the end.

`TCP_NODELAY` was already set on both ends specifically because "inter-stage frames are small and latency-sensitive" (pre-existing comment in the code) — but that flag only controls whether the kernel coalesces data already written to the socket. It does nothing if userspace never issues the write. The `BufWriter` was quietly defeating the exact behavior `TCP_NODELAY` was configured to provide. This function is shared by both the loopback benchmark path and the real LAN-distributed pipeline (`execute_pipeline_distributed`), so the fix isn't benchmark-only.

**Fix:** flush after every frame instead of once at the end.

## Measured impact

`cargo bench -p ghostlink-core`, same machine, before vs. after:

| Metric | Before | After | Delta |
|---|---|---|---|
| TCP loopback throughput (1024 tok, 128 batches) | 545,639 tok/s | 655,108 tok/s | **+20.1%** |
| TCP loopback wall time (1024 tok) | 1.877 ms | 1.563 ms | **-16.7%** |
| TCP as % of in-process throughput | 64.4% | 74.1% | **+9.7 points** |
| `fabric_tcp_two_stage_split` median (criterion) | 1.14 ms | 0.93 ms | spread 760µs–1.73ms → 892µs–966µs |
| `fabric_tcp_four_stage_split` median (criterion) | 56.1 ms | 24.4 ms | tail (max) 133.9ms → 70.6ms |

The dramatic drop in variance is the real signal — that's the burst-then-wait pattern disappearing.

**Honest caveat:** a synthetic 8-batch/64-token run got *slower* in absolute wall time (one more flush syscall per frame, too little work to amortize it against with only 8 frames). Real generation runs hundreds to thousands of tokens per response, and `CONTRIBUTING.md`'s own canonical comparison point is the 1024-token case, where this is an unambiguous win — but it isn't a free lunch at every batch count, and I'm reporting that rather than only citing the favorable numbers.

## Also in this PR (P0 / P3 from the plan)

- **`native_engine.rs`** — logs the resolved VRAM tier and its `-b`/`-ub` flags at model-load time (`[perf-tier] ...`), so `docs/LOCAL_INFERENCE_TUNING.md`'s VRAM-scaled defaults are verifiable at boot instead of only inferable later from slow generations. Confirmed `default_perf_args()` already matches that doc's table exactly — this is proof-of-application logging, not a behavior change.
- **`xdp.rs`** — corrected the module doc comment, which described AF_XDP kernel-bypass as if implemented. Every I/O path in the module is a stub that errors or returns `None`; `docs/BENCHMARKS.md`'s "not currently implemented" note was already accurate, only this module's own header oversold it.

## Deliberately not done

- **`ClusterState`'s metrics `Mutex`** (P2 in the plan) — recently optimized in `5720ecf` to skip cloning on the count-only path. Swapping it for a read-optimized lock is only worth doing with evidence of real contention under multi-node load, which hasn't been measured. Adding it speculatively isn't justified by anything in hand.

## Validation

Per `CONTRIBUTING.md`'s pre-push checklist, and the "if you changed transport/pipeline code" benchmark-reporting requirement above:

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 275 passed, 0 failed
- [x] `cargo audit` — 0 vulnerabilities (same 3 pre-existing unmaintained/unsound advisories on transitive deps, unrelated)

## Risk / rollback

Scope is one write loop in one function plus two log lines and a doc comment. No wire-format, config, or API changes. Rollback is a plain revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)