### PR TITLE
⚡ Bolt: Optimize Compare Mode message list rendering complexity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2026-07-20 - [Compare Mode O(n) rendering optimization]
+**Learning:** Performing nested array scans like `messages.find(...)` inside React list mapping (`messages.map(...)`) causes $O(n^2)$ time complexity for list rendering on the main thread. This is especially problematic in fast-paced streaming interfaces where the list is re-rendered with every incoming token. Pre-computing a `Map` of partners/related messages outside the map via `useMemo` reduces the rendering lookup cost to $O(1)$ and the overall render loop complexity to $O(n)$.
+**Action:** Always pre-compute lookup maps/objects for related messages or group keys in lists to avoid nested $O(n^2)$ iterations during React rendering loops.
+
 ## 2026-07-02 - [SPSC Ring Buffer Optimization]
 **Learning:** Shared atomic counters in SPSC (Single-Producer Single-Consumer) structures cause significant cache line contention (false sharing or simply bouncing) even if the rest of the structure is properly padded. The length of a ring buffer can be derived from head/tail pointers, making an explicit shared 'count' or 'empty_count' redundant and slow.
 **Action:** Always derive length/fullness from head and tail pointers in SPSC buffers instead of using a shared atomic counter. Ensure power-of-two capacities to allow bitwise masking for wrapping.

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -216,6 +216,18 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     return Array.from(bySlot.values());
   }, [mcpServers]);
 
+  // Pre-compute a map for O(1) partner lookup during Compare Mode rendering,
+  // avoiding O(n^2) nested find scans over the message list.
+  const compareGroupBMap = useMemo(() => {
+    const map = new Map<string, Message>();
+    for (const m of messages) {
+      if (m.compareGroupId && m.id.endsWith('-b')) {
+        map.set(m.compareGroupId, m);
+      }
+    }
+    return map;
+  }, [messages]);
+
   useEffect(() => {
     setTools((prev) => {
       const prevEnabled = new Map(prev.map((t) => [t.name, t.enabled]));
@@ -834,7 +846,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                 // partner below, not on its own.
                 if (msg.compareGroupId && msg.id.endsWith('-b')) return null;
                 if (msg.compareGroupId && msg.id.endsWith('-a')) {
-                    const partner = messages.find((m) => m.compareGroupId === msg.compareGroupId && m.id !== msg.id);
+                    const partner = compareGroupBMap.get(msg.compareGroupId);
                     return (
                         <CompareRow
                             key={msg.compareGroupId}


### PR DESCRIPTION
Optimize the Compare Mode message list rendering inside ChatTab.tsx from O(n^2) to O(n) by using a memoized Map (via useMemo) to do O(1) partner message lookups instead of nested array `.find` scans. This prevents performance degradation and lag on larger conversation sessions and during active streamed token generation.

---
*PR created automatically by Jules for task [11386538199618452879](https://jules.google.com/task/11386538199618452879) started by @rwilliamspbg-ops*