### PR TITLE
fix(pages): theme the GitHub Pages site — it was rendering unstyled

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+title: Ghostlink
+description: Distributed inference fabric for custom LLM systems — route workloads across CPU, GPU, and NPU resources with explicit scheduling, hardware-aware placement, and a self-hosted open-source stack.
+theme: jekyll-theme-midnight
+
+# GitHub Pages is on the legacy "deploy from branch" source (main, path /),
+# so with no root index.html Jekyll auto-renders README.md as the site
+# index — this file just gives that render an actual theme (dark, matches
+# the app's own UI) instead of the unstyled bare-HTML fallback.


### PR DESCRIPTION
## Summary

- GitHub Pages is on the legacy "deploy from branch" source (`main`, path `/`), confirmed via `gh api repos/.../pages` — **not** the `deploy-pages.yml` Actions workflow that uploads `docs/`; that workflow's output was never actually the live site.
- With no root `index.html`, GitHub's Jekyll pipeline auto-renders `README.md` as the site index through its bare default theme: no stylesheet, unstyled badges/tables, generic footer. That's what's live at https://rwilliamspbg-ops.github.io/Ghostlink/.
- Adds a root `_config.yml` selecting `jekyll-theme-midnight` (dark, built into GitHub Pages' supported theme set, no vendoring needed) so the auto-rendered README gets real styling instead of the bare fallback.

Not addressed here (flagged for a follow-up, since it needs a repo settings change + reviving old content): there was previously a dedicated custom landing page (`docs/index.html`, deleted 2026-07-15 in `ca82a9b`) that the README's "polished landing page" line still references. Reviving that and switching Pages source to "GitHub Actions" so `deploy-pages.yml` actually goes live is a bigger fix than this PR.

## Test plan

- [x] Confirmed via `gh api repos/rwilliamspbg-ops/Ghostlink/pages` that source is `legacy` branch-root, so this file is picked up automatically by the next Pages build after merge — no repo settings change needed.
- [ ] After merge, visually confirm https://rwilliamspbg-ops.github.io/Ghostlink/ renders with the new theme (can't verify pre-merge — Pages only builds from `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)