### PR TITLE
feat(dashboard): real backend health/temperature, cluster load, CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,67 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.10.0] - 2026-07-25 (Dashboard: real backend health, cluster load, CSV export)
+
+Third of four PRs implementing the remaining roadmap items (voice input,
+RAG, dashboard, multi-node — see voice/RAG's own CHANGELOG entries for
+context); this one targeted "live dashboard improvements."
+
+### 🐛 Correctness
+
+- **`BackendRegistry::get_status()` returned hardcoded fake data.**
+  `health` was unconditionally `"healthy"` (even for a backend
+  `available_backends()` doesn't consider available) and
+  `utilization`/`temperature` were always `None` with literal `// TODO`
+  comments, despite `host_metrics.rs` already having working
+  `nvidia-smi`/`rocm-smi` probes it could reuse instead of hardcoding.
+  `health` now reflects real backend availability; `utilization`/
+  `temperature` are populated from the same host-wide GPU probe
+  `/api/metrics` already uses, but only when the queried backend is both
+  the *active* one and GPU-backed — attaching a live reading to an inactive
+  or CPU backend would be presenting a number nothing actually measured
+  for it.
+- **`host_metrics.rs` gains GPU temperature probing** (previously not
+  captured anywhere): `try_nvidia_smi`/`try_rocm_smi` now also query
+  `temperature.gpu`/`--showtemp` in the same CLI call. The Windows
+  generic-fallback path (DirectML/Vulkan iGPUs with no nvidia-smi/rocm-smi)
+  still returns `None` for temperature — there's no vendor-neutral Windows
+  perf counter for it the way there is for utilization — documented in
+  code rather than left as a silent gap.
+
+### ✨ Features
+
+- **New "Backend Health" panel** in the Metrics tab surfacing the
+  now-real utilization/temperature — previously dead data (the
+  `/api/backends/:name/status` endpoint existed but nothing in the UI ever
+  called it).
+- **New "Cluster Load" gauge**, shown only when more than one worker is
+  connected — the average of each worker's `load` figure from
+  `/api/workers` (already centrally polled by `App.tsx`). Note this is a
+  load-percentage aggregate, not a throughput one: `/api/workers` has no
+  per-worker tok/s figure to sum, so "Cluster Throughput" would have been
+  a fabricated label for data that doesn't exist.
+- **CSV export** for the in-memory metrics history — a new header button,
+  disabled when there's no history yet.
+
+### ✅ Validation
+
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D
+  warnings`, `cargo test --workspace` (284 passed, 0 failed, 6 ignored;
+  3 new backend_registry tests constructing a registry directly —
+  bypassing the real hardware probe in `discover()` — so the
+  health/availability and no-fake-GPU-readings assertions are deterministic
+  on any CI runner regardless of what GPU, if any, is present).
+- `tsc --noEmit` clean, `vitest run` (112 passed, 0 failed; 6 new
+  `MetricsTab` tests: Cluster Load gauge visibility and averaging, Backend
+  Health panel rendering real data, "not monitored"/"not available"
+  instead of fake numbers when a backend has no GPU reading, CSV export
+  button's disabled state).
+- Manually verified in a live browser with no backend running: the tab
+  renders cleanly with graceful empty states (no crash), Cluster Load and
+  Backend Health correctly stay hidden with no data to show, and the CSV
+  export button renders correctly disabled.
+
 ## [1.7.1] - 2026-07-25 (Fix: concurrent model load/unload requests corrupted state and could kill llama-server)
 
 Chasing a report of chat suddenly failing with `error sending request for url

--- a/crates/ghost-link/src/backend_registry.rs
+++ b/crates/ghost-link/src/backend_registry.rs
@@ -445,7 +445,36 @@ impl BackendRegistry {
         let is_active = current == *backend;
 
         let status = if is_active { "active" } else { "ready" }.to_string();
-        let health = "healthy".to_string(); // TODO: implement health checks
+        // Previously hardcoded "healthy" unconditionally, even for a backend
+        // that `available_backends()` doesn't consider available — an
+        // unavailable backend reporting itself healthy is actively
+        // misleading. "healthy"/"unavailable" is a real (if coarse) signal;
+        // a genuine degraded-but-available state would need actual runtime
+        // probing this registry doesn't do.
+        let health = if info.available {
+            "healthy"
+        } else {
+            "unavailable"
+        }
+        .to_string();
+
+        // GPU utilization/temperature come from one machine-wide probe
+        // (host_metrics::current_host_snapshot — nvidia-smi/rocm-smi/Windows
+        // perf counters, whichever succeeds first), not a per-backend query.
+        // Only meaningful to attach to the backend that's actually active
+        // and GPU-backed — reporting a live utilization reading against an
+        // inactive or CPU backend would be fabricating a number nothing
+        // actually measured for it.
+        let (utilization, temperature) = if is_active && *backend != ComputeBackend::Cpu {
+            let snapshot = crate::host_metrics::current_host_snapshot();
+            if snapshot.gpu_available {
+                (Some(snapshot.gpu), snapshot.gpu_temp_c)
+            } else {
+                (None, None)
+            }
+        } else {
+            (None, None)
+        };
 
         Some(BackendStatus {
             backend: info.backend,
@@ -453,8 +482,8 @@ impl BackendRegistry {
             vram_gb: info.vram_gb,
             status,
             health,
-            utilization: None, // TODO: query nvidia-smi or rocm-smi
-            temperature: None, // TODO: query nvidia-smi or rocm-smi
+            utilization,
+            temperature,
         })
     }
 }
@@ -516,6 +545,75 @@ mod tests {
         // Switch to CPU should always work
         assert!(registry.switch_backend(ComputeBackend::Cpu).is_ok());
         assert_eq!(registry.current_backend(), ComputeBackend::Cpu);
+    }
+
+    fn info(backend: ComputeBackend, available: bool) -> BackendInfo {
+        BackendInfo {
+            backend,
+            device_name: format!("{} device", backend.as_str()),
+            vram_gb: Some(8.0),
+            compute_capability: "test".to_string(),
+            driver_version: "test".to_string(),
+            available,
+        }
+    }
+
+    // Constructs a registry directly (bypassing the real hardware probe in
+    // `discover()`) so these tests are deterministic on any CI runner,
+    // regardless of what GPU (if any) is actually present.
+    fn registry_with(backends: Vec<BackendInfo>, current: ComputeBackend) -> BackendRegistry {
+        BackendRegistry {
+            backends: Arc::new(Mutex::new(backends)),
+            current: Arc::new(Mutex::new(current)),
+        }
+    }
+
+    #[test]
+    fn get_status_health_reflects_availability_not_hardcoded_healthy() {
+        // Regression: get_status() used to report health: "healthy"
+        // unconditionally, even for a backend available_backends() doesn't
+        // consider available.
+        let registry = registry_with(
+            vec![
+                info(ComputeBackend::Cpu, true),
+                info(ComputeBackend::Cuda, false),
+            ],
+            ComputeBackend::Cpu,
+        );
+
+        let cpu_status = registry.get_status(&ComputeBackend::Cpu).unwrap();
+        assert_eq!(cpu_status.health, "healthy");
+
+        let cuda_status = registry.get_status(&ComputeBackend::Cuda).unwrap();
+        assert_eq!(cuda_status.health, "unavailable");
+    }
+
+    #[test]
+    fn get_status_never_reports_gpu_readings_for_the_cpu_backend() {
+        // Cpu is never GPU-backed, so utilization/temperature must stay None
+        // regardless of what the host's GPU probe (if any) reports — there's
+        // nothing for a "CPU utilization is 40%" GPU-style reading to mean.
+        let registry = registry_with(vec![info(ComputeBackend::Cpu, true)], ComputeBackend::Cpu);
+        let status = registry.get_status(&ComputeBackend::Cpu).unwrap();
+        assert_eq!(status.utilization, None);
+        assert_eq!(status.temperature, None);
+    }
+
+    #[test]
+    fn get_status_never_reports_gpu_readings_for_an_inactive_backend() {
+        // The host-wide GPU probe reflects whichever GPU is actually active;
+        // attaching its reading to a backend that isn't the current one would
+        // be presenting a number nothing measured for it as if it were real.
+        let registry = registry_with(
+            vec![
+                info(ComputeBackend::Cuda, true),
+                info(ComputeBackend::Rocm, true),
+            ],
+            ComputeBackend::Cuda,
+        );
+        let inactive_status = registry.get_status(&ComputeBackend::Rocm).unwrap();
+        assert_eq!(inactive_status.utilization, None);
+        assert_eq!(inactive_status.temperature, None);
     }
 
     #[test]

--- a/crates/ghost-link/src/host_metrics.rs
+++ b/crates/ghost-link/src/host_metrics.rs
@@ -25,6 +25,11 @@ pub struct HostSnapshot {
     pub total_memory_gb: f32,
     pub used_memory_gb: f32,
     pub total_vram_gb: f32,
+    /// GPU die temperature in °C, when the active probe reports one.
+    /// `None` on the Windows generic-fallback path (`try_windows_gpu_counters`)
+    /// — there's no standard cross-vendor perf counter for GPU temperature the
+    /// way there is for utilization, only nvidia-smi/rocm-smi expose it.
+    pub gpu_temp_c: Option<f32>,
 }
 
 impl Default for HostSnapshot {
@@ -37,6 +42,7 @@ impl Default for HostSnapshot {
             total_memory_gb: 0.0,
             used_memory_gb: 0.0,
             total_vram_gb: 0.0,
+            gpu_temp_c: None,
         }
     }
 }
@@ -167,7 +173,7 @@ fn percentile_sorted(sorted: &[f32], q: f32) -> f32 {
 struct HostSamplerState {
     snap: RwLock<HostSnapshot>,
     started: AtomicBool,
-    gpu_cache: Mutex<(Instant, f32, bool, f32)>, // ts, util, available, vram_gb
+    gpu_cache: Mutex<(Instant, f32, bool, f32, Option<f32>)>, // ts, util, available, vram_gb, temp_c
 }
 
 static HOST: OnceLock<HostSamplerState> = OnceLock::new();
@@ -176,7 +182,13 @@ fn host_state() -> &'static HostSamplerState {
     HOST.get_or_init(|| HostSamplerState {
         snap: RwLock::new(HostSnapshot::default()),
         started: AtomicBool::new(false),
-        gpu_cache: Mutex::new((Instant::now() - Duration::from_secs(60), 0.0, false, 0.0)),
+        gpu_cache: Mutex::new((
+            Instant::now() - Duration::from_secs(60),
+            0.0,
+            false,
+            0.0,
+            None,
+        )),
     })
 }
 
@@ -233,7 +245,7 @@ fn refresh_host_once() {
     let total_memory_gb = (total / (1024.0 * 1024.0 * 1024.0)) as f32;
     let used_memory_gb = (used / (1024.0 * 1024.0 * 1024.0)) as f32;
 
-    let (gpu, gpu_available, total_vram_gb) = sample_gpu_cached();
+    let (gpu, gpu_available, total_vram_gb, gpu_temp_c) = sample_gpu_cached();
 
     if let Ok(mut snap) = host_state().snap.write() {
         *snap = HostSnapshot {
@@ -244,36 +256,37 @@ fn refresh_host_once() {
             total_memory_gb,
             used_memory_gb,
             total_vram_gb,
+            gpu_temp_c,
         };
     }
 }
 
-fn sample_gpu_cached() -> (f32, bool, f32) {
+fn sample_gpu_cached() -> (f32, bool, f32, Option<f32>) {
     let state = host_state();
     if let Ok(cache) = state.gpu_cache.lock() {
         if cache.0.elapsed() < Duration::from_millis(GPU_CACHE_MS) {
-            return (cache.1, cache.2, cache.3);
+            return (cache.1, cache.2, cache.3, cache.4);
         }
     }
-    let (util, available, vram) = sample_gpu_util();
+    let (util, available, vram, temp_c) = sample_gpu_util();
     if let Ok(mut cache) = state.gpu_cache.lock() {
-        *cache = (Instant::now(), util, available, vram);
+        *cache = (Instant::now(), util, available, vram, temp_c);
     }
-    (util, available, vram)
+    (util, available, vram, temp_c)
 }
 
-fn sample_gpu_util() -> (f32, bool, f32) {
-    if let Some((util, vram)) = try_nvidia_smi() {
-        return (util, true, vram);
+fn sample_gpu_util() -> (f32, bool, f32, Option<f32>) {
+    if let Some((util, vram, temp_c)) = try_nvidia_smi() {
+        return (util, true, vram, temp_c);
     }
-    if let Some((util, vram)) = try_rocm_smi() {
-        return (util, true, vram);
+    if let Some((util, vram, temp_c)) = try_rocm_smi() {
+        return (util, true, vram, temp_c);
     }
     #[cfg(target_os = "windows")]
-    if let Some((util, vram)) = try_windows_gpu_counters() {
-        return (util, true, vram);
+    if let Some((util, vram, temp_c)) = try_windows_gpu_counters() {
+        return (util, true, vram, temp_c);
     }
-    (0.0, false, 0.0)
+    (0.0, false, 0.0, None)
 }
 
 /// Windows-native fallback GPU utilization for hosts with no nvidia-smi/rocm-smi
@@ -292,8 +305,13 @@ fn sample_gpu_util() -> (f32, bool, f32) {
 /// picking up). No llama-server process running just means 0% — not a probe
 /// failure — so this still reports gpu_available=true (there IS a GPU here,
 /// it's simply idle).
+/// No temperature: Windows exposes GPU utilization for any vendor via the
+/// "GPU Engine" perf counter category used below, but there's no equivalent
+/// vendor-neutral counter for die temperature — that third tuple element is
+/// always `None` here (nvidia-smi/rocm-smi, tried first in `sample_gpu_util`,
+/// cover the vendors that do expose it).
 #[cfg(target_os = "windows")]
-fn try_windows_gpu_counters() -> Option<(f32, f32)> {
+fn try_windows_gpu_counters() -> Option<(f32, f32, Option<f32>)> {
     let output = Command::new("powershell")
         .args([
             "-NoProfile",
@@ -323,7 +341,7 @@ fn try_windows_gpu_counters() -> Option<(f32, f32)> {
     } else {
         trimmed.parse().ok()?
     };
-    Some((util.clamp(0.0, 100.0), windows_vram_gb_cached()))
+    Some((util.clamp(0.0, 100.0), windows_vram_gb_cached(), None))
 }
 
 /// VRAM (really: usable GPU memory budget) for the Windows fallback path.
@@ -361,10 +379,10 @@ fn windows_vram_from_llama_list_devices() -> Option<f32> {
     None
 }
 
-fn try_nvidia_smi() -> Option<(f32, f32)> {
+fn try_nvidia_smi() -> Option<(f32, f32, Option<f32>)> {
     let output = Command::new("nvidia-smi")
         .args([
-            "--query-gpu=utilization.gpu,memory.total",
+            "--query-gpu=utilization.gpu,memory.total,temperature.gpu",
             "--format=csv,noheader,nounits",
         ])
         .output()
@@ -374,17 +392,19 @@ fn try_nvidia_smi() -> Option<(f32, f32)> {
     }
     let text = String::from_utf8_lossy(&output.stdout);
     let line = text.lines().next()?.trim();
-    // e.g. "12, 8192"
+    // e.g. "12, 8192, 47"
     let mut parts = line.split(',').map(|s| s.trim());
     let util: f32 = parts.next()?.parse().ok()?;
     let mem_mib: f32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0.0);
-    Some((util.clamp(0.0, 100.0), mem_mib / 1024.0))
+    let temp_c: Option<f32> = parts.next().and_then(|s| s.parse().ok());
+    Some((util.clamp(0.0, 100.0), mem_mib / 1024.0, temp_c))
 }
 
-fn try_rocm_smi() -> Option<(f32, f32)> {
-    // Best-effort: rocm-smi --showuse prints GPU use %
+fn try_rocm_smi() -> Option<(f32, f32, Option<f32>)> {
+    // Best-effort: rocm-smi --showuse prints GPU use %, --showtemp prints
+    // one or more "Temperature (Sensor ...) (C): NN.N" lines per GPU.
     let output = Command::new("rocm-smi")
-        .args(["--showuse", "--showmeminfo", "vram"])
+        .args(["--showuse", "--showmeminfo", "vram", "--showtemp"])
         .output()
         .ok()?;
     if !output.status.success() {
@@ -393,6 +413,7 @@ fn try_rocm_smi() -> Option<(f32, f32)> {
     let text = String::from_utf8_lossy(&output.stdout);
     let mut util = None;
     let mut vram_gb = 0.0_f32;
+    let mut temp_c = None;
     for line in text.lines() {
         let lower = line.to_ascii_lowercase();
         if lower.contains("gpu use") || lower.contains("gpu%") {
@@ -406,8 +427,13 @@ fn try_rocm_smi() -> Option<(f32, f32)> {
                 vram_gb = if num > 256.0 { num / 1024.0 } else { num };
             }
         }
+        if lower.contains("temperature") {
+            if let Some(num) = extract_first_number(line) {
+                temp_c = Some(num);
+            }
+        }
     }
-    util.map(|u| (u, vram_gb))
+    util.map(|u| (u, vram_gb, temp_c))
 }
 
 fn extract_first_number(s: &str) -> Option<f32> {

--- a/ghostlink_gui_modern/src/components/MetricsTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/MetricsTab.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MetricsTab } from './MetricsTab';
+import { useAppStore } from '../store';
+
+function createMockApi(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    getMetrics: vi.fn().mockResolvedValue({ metrics: null }),
+    getBackends: vi.fn().mockResolvedValue({ available: [], current: 'cpu' }),
+    getBackendStatus: vi.fn().mockResolvedValue({ status: undefined }),
+    ...overrides,
+  };
+}
+
+describe('MetricsTab', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      metrics: null,
+      metricsHistory: [],
+      workers: [],
+    });
+  });
+
+  it('renders without a backend or workers', () => {
+    const api = createMockApi();
+    render(<MetricsTab api={api} />);
+    expect(screen.getByText('System Performance')).toBeInTheDocument();
+  });
+
+  it('does not show the Cluster Load gauge with 0 or 1 workers', () => {
+    useAppStore.setState({
+      workers: [{ id: 'w1', host: '127.0.0.1', port: 8003, status: 'Connected', model: 'x', threads: 4, load: 50 }],
+    });
+    const api = createMockApi();
+    render(<MetricsTab api={api} />);
+    expect(screen.queryByText('Cluster Load')).not.toBeInTheDocument();
+  });
+
+  it('shows the Cluster Load gauge averaging worker load with 2+ workers', () => {
+    useAppStore.setState({
+      workers: [
+        { id: 'w1', host: '127.0.0.1', port: 8003, status: 'Connected', model: 'x', threads: 4, load: 40 },
+        { id: 'w2', host: '127.0.0.2', port: 8003, status: 'Connected', model: 'x', threads: 4, load: 60 },
+      ],
+    });
+    const api = createMockApi();
+    render(<MetricsTab api={api} />);
+    expect(screen.getByText('Cluster Load')).toBeInTheDocument();
+    expect(screen.getByText('50.0%')).toBeInTheDocument();
+    expect(screen.getByText('avg across 2 workers')).toBeInTheDocument();
+  });
+
+  it('shows a real (not hardcoded) Backend Health panel once the status poll resolves', async () => {
+    const api = createMockApi({
+      getBackends: vi.fn().mockResolvedValue({ available: [], current: 'directml' }),
+      getBackendStatus: vi.fn().mockResolvedValue({
+        status: {
+          backend: 'directml',
+          device_name: 'AMD Radeon 860M',
+          status: 'active',
+          health: 'healthy',
+          utilization: 42,
+          temperature: 61,
+        },
+      }),
+    });
+    render(<MetricsTab api={api} />);
+
+    await waitFor(() => expect(screen.getByText('Backend Health')).toBeInTheDocument());
+    expect(screen.getByText('AMD Radeon 860M')).toBeInTheDocument();
+    expect(screen.getByText('healthy')).toBeInTheDocument();
+    expect(screen.getByText('42%')).toBeInTheDocument();
+    expect(screen.getByText('61°C')).toBeInTheDocument();
+  });
+
+  it('renders "not monitored"/"not available" instead of fake numbers when the backend has no GPU reading', async () => {
+    const api = createMockApi({
+      getBackends: vi.fn().mockResolvedValue({ available: [], current: 'cpu' }),
+      getBackendStatus: vi.fn().mockResolvedValue({
+        status: { backend: 'cpu', device_name: 'CPU', status: 'active', health: 'healthy', utilization: null, temperature: null },
+      }),
+    });
+    render(<MetricsTab api={api} />);
+
+    await waitFor(() => expect(screen.getByText('Backend Health')).toBeInTheDocument());
+    expect(screen.getByText('not monitored')).toBeInTheDocument();
+    expect(screen.getByText('not available')).toBeInTheDocument();
+  });
+
+  it('disables CSV export with no history and enables it once samples exist', () => {
+    const api = createMockApi();
+    const { rerender } = render(<MetricsTab api={api} />);
+    expect(screen.getByLabelText('Export metrics history as CSV')).toBeDisabled();
+
+    useAppStore.setState({
+      metricsHistory: [{ t: Date.now(), throughput: 10, cpu: 5, memory: 5, gpu: 0, latency_p50: 1, latency_p95: 2 }],
+    });
+    rerender(<MetricsTab api={api} />);
+    expect(screen.getByLabelText('Export metrics history as CSV')).not.toBeDisabled();
+  });
+});

--- a/ghostlink_gui_modern/src/components/MetricsTab.tsx
+++ b/ghostlink_gui_modern/src/components/MetricsTab.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { RefreshCw, Activity, Cpu, Database, Zap, Clock, ShieldCheck, Server, TrendingUp } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { RefreshCw, Activity, Cpu, Database, Zap, Clock, ShieldCheck, Server, TrendingUp, HeartPulse, Thermometer, Download, Network } from 'lucide-react';
 import {
   ResponsiveContainer,
   LineChart,
@@ -13,9 +13,20 @@ import {
 import { useAppStore } from '../store';
 import { EmptyState } from './StatusViews';
 
+interface BackendStatus {
+  backend?: string;
+  device_name?: string;
+  vram_gb?: number | null;
+  status?: string;
+  health?: string;
+  utilization?: number | null;
+  temperature?: number | null;
+}
+
 export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
-  const { metrics, setMetrics, metricsHistory } = useAppStore();
+  const { metrics, setMetrics, metricsHistory, workers } = useAppStore();
   const [loading, setLoading] = React.useState(false);
+  const [backendStatus, setBackendStatus] = useState<BackendStatus | null>(null);
 
   // App.tsx already polls metrics every 5s — only manual refresh here.
   const refreshMetrics = async () => {
@@ -28,6 +39,59 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
     } finally {
       setLoading(false);
     }
+  };
+
+  // Backend health/utilization/temperature aren't part of the shared
+  // /api/metrics poll (App.tsx) — a separate, tab-local poll, same 5s
+  // cadence WorkersTab.tsx uses for its own local data.
+  useEffect(() => {
+    let cancelled = false;
+    const refreshBackendStatus = async () => {
+      const backends = await api.getBackends();
+      if (cancelled || backends.error || !backends.current) return;
+      const statusResult = await api.getBackendStatus(backends.current);
+      if (!cancelled && !statusResult.error && statusResult.status) {
+        setBackendStatus(statusResult.status);
+      }
+    };
+    refreshBackendStatus();
+    const interval = setInterval(refreshBackendStatus, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [api]);
+
+  // Average per-worker load — only meaningful once there's more than one
+  // worker to aggregate across; /api/workers has no throughput figure (only
+  // `load` 0-100%), so this is a load aggregate, not a tok/s one.
+  const clusterLoad = useMemo(() => {
+    if (workers.length <= 1) return null;
+    const total = workers.reduce((sum, w) => sum + (w.load ?? 0), 0);
+    return total / workers.length;
+  }, [workers]);
+
+  const exportMetricsCsv = () => {
+    const header = 'time,throughput_tok_s,latency_p50_ms,latency_p95_ms,cpu_pct,memory_pct,gpu_pct';
+    const rows = metricsHistory.map((m) =>
+      [
+        new Date(m.t).toISOString(),
+        m.throughput ?? 0,
+        m.latency_p50 ?? 0,
+        m.latency_p95 ?? 0,
+        m.cpu ?? 0,
+        m.memory ?? 0,
+        m.gpu ?? 0,
+      ].join(',')
+    );
+    const csv = [header, ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `ghostlink-metrics-${new Date().toISOString().replace(/[:.]/g, '-')}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   const throughputHistory = useMemo(() => metricsHistory.map((m) => m.throughput ?? 0), [metricsHistory]);
@@ -78,14 +142,25 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
             {typeof metrics?.samples === 'number' ? ` · ${metrics.samples} samples` : ''}
           </p>
         </div>
-        <button
-          onClick={refreshMetrics}
-          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition"
-          title="Refresh metrics"
-          aria-label="Refresh metrics"
-        >
-          <RefreshCw size={18} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={exportMetricsCsv}
+            disabled={metricsHistory.length === 0}
+            className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition disabled:opacity-30 disabled:hover:bg-transparent"
+            title="Export metrics history as CSV"
+            aria-label="Export metrics history as CSV"
+          >
+            <Download size={18} aria-hidden="true" />
+          </button>
+          <button
+            onClick={refreshMetrics}
+            className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition"
+            title="Refresh metrics"
+            aria-label="Refresh metrics"
+          >
+            <RefreshCw size={18} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto p-6">
@@ -128,7 +203,7 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
             />
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className={`grid grid-cols-1 md:grid-cols-3 ${clusterLoad !== null ? 'lg:grid-cols-4' : ''} gap-6`}>
             <GaugeCard label="CPU Utilization" value={metrics?.cpu ?? 0} icon={Cpu} color="text-emerald-400" />
             <GaugeCard label="Memory Usage" value={metrics?.memory ?? 0} icon={Database} color="text-purple-400" />
             <GaugeCard
@@ -138,7 +213,53 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
               color="text-blue-400"
               subtitle={gpuLabel}
             />
+            {clusterLoad !== null && (
+              <GaugeCard
+                label="Cluster Load"
+                value={clusterLoad}
+                icon={Network}
+                color="text-amber-400"
+                subtitle={`avg across ${workers.length} workers`}
+              />
+            )}
           </div>
+
+          {backendStatus && (
+            <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
+              <h3 className="text-lg font-bold text-white mb-4 flex items-center gap-2">
+                <HeartPulse size={20} className="text-pink-500" aria-hidden="true" />
+                Backend Health
+              </h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <div>
+                  <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-1">Device</p>
+                  <p className="text-sm text-slate-200 truncate">{backendStatus.device_name || backendStatus.backend || 'unknown'}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-1">Health</p>
+                  <p className={`text-sm font-bold ${backendStatus.health === 'healthy' ? 'text-green-400' : 'text-red-400'}`}>
+                    {backendStatus.health ?? 'unknown'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-1 flex items-center gap-1">
+                    <ShieldCheck size={10} aria-hidden="true" /> Utilization
+                  </p>
+                  <p className="text-sm text-slate-200">
+                    {backendStatus.utilization != null ? `${backendStatus.utilization.toFixed(0)}%` : 'not monitored'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-1 flex items-center gap-1">
+                    <Thermometer size={10} aria-hidden="true" /> Temperature
+                  </p>
+                  <p className="text-sm text-slate-200">
+                    {backendStatus.temperature != null ? `${backendStatus.temperature.toFixed(0)}°C` : 'not available'}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
 
           <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6">
             <div className="flex items-baseline justify-between mb-4">


### PR DESCRIPTION
## Summary

Third of four PRs implementing the remaining roadmap items (voice input, RAG, dashboard, multi-node) — see the approved plan for full context.

**Fixed a real bug**: `BackendRegistry::get_status()` returned hardcoded fake data — `health` was unconditionally `"healthy"`, and `utilization`/`temperature` were always `None` with literal `// TODO` comments, despite `host_metrics.rs` already having working `nvidia-smi`/`rocm-smi` probes it could reuse.

- `health` now reflects real backend availability.
- `utilization`/`temperature` come from the same host-wide GPU probe `/api/metrics` uses, but only attached to the *active*, GPU-backed backend — never fabricated for an inactive or CPU backend.
- `host_metrics.rs` gains GPU **temperature** probing (didn't exist anywhere before) via the same `nvidia-smi`/`rocm-smi` CLI calls, no extra process spawn. Windows' generic DirectML/Vulkan fallback path honestly still returns `None` — there's no vendor-neutral perf counter for GPU temperature the way there is for utilization.

**Dashboard additions** (`MetricsTab.tsx`):
- New "Backend Health" panel surfacing the now-real data — previously dead (`/api/backends/:name/status` existed, nothing in the UI ever called it).
- New "Cluster Load" gauge (shown only with 2+ workers) — averages each worker's `load` %. Note: this is a load aggregate, not throughput — `/api/workers` has no per-worker tok/s to sum, so I adjusted away from the plan's original "Cluster Throughput" label rather than build to a name that doesn't match the data.
- CSV export for the in-memory metrics history.

## Test plan

- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 284 passed, 0 failed, 6 ignored (3 new deterministic `backend_registry` tests, not dependent on real hardware)
- [x] `tsc --noEmit` clean, `vitest run` — 112 passed, 0 failed (6 new `MetricsTab` tests)
- [x] Manually verified in a live browser with no backend running: clean graceful empty states, new panels correctly stay hidden with no data, CSV button renders disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)