### PR TITLE
fix(models): serialize load/unload to stop concurrent requests racing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.7.1] - 2026-07-25 (Fix: concurrent model load/unload requests corrupted state and could kill llama-server)
+
+Chasing a report of chat suddenly failing with `error sending request for url
+(http://127.0.0.1:8080/v1/chat/completions)` — llama-server was dead despite
+ghost-link's own log claiming "Successfully loaded model" moments earlier.
+
+### 🐛 Correctness
+
+- **`/api/models/load` and `/api/models/unload` had no mutual exclusion.**
+  `handle_gui_model_load`/`handle_gui_model_unload` deliberately drop the
+  `BackendState` lock before calling the (intentionally blocking)
+  `NativeEngineClient::load_model_into_slot`/`unload_model`, so two
+  overlapping requests (a double-click, a fast model switch before the
+  first request's promise resolved, etc.) could run the whole
+  stage-on-scratch-port → kill-existing → bind-real-port sequence
+  concurrently. `free_llama_port` kills by image name
+  (`taskkill /F /IM llama-server.exe` on Windows) rather than by PID, so one
+  request's cleanup could kill the *other* request's freshly-staged or
+  just-promoted process. Confirmed by firing 3 concurrent `/api/models/load`
+  requests: each response reported a *different*, wrong `current_model`
+  (`backend.current_model = selected_model` was a plain last-writer-wins
+  race with no relation to which underlying process actually survived).
+- Fixed with a new `model_lifecycle_lock` (`Arc<tokio::sync::Mutex<()>>`) on
+  `BackendState`, held for the full duration of both handlers — from model
+  resolution through the `BackendState` updates that follow the load/unload
+  call. Overlapping requests now queue instead of racing.
+
+### ✅ Validation
+
+- Reproduced the corruption pre-fix: 3 concurrent `/api/models/load` calls
+  each returned a different `current_model` field, with the shared
+  `model_path` field also cross-contaminated between requests.
+- Post-fix: the same 3-way concurrent load re-run — each response now
+  correctly reports its own requested model, `/api/models/status` and the
+  actual running `llama-server.exe` process agree, and a follow-up chat
+  request against the settled model succeeds.
+- Single-request stability: model loaded via the real API, then polled the
+  live `llama-server.exe` PID every 250ms for 90s (spanning a real chat
+  turn) — stayed alive the whole time, confirming the earlier crash needed
+  the concurrent-request race, not just normal single-session use.
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D
+  warnings`, `cargo test --workspace` (281 passed, 0 failed, 6 ignored) all
+  clean.
+
 ## [1.7.0] - 2026-07-25 (Chat gains conversation memory; README overhaul with live demo)
 
 Chat turns previously carried zero history — every request to the model was

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1470,6 +1470,18 @@ struct BackendState {
     mcp_registry: Arc<mcp::McpRegistry>,
     pending_tool_calls: Arc<tokio::sync::Mutex<HashMap<String, PendingToolCall>>>,
     download_progress: HashMap<String, DownloadProgressInfo>,
+    /// Serializes the full model load/unload sequence end to end — the
+    /// llama-server stage/kill/spawn dance in `NativeEngineClient::load_model_into_slot`
+    /// plus the `BackendState` updates (`current_model`, model status, settings)
+    /// that follow it. Without this, two overlapping `/api/models/load` (or
+    /// load+unload) requests each independently ran `free_llama_port`'s
+    /// system-wide `taskkill /F /IM llama-server.exe` and raced to bind the
+    /// same port — confirmed by firing concurrent load requests and seeing
+    /// each response report a *different* `current_model`, since the final
+    /// `backend.current_model = selected_model` write was a plain
+    /// last-writer-wins race with no relation to which process actually
+    /// survived the taskkill/spawn collision.
+    model_lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// Real byte-level progress for an in-flight (or just-finished) model download.
@@ -2713,6 +2725,15 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             return Json(serde_json::json!({ "error": "model cannot be empty" }));
         }
 
+        // Held for the rest of this handler so an overlapping load/unload
+        // request queues up instead of racing it — see the field doc on
+        // `model_lifecycle_lock` for what went wrong without this.
+        let lifecycle_lock = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.model_lifecycle_lock)
+        };
+        let _lifecycle_guard = lifecycle_lock.lock().await;
+
         let (inference_backend, ollama_client, ollama_available) = {
             let backend = lock_state(&state);
             // Prefer live settings string (updated by Settings UI / runtime select)
@@ -3247,6 +3268,14 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         if requested.is_empty() {
             return Json(serde_json::json!({ "error": "model cannot be empty" }));
         }
+
+        // See `model_lifecycle_lock`'s field doc — same race as the load
+        // handler applies here (an unload racing a concurrent load).
+        let lifecycle_lock = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.model_lifecycle_lock)
+        };
+        let _lifecycle_guard = lifecycle_lock.lock().await;
 
         let (inference_backend, ollama_client, ollama_available, native_engine_client, settings) = {
             let backend = lock_state(&state);
@@ -5876,6 +5905,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         ))),
         pending_tool_calls: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         download_progress: HashMap::new(),
+        model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
     }));
 
     // Background CPU/RAM/GPU sampler — keeps /api/metrics non-blocking.


### PR DESCRIPTION
## Summary

- Chasing a real bug hit this session: chat suddenly failed with `error sending request for url (http://127.0.0.1:8080/v1/chat/completions)` — llama-server was dead despite ghost-link's own log claiming `Successfully loaded model` moments earlier, with no crash reason available since `native_engine.rs` spawns it with `Stdio::null()`.
- Root cause: `handle_gui_model_load` / `handle_gui_model_unload` deliberately drop the `BackendState` lock before calling the blocking `NativeEngineClient::load_model_into_slot` / `unload_model` (by design, so a slow load doesn't hold the whole app's state lock) — but that also means **two overlapping requests can run the entire stage → kill-existing → bind-real-port sequence concurrently with zero synchronization**. `free_llama_port` kills by image name (`taskkill /F /IM llama-server.exe` on Windows), not by PID, so one request's cleanup can kill a *different* request's freshly-staged or just-promoted process.
- Confirmed concretely: firing 3 concurrent `/api/models/load` requests, each response reported a **different, wrong** `current_model` — `backend.current_model = selected_model` was a plain last-writer-wins race with no relation to which OS process actually survived the collision.
- Fix: a new `model_lifecycle_lock` (`Arc<tokio::sync::Mutex<()>>`) on `BackendState`, held for the full duration of both handlers. Overlapping requests now queue instead of racing.

## Test plan

- [x] Reproduced pre-fix: 3 concurrent loads → 3 different `current_model` values in the responses, `model_path` cross-contaminated too.
- [x] Post-fix: same 3-way race re-run → each response correctly reports its own model; `/api/models/status` and the actual `llama-server.exe` process agree; a follow-up chat request against the settled model succeeds.
- [x] Single-request stability: loaded via the real API, then polled the live `llama-server.exe` PID every 250ms for 90s spanning a real chat turn — stayed alive throughout, confirming normal single-session use was never the problem, only concurrent requests.
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 281 passed, 0 failed, 6 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)