### PR TITLE
feat(chat): add browser-native voice input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.8.0] - 2026-07-25 (Voice input in chat)
+
+### ✨ Features
+
+- **Chat gains browser-native voice input.** A mic toggle button next to
+  Send in `ChatTab.tsx` uses the Web Speech API (`SpeechRecognition` /
+  `webkitSpeechRecognition`) to transcribe speech directly into the message
+  box — interim results update live, final results accumulate, and the
+  button never renders on browsers without support (Firefox/Safari) rather
+  than showing a dead control.
+- Worth being upfront about: this is cloud-backed (the browser's built-in
+  recognizer needs internet), a real tension with the rest of this app's
+  local-first inference story. A local Whisper.cpp integration (mirroring
+  `native_engine.rs`'s process-management pattern) would resolve that but
+  is a substantially bigger lift — left as explicit future work, not
+  silently glossed over.
+
+### ✅ Validation
+
+- `tsc --noEmit` clean, `vitest run` (108 passed, 0 failed) including 2 new
+  tests: mic button absence when `SpeechRecognition` is unavailable, and
+  start/stop/transcript-into-input behavior with a mocked recognizer.
+- Manually verified in a live browser: clicking the mic button triggers a
+  real microphone permission request (confirming the Web Speech API call is
+  wired correctly end to end), and the button correctly resets to its
+  initial state when permission is denied rather than getting stuck
+  "recording."
+
 ## [1.7.1] - 2026-07-25 (Fix: concurrent model load/unload requests corrupted state and could kill llama-server)
 
 Chasing a report of chat suddenly failing with `error sending request for url

--- a/ghostlink_gui_modern/src/components/ChatTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ChatTab } from './ChatTab';
 import { useAppStore } from '../store';
 import { GhostlinkAPI } from '../api';
@@ -70,5 +70,61 @@ describe('ChatTab', () => {
     const api = createMockApi();
     render(<ChatTab api={api} />);
     expect(screen.getByText('llama-3-8b')).toBeInTheDocument();
+  });
+
+  describe('voice input', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('does not render the mic button when SpeechRecognition is unavailable', () => {
+      const api = createMockApi();
+      render(<ChatTab api={api} />);
+      expect(screen.queryByLabelText('Start voice input')).not.toBeInTheDocument();
+    });
+
+    it('renders the mic button and starts/stops recognition on click', () => {
+      const instances: any[] = [];
+      class MockSpeechRecognition {
+        continuous = false;
+        interimResults = false;
+        lang = '';
+        onresult: ((e: any) => void) | null = null;
+        onerror: (() => void) | null = null;
+        onend: (() => void) | null = null;
+        start = vi.fn();
+        stop = vi.fn(() => {
+          this.onend?.();
+        });
+        constructor() {
+          instances.push(this);
+        }
+      }
+      vi.stubGlobal('SpeechRecognition', MockSpeechRecognition);
+
+      const api = createMockApi();
+      render(<ChatTab api={api} />);
+
+      const micButton = screen.getByLabelText('Start voice input');
+      fireEvent.click(micButton);
+
+      expect(instances).toHaveLength(1);
+      expect(instances[0].start).toHaveBeenCalledOnce();
+      expect(screen.getByLabelText('Stop voice input')).toBeInTheDocument();
+
+      // A final transcript result should land in the textarea. `results[i]`
+      // mimics a SpeechRecognitionResult: array-indexable to an alternative
+      // with `.transcript`, plus an `.isFinal` flag.
+      const finalResult = Object.assign([{ transcript: 'hello from voice' }], { isFinal: true });
+      act(() => {
+        instances[0].onresult({ resultIndex: 0, results: [finalResult] });
+      });
+      const textarea = screen.getByPlaceholderText('Send a Message');
+      expect(textarea).toHaveValue('hello from voice');
+
+      fireEvent.click(screen.getByLabelText('Stop voice input'));
+      expect(instances[0].stop).toHaveBeenCalledOnce();
+      expect(screen.getByLabelText('Start voice input')).toBeInTheDocument();
+    });
   });
 });

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -25,11 +25,26 @@ import {
   ShieldAlert,
   GitCompare,
   Pencil,
+  Mic,
 } from 'lucide-react';
 import { useAppStore, ChatMessage } from '../store';
 import { GhostlinkAPI } from '../api';
 
 type Message = ChatMessage;
+
+// Browser-native speech-to-text (Web Speech API) — not in TS's DOM lib under
+// the vendor-prefixed name Chrome/Edge actually ship it under, and Firefox/
+// Safari don't implement it at all, hence the `any`-typed feature-detect
+// rather than a proper interface. Cloud-backed (needs internet), unlike the
+// rest of this app's local-first inference — a real tradeoff, not hidden:
+// the mic button below simply doesn't render where this is undefined.
+// Resolved lazily (not a module-level constant) so it reflects `window` at
+// call time rather than whatever it was when this module first loaded —
+// also what makes it mockable in tests via `vi.stubGlobal`.
+function getSpeechRecognitionCtor(): any {
+  if (typeof window === 'undefined') return undefined;
+  return (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
+}
 
 interface Session {
   id: string;
@@ -175,6 +190,14 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   } = useAppStore();
   const [input, setInput] = useState('');
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const recognitionRef = useRef<any>(null);
+  // What was already in the input box when recording started, and the
+  // finalized (non-interim) transcript so far — combined with the current
+  // interim chunk on every onresult event to rebuild the full input value
+  // without duplicating text across repeated interim updates.
+  const recordingBaseRef = useRef('');
+  const finalTranscriptRef = useRef('');
 
   // Controls
   const [temperature] = useState(0.7);
@@ -593,6 +616,58 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
       setError(result.error || 'Failed to resolve tool call');
     }
   };
+
+  // Toggles browser speech-to-text. Rebuilds the full input value on every
+  // `onresult` (base text from before recording + finalized transcript +
+  // current interim chunk) rather than appending, since interim results
+  // fire repeatedly for the same in-progress phrase — appending would
+  // duplicate words on every partial update.
+  const toggleRecording = useCallback(() => {
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor) return;
+    if (isRecording) {
+      recognitionRef.current?.stop();
+      return;
+    }
+    const recognition = new Ctor();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = 'en-US';
+    recordingBaseRef.current = input;
+    finalTranscriptRef.current = '';
+
+    recognition.onresult = (event: any) => {
+      let interim = '';
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript;
+        if (event.results[i].isFinal) {
+          finalTranscriptRef.current += transcript;
+        } else {
+          interim += transcript;
+        }
+      }
+      const combined = [recordingBaseRef.current, finalTranscriptRef.current, interim]
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .join(' ');
+      setInput(combined);
+    };
+    recognition.onerror = () => setIsRecording(false);
+    recognition.onend = () => setIsRecording(false);
+
+    recognitionRef.current = recognition;
+    recognition.start();
+    setIsRecording(true);
+  }, [isRecording, input]);
+
+  // Stop any in-flight recognition if the tab unmounts mid-recording —
+  // otherwise the browser keeps listening (and the mic indicator stays on
+  // in the OS) with nothing left to receive the transcript.
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.stop();
+    };
+  }, []);
 
   const handleCopy = async (content: string, id: string) => {
     try {
@@ -1173,6 +1248,24 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             </div>
 
             <div className="absolute right-3 bottom-3 flex items-center gap-1">
+                {getSpeechRecognitionCtor() && (
+                    <button
+                        onClick={toggleRecording}
+                        aria-label={isRecording ? 'Stop voice input' : 'Start voice input'}
+                        aria-pressed={isRecording}
+                        title={isRecording ? 'Stop voice input' : 'Voice input (requires internet — browser speech recognition)'}
+                        className={`relative p-2 rounded-full transition ${
+                            isRecording
+                                ? 'bg-red-500/20 text-red-400'
+                                : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'
+                        }`}
+                    >
+                        <Mic size={18} aria-hidden="true" />
+                        {isRecording && (
+                            <span className="absolute inset-0 rounded-full bg-red-500/30 animate-ping" aria-hidden="true" />
+                        )}
+                    </button>
+                )}
                 <button
                     onClick={handleSend}
                     disabled={!input.trim() || loading}


### PR DESCRIPTION
## Summary

First of four PRs implementing the remaining roadmap items (voice input, RAG, dashboard, multi-node) — see the approved plan for full context.

- Mic toggle button next to Send in `ChatTab.tsx`, using the Web Speech API (`SpeechRecognition`/`webkitSpeechRecognition`) to transcribe speech directly into the message box.
- Interim results update live; final results accumulate without duplicating text on repeated partial updates.
- The button doesn't render at all on browsers without support (Firefox/Safari) rather than showing a dead control.
- Cleans up recognition on unmount.
- **Trade-off called out directly** (button `title`, CHANGELOG): this is cloud-backed — the browser's built-in recognizer needs internet — a real tension with this app's local-first inference story. A local Whisper.cpp integration is noted as explicit future work, not silently glossed over.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 108 passed, 0 failed, including 2 new tests (button absence without `SpeechRecognition`; start/stop/transcript behavior with a mocked recognizer)
- [x] Manually verified in a live browser: clicking the mic button triggers a real microphone permission request end to end, and correctly resets to its initial state when permission is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)