### PR TITLE
Multi-node: real cross-process flow execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,84 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.9.0] - 2026-07-26 (Multi-node: real cross-process execution, replacing the fabricated flow demo)
+
+### 🐛 Fixed (fabrication)
+
+- **`ghost-link flow` never actually reached a second machine, even when
+  given a `--remote-addr`-shaped setup** (it had no such flag at all). It
+  registered a fake "remote" node and hand-seeded its metrics
+  (`record_latency(3.2)`, `record_delivery_ratio(0.95)`) — the entire
+  "distributed" demo ran in one process. `docker-compose.test-fabric.yml`
+  stood up real worker containers whose IPs were never dialed.
+
+### ✨ Features
+
+- **New `ghost-link stage-worker --bind <addr>` process**: binds a TCP
+  listener, accepts exactly one coordinator connection, reads a handshake
+  describing its assigned stage, then loops real batch exchange
+  (`read_transport_batch` → compute → `write_transport_batch`) until the
+  coordinator disconnects — a genuine one-shot worker, not a simulation.
+- **New `flow --remote-addr <host:port>` flag**: when given, the
+  coordinator does a real outbound `TcpStream::connect` to a running
+  `stage-worker` and executes that node's stage(s) across the real
+  socket, deriving the remote node's health metrics from the actual
+  measured round-trip time instead of placeholder constants. Because real
+  layer assignment splits one node's range into multiple raw pipeline
+  stages (verified: 60 layers / 2 nodes → 11 raw stages), a new
+  `merge_stages_for_node` helper collapses all of a node's stages into one
+  logical placement before executing it remotely.
+  Omitting `--remote-addr` keeps today's single-process behavior exactly
+  as before, but now prints `SIMULATED execution: ...` instead of
+  silently implying a second machine was involved.
+- **`docker-compose.test-fabric.yml` fixed to match its own apparent
+  intent**: `ghostlink-worker-2` now runs `stage-worker` and the
+  coordinator's `flow` command connects to it via `--remote-addr` across
+  the compose network, instead of both sides running unrelated commands
+  that never talked to each other.
+- **New benchmark harness** (`scripts/remote_flow_benchmark.py`) drives
+  the real `stage-worker`/`flow --remote-addr` path repeatedly and reports
+  measured throughput and real remote round-trip time — for use across
+  two physical machines to get honest multi-host numbers.
+
+### 🐛 Fixed (latent, found while building the harness)
+
+- `ghost-link stage-worker` ignored `GHOSTLINK_TCP_AUTH_TOKEN` and other
+  TCP transport env vars entirely, always using
+  `TcpTransportConfig::default()` — meaning a coordinator configured with
+  a non-default auth token (exactly what the docker-compose fix above
+  does) would have its connection reset by the worker. Now reads the same
+  `tcp_transport_config_from_env()` the coordinator already uses.
+
+### 📝 Docs
+
+- `docs/DEPLOYMENT.md` gained a "Stage 3b: Real Cross-Machine Flow
+  Execution" section documenting `stage-worker`/`flow --remote-addr`, with
+  an explicit callout that the transport is genuinely cross-process but
+  `run_stage_compute` remains a synthetic timing proxy, not real
+  distributed LLM inference.
+- `docs/BENCHMARKS.md`'s "Multi-Node Performance / LAN Performance" table
+  — untraceable to any real run, and impossible to have produced before
+  this PR since `flow` couldn't reach a second machine — is now explicitly
+  labeled "unverified, pending a real multi-host run" instead of presented
+  as measured. A real (loopback smoke-test) run of the new harness is
+  documented alongside it.
+
+### ✅ Validation
+
+- New `crates/ghost-link/tests/stage_worker_integration.rs`: spawns the
+  real `ghost-link` binary as two separate OS processes (not threads, not
+  in-process calls) via `CARGO_BIN_EXE_ghost-link`, and asserts the `flow`
+  process actually took the `REAL execution` path and the `stage-worker`
+  process actually processed a nonzero batch count.
+- 4 new `ghostlink-core` unit tests for the handshake, remote-stage
+  rejection on missing stages, stage-merging, and a real (non-loopback
+  simulation) TCP round trip.
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D
+  warnings`, and `cargo test --workspace` all pass: 138 `ghostlink-core`
+  tests, 99 `ghost-link` unit tests, 1 new integration test, 10 `mcp-rag`
+  tests — all green.
+
 ## [1.8.0] - 2026-07-25 (Voice input in chat)
 
 ### ✨ Features

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -25,7 +25,8 @@ use ghostlink_core::protocol::NodeResources;
 use ghostlink_core::protocol::{DiscoveryFrame, FrameKind};
 use ghostlink_core::runtime::{
     build_token_schedule, execute_pipeline_tcp_loopback_with_config,
-    execute_pipeline_with_rebalance_and_measured, DeviceKind, PipelinePlan, TcpTransportConfig,
+    execute_pipeline_with_rebalance_and_measured, execute_pipeline_with_remote_stage,
+    run_stage_worker, DeviceKind, PipelinePlan, TcpTransportConfig,
 };
 use ghostlink_core::xdp::probe_xdp_support;
 use serde::{Deserialize, Serialize};
@@ -158,6 +159,13 @@ struct FlowOptions<'a> {
     transport_mode: FlowTransportMode,
     top_k: usize,
     penalty: f32,
+    /// Real cross-process execution when set: `remote_id`'s stage runs on
+    /// a separate `ghost-link stage-worker --bind <this address>` process
+    /// (started ahead of time by the caller) instead of being simulated
+    /// in-process like every other transport mode here. `None` keeps the
+    /// existing local-simulation behavior, now honestly labeled as such in
+    /// the printed output rather than implying a real second node.
+    remote_addr: Option<SocketAddr>,
 }
 
 fn main() -> Result<()> {
@@ -401,6 +409,9 @@ enum CliCommand {
         node_id: String,
         once: bool,
     },
+    StageWorker {
+        bind: String,
+    },
     Gui {
         args: Vec<String>,
     },
@@ -430,6 +441,10 @@ enum CliCommand {
         transport_mode: FlowTransportMode,
         top_k: usize,
         penalty: f32,
+        /// When set, `remote_id`'s stage runs for real on a separate
+        /// `ghost-link stage-worker` process at this address instead of
+        /// being simulated locally. See `FlowOptions::remote_addr`.
+        remote_addr: Option<SocketAddr>,
     },
     Serve {
         port: u16,
@@ -451,6 +466,7 @@ fn execute_command(command: CliCommand) -> Result<()> {
         CliCommand::Plan => print_plan()?,
         CliCommand::Join { node_id } => print_join(&node_id)?,
         CliCommand::Listen { node_id, once } => print_discovery_listener(&node_id, once)?,
+        CliCommand::StageWorker { bind } => print_stage_worker(&bind)?,
         CliCommand::Gui { args } => launch_mohawk_gui(&args)?,
         CliCommand::GuiCheck { strict } => print_gui_readiness(strict)?,
         CliCommand::GuiDiagnose { strict } => print_gui_diagnostics(strict)?,
@@ -471,6 +487,7 @@ fn execute_command(command: CliCommand) -> Result<()> {
             transport_mode,
             top_k,
             penalty,
+            remote_addr,
         } => print_flow(FlowOptions {
             local_id: &local_id,
             remote_id: &remote_id,
@@ -481,6 +498,7 @@ fn execute_command(command: CliCommand) -> Result<()> {
             transport_mode,
             top_k,
             penalty,
+            remote_addr,
         })?,
         CliCommand::Serve { port, host } => start_openai_api_server(port, &host)?,
         CliCommand::Help => print_help(),
@@ -510,6 +528,12 @@ where
             });
             let once = args.any(|arg| arg == "--once");
             Ok(CliCommand::Listen { node_id, once })
+        }
+        "stage-worker" => {
+            let bind = args.next().unwrap_or_else(|| {
+                env_default_string("GHOSTLINK_STAGE_WORKER_DEFAULT_BIND", "0.0.0.0:9500")
+            });
+            Ok(CliCommand::StageWorker { bind })
         }
         "gui" => Ok(CliCommand::Gui {
             args: args.collect(),
@@ -591,6 +615,21 @@ where
             let transport_mode =
                 parse_flow_transport_mode(cli_transport.as_deref().or(env_transport.as_deref()))?;
 
+            // Trailing flag, not positional (unlike everything above it) —
+            // scan whatever's left rather than consuming a fixed slot, so
+            // it can be added/omitted without shifting the existing
+            // positional argument order.
+            let remaining: Vec<String> = args.collect();
+            let remote_addr = remaining
+                .iter()
+                .position(|a| a == "--remote-addr")
+                .and_then(|i| remaining.get(i + 1))
+                .map(|s| {
+                    s.parse::<SocketAddr>()
+                        .map_err(|e| anyhow::anyhow!("invalid --remote-addr '{s}': {e}"))
+                })
+                .transpose()?;
+
             Ok(CliCommand::Flow {
                 local_id,
                 remote_id,
@@ -601,6 +640,7 @@ where
                 transport_mode,
                 top_k: 40,
                 penalty: 1.1,
+                remote_addr,
             })
         }
         "serve" => {
@@ -1187,11 +1227,19 @@ fn print_flow(opts: FlowOptions) -> Result<()> {
         metrics.record_delivery_ratio(0.97);
         metrics.record_throughput(8.0);
     });
-    cluster.get_metrics_mut(opts.remote_id, |metrics| {
-        metrics.record_latency(3.2);
-        metrics.record_delivery_ratio(0.95);
-        metrics.record_throughput(7.4);
-    });
+    // Remote metrics are seeded with placeholder constants ONLY for the
+    // simulated (no --remote-addr) path, where there's no real connection to
+    // measure anything from — the health monitor still needs *some* number
+    // to classify status against. When --remote-addr is given, these get
+    // replaced below with figures derived from the actual execution result
+    // instead of being presented as if they were real from the start.
+    if opts.remote_addr.is_none() {
+        cluster.get_metrics_mut(opts.remote_id, |metrics| {
+            metrics.record_latency(3.2);
+            metrics.record_delivery_ratio(0.95);
+            metrics.record_throughput(7.4);
+        });
+    }
 
     let health_monitor =
         NetworkHealthMonitor::with_runtime_profile(Arc::new(cluster.clone()), &local_profile);
@@ -1220,108 +1268,149 @@ fn print_flow(opts: FlowOptions) -> Result<()> {
     let token_schedule = build_token_schedule(pipeline_plan.stages.len(), schedule_preview_tokens);
     let mut selected_tcp_cfg: Option<TcpTransportConfig> = None;
     let mut effective_transport_mode = opts.transport_mode;
-    let execution = match opts.transport_mode {
-        FlowTransportMode::TcpLoopback => {
-            let base_tcp_cfg = tcp_transport_config_from_env();
-            let tcp_cfg = if is_env_truthy("GHOSTLINK_TCP_AUTOTUNE") {
-                autotune_tcp_transport_config(
+    let execution = if let Some(remote_addr) = opts.remote_addr {
+        // Real path: remote_id's stage(s) run on a separate stage-worker
+        // process — merged into one logical stage internally, since the
+        // real layer-assignment algorithm splits one node's range into
+        // several raw stages rather than exactly one (verified: a 60-layer/
+        // 2-node plan produces ~11 raw stages). See
+        // execute_pipeline_with_remote_stage's doc comment.
+        println!(
+            "REAL execution: {}'s stage runs on a separate process at {remote_addr} \
+             (start it first with `ghost-link stage-worker --bind {remote_addr}`)",
+            opts.remote_id
+        );
+        execute_pipeline_with_remote_stage(
+            &pipeline_plan,
+            opts.local_id,
+            opts.remote_id,
+            opts.execution_tokens,
+            opts.micro_batch,
+            tcp_transport_config_from_env(),
+            remote_addr,
+        )
+    } else {
+        println!(
+            "SIMULATED execution: single process, no second machine involved. \
+             Pass --remote-addr <host:port> (with a `ghost-link stage-worker` \
+             already running there) for real cross-process execution."
+        );
+        match opts.transport_mode {
+            FlowTransportMode::TcpLoopback => {
+                let base_tcp_cfg = tcp_transport_config_from_env();
+                let tcp_cfg = if is_env_truthy("GHOSTLINK_TCP_AUTOTUNE") {
+                    autotune_tcp_transport_config(
+                        &pipeline_plan,
+                        opts.execution_tokens,
+                        opts.micro_batch,
+                        base_tcp_cfg,
+                    )?
+                } else {
+                    base_tcp_cfg
+                };
+                selected_tcp_cfg = Some(tcp_cfg.clone());
+                execute_pipeline_tcp_loopback_with_config(
                     &pipeline_plan,
                     opts.execution_tokens,
                     opts.micro_batch,
-                    base_tcp_cfg,
-                )?
-            } else {
-                base_tcp_cfg
-            };
-            selected_tcp_cfg = Some(tcp_cfg.clone());
-            execute_pipeline_tcp_loopback_with_config(
-                &pipeline_plan,
-                opts.execution_tokens,
-                opts.micro_batch,
-                tcp_cfg,
-            )
-        }
-        FlowTransportMode::InMemory => {
-            let rebalance = if enable_inmem_runtime_feedback {
-                Some(&rebalance_trigger)
-            } else {
-                None
-            };
-            let cluster_feedback = if enable_inmem_runtime_feedback {
-                Some(&cluster)
-            } else {
-                None
-            };
-            let placement_feedback = if enable_inmem_runtime_feedback {
-                Some(&placement_context)
-            } else {
-                None
-            };
+                    tcp_cfg,
+                )
+            }
+            FlowTransportMode::InMemory => {
+                let rebalance = if enable_inmem_runtime_feedback {
+                    Some(&rebalance_trigger)
+                } else {
+                    None
+                };
+                let cluster_feedback = if enable_inmem_runtime_feedback {
+                    Some(&cluster)
+                } else {
+                    None
+                };
+                let placement_feedback = if enable_inmem_runtime_feedback {
+                    Some(&placement_context)
+                } else {
+                    None
+                };
 
-            execute_pipeline_with_rebalance_and_measured(
-                &pipeline_plan,
-                opts.execution_tokens,
-                opts.micro_batch,
-                rebalance,
-                cluster_feedback,
-                placement_feedback,
-            )
-        }
-        FlowTransportMode::Xdp => {
-            let interface = xdp_interface_from_env();
-            match probe_xdp_support(&interface) {
-                Ok(()) => {
-                    println!(
+                execute_pipeline_with_rebalance_and_measured(
+                    &pipeline_plan,
+                    opts.execution_tokens,
+                    opts.micro_batch,
+                    rebalance,
+                    cluster_feedback,
+                    placement_feedback,
+                )
+            }
+            FlowTransportMode::Xdp => {
+                let interface = xdp_interface_from_env();
+                match probe_xdp_support(&interface) {
+                    Ok(()) => {
+                        println!(
                         "AF_XDP probe succeeded on interface '{}'; using xdp-optimized runtime settings.",
                         interface
                     );
-                    let base_tcp_cfg = xdp_optimized_tcp_config();
-                    let tcp_cfg = if xdp_autotune_enabled() {
-                        autotune_tcp_transport_config(
+                        let base_tcp_cfg = xdp_optimized_tcp_config();
+                        let tcp_cfg = if xdp_autotune_enabled() {
+                            autotune_tcp_transport_config(
+                                &pipeline_plan,
+                                opts.execution_tokens,
+                                opts.micro_batch,
+                                base_tcp_cfg,
+                            )?
+                        } else {
+                            base_tcp_cfg
+                        };
+                        selected_tcp_cfg = Some(tcp_cfg.clone());
+                        execute_pipeline_tcp_loopback_with_config(
                             &pipeline_plan,
                             opts.execution_tokens,
                             opts.micro_batch,
-                            base_tcp_cfg,
-                        )?
-                    } else {
-                        base_tcp_cfg
-                    };
-                    selected_tcp_cfg = Some(tcp_cfg.clone());
-                    execute_pipeline_tcp_loopback_with_config(
-                        &pipeline_plan,
-                        opts.execution_tokens,
-                        opts.micro_batch,
-                        tcp_cfg,
-                    )
-                }
-                Err(reason) => {
-                    println!(
-                        "AF_XDP unavailable on '{}': {}. Falling back to TCP transport.",
-                        interface, reason
-                    );
-                    effective_transport_mode = FlowTransportMode::TcpLoopback;
-                    let base_tcp_cfg = tcp_transport_config_from_env();
-                    let tcp_cfg = if is_env_truthy("GHOSTLINK_TCP_AUTOTUNE") {
-                        autotune_tcp_transport_config(
+                            tcp_cfg,
+                        )
+                    }
+                    Err(reason) => {
+                        println!(
+                            "AF_XDP unavailable on '{}': {}. Falling back to TCP transport.",
+                            interface, reason
+                        );
+                        effective_transport_mode = FlowTransportMode::TcpLoopback;
+                        let base_tcp_cfg = tcp_transport_config_from_env();
+                        let tcp_cfg = if is_env_truthy("GHOSTLINK_TCP_AUTOTUNE") {
+                            autotune_tcp_transport_config(
+                                &pipeline_plan,
+                                opts.execution_tokens,
+                                opts.micro_batch,
+                                base_tcp_cfg,
+                            )?
+                        } else {
+                            base_tcp_cfg
+                        };
+                        selected_tcp_cfg = Some(tcp_cfg.clone());
+                        execute_pipeline_tcp_loopback_with_config(
                             &pipeline_plan,
                             opts.execution_tokens,
                             opts.micro_batch,
-                            base_tcp_cfg,
-                        )?
-                    } else {
-                        base_tcp_cfg
-                    };
-                    selected_tcp_cfg = Some(tcp_cfg.clone());
-                    execute_pipeline_tcp_loopback_with_config(
-                        &pipeline_plan,
-                        opts.execution_tokens,
-                        opts.micro_batch,
-                        tcp_cfg,
-                    )
+                            tcp_cfg,
+                        )
+                    }
                 }
             }
         }
     };
+
+    // Replace the remote node's placeholder health-monitor metrics (never
+    // seeded in the first place for this path — see above) with figures
+    // derived from what actually happened, now that it's known.
+    if let (Some(_), Ok(result)) = (opts.remote_addr, &execution) {
+        if let Some(remote_stats) = result.stage_stats.get(1) {
+            cluster.get_metrics_mut(opts.remote_id, |metrics| {
+                metrics.record_latency(remote_stats.avg_bridge_write_ms.max(0.01) * 1000.0);
+                metrics.record_delivery_ratio(1.0);
+                metrics.record_throughput(result.throughput_tokens_per_sec);
+            });
+        }
+    }
 
     let load_balancer =
         LoadBalancer::with_runtime_profile(Arc::new(cluster.clone()), &local_profile);
@@ -6382,6 +6471,36 @@ Auto-tuned local runtime: {} workers, {} acceleration",
     Ok(())
 }
 
+/// Runs one pipeline stage for real on this machine, waiting for a
+/// `ghost-link flow --remote-addr <this bind address>` coordinator to
+/// connect. See `ghostlink_core::runtime::run_stage_worker` for the actual
+/// accept/handshake/compute loop this just binds a listener for and reports
+/// the result of — this function is deliberately thin, matching how
+/// `print_join`/`print_discovery_listener` above are thin wrappers around
+/// `ghostlink_core::discovery`.
+fn print_stage_worker(bind: &str) -> Result<()> {
+    let bind_addr: SocketAddr = bind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid --bind address '{bind}': {e}"))?;
+
+    println!("Ghost-Link Stage Worker\n");
+    println!("=======================\n");
+    println!("Binding: {bind_addr}");
+    println!("Waiting for one coordinator connection (this process handles exactly one, then exits — same one-shot model `cluster-start`'s child processes already use)...");
+
+    let listener = std::net::TcpListener::bind(bind_addr)
+        .map_err(|e| anyhow::anyhow!("failed to bind {bind_addr}: {e}"))?;
+
+    let summary = run_stage_worker(listener, &tcp_transport_config_from_env())
+        .map_err(|e| anyhow::anyhow!("stage worker failed: {e}"))?;
+
+    println!(
+        "Done: processed {} batch(es), avg compute {:.2} ms/batch",
+        summary.batches_processed, summary.avg_compute_ms
+    );
+    Ok(())
+}
+
 fn print_cluster_start(node_count: usize, base_port: u16) -> Result<()> {
     let mut listeners = Vec::new();
     let self_exe = std::env::current_exe()
@@ -8104,11 +8223,13 @@ mod tests {
         if let CliCommand::Flow {
             local_id,
             transport_mode,
+            remote_addr,
             ..
         } = flow
         {
             assert_eq!(local_id, "l1");
             assert_eq!(transport_mode, FlowTransportMode::TcpLoopback);
+            assert_eq!(remote_addr, None);
         } else {
             panic!("Expected Flow");
         }
@@ -8118,6 +8239,61 @@ mod tests {
             CliCommand::Serve {
                 port: 1234,
                 host: "0.0.0.0".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_cli_flow_remote_addr() {
+        let flow = parse_cli(args(&[
+            "flow",
+            "l1",
+            "r1",
+            "16",
+            "32",
+            "128",
+            "8",
+            "tcp",
+            "--remote-addr",
+            "192.168.1.50:9500",
+        ]))
+        .unwrap();
+        let CliCommand::Flow { remote_addr, .. } = flow else {
+            panic!("Expected Flow");
+        };
+        assert_eq!(
+            remote_addr,
+            Some("192.168.1.50:9500".parse::<SocketAddr>().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_parse_cli_flow_rejects_invalid_remote_addr() {
+        let err = parse_cli(args(&[
+            "flow",
+            "l1",
+            "r1",
+            "16",
+            "32",
+            "128",
+            "8",
+            "tcp",
+            "--remote-addr",
+            "not-an-addr",
+        ]))
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid --remote-addr"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_cli_stage_worker() {
+        assert_eq!(
+            parse_cli(args(&["stage-worker", "127.0.0.1:9500"])).unwrap(),
+            CliCommand::StageWorker {
+                bind: "127.0.0.1:9500".to_string()
             }
         );
     }

--- a/crates/ghost-link/tests/stage_worker_integration.rs
+++ b/crates/ghost-link/tests/stage_worker_integration.rs
@@ -1,0 +1,124 @@
+//! Spawns the real `ghost-link` binary as two separate OS processes — a
+//! `stage-worker` and a `flow --remote-addr` coordinator — and asserts they
+//! actually talk to each other over a real TCP socket. This is deliberately
+//! NOT a unit test calling `execute_pipeline_with_remote_stage` in-process:
+//! the point is to prove the CLI-level feature works across a genuine
+//! process boundary, the same way a user invoking it from two terminals
+//! would exercise it. `env!("CARGO_BIN_EXE_ghost-link")` is required here —
+//! `std::env::current_exe()` inside a test resolves to the test harness
+//! binary, not `ghost-link.exe`.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+#[test]
+fn flow_remote_addr_executes_across_real_processes() {
+    let bin = env!("CARGO_BIN_EXE_ghost-link");
+    let bind_addr = "127.0.0.1:19733";
+
+    let mut worker = Command::new(bin)
+        .arg("stage-worker")
+        .arg(bind_addr)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn stage-worker child process");
+
+    // Give the worker time to bind before the coordinator dials it —
+    // matches print_cluster_start's own settle delay for the same reason.
+    std::thread::sleep(Duration::from_millis(300));
+
+    let flow_output = Command::new(bin)
+        .args([
+            "flow",
+            "node-local",
+            "node-remote",
+            "32",
+            "32",
+            "8",
+            "4",
+            "tcp",
+            "--remote-addr",
+            bind_addr,
+        ])
+        .output()
+        .expect("failed to run flow child process");
+
+    let worker_status = worker
+        .wait_timeout_or_kill(Duration::from_secs(20))
+        .expect("stage-worker did not exit after handling the coordinator");
+
+    let mut worker_stdout = String::new();
+    worker
+        .stdout
+        .take()
+        .expect("worker stdout was not piped")
+        .read_to_string(&mut worker_stdout)
+        .expect("failed to read worker stdout");
+
+    let flow_stdout = String::from_utf8_lossy(&flow_output.stdout);
+
+    assert!(
+        flow_output.status.success(),
+        "flow process exited with {:?}\nstdout:\n{flow_stdout}\nstderr:\n{}",
+        flow_output.status,
+        String::from_utf8_lossy(&flow_output.stderr)
+    );
+    assert!(
+        worker_status.success(),
+        "stage-worker process exited with {worker_status:?}\nstdout:\n{worker_stdout}"
+    );
+
+    assert!(
+        flow_stdout.contains("REAL execution"),
+        "expected the real cross-process path, not the simulated fallback:\n{flow_stdout}"
+    );
+    assert!(
+        !flow_stdout.contains("SIMULATED execution"),
+        "flow unexpectedly fell back to single-process simulation:\n{flow_stdout}"
+    );
+
+    assert!(
+        worker_stdout.contains("Done: processed"),
+        "worker never reported completing a batch exchange:\n{worker_stdout}"
+    );
+    assert!(
+        !worker_stdout.contains("processed 0 batch"),
+        "worker reported zero batches processed — no real work crossed the socket:\n{worker_stdout}"
+    );
+}
+
+/// `std::process::Child` has no built-in wait-with-timeout, so this polls —
+/// the same approach used to observe subprocess lifecycles earlier in this
+/// project's manual debugging (a `Get-CimInstance` poll loop), just ported
+/// into Rust for an automated test.
+trait WaitTimeout {
+    fn wait_timeout_or_kill(
+        &mut self,
+        timeout: Duration,
+    ) -> std::io::Result<std::process::ExitStatus>;
+}
+
+impl WaitTimeout for std::process::Child {
+    fn wait_timeout_or_kill(
+        &mut self,
+        timeout: Duration,
+    ) -> std::io::Result<std::process::ExitStatus> {
+        let start = std::time::Instant::now();
+        loop {
+            if let Some(status) = self.try_wait()? {
+                return Ok(status);
+            }
+            if start.elapsed() > timeout {
+                let _ = self.kill();
+                let _ = self.wait();
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "process did not exit within the timeout",
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}

--- a/crates/ghostlink-core/src/runtime.rs
+++ b/crates/ghostlink-core/src/runtime.rs
@@ -1849,6 +1849,335 @@ pub fn execute_pipeline_tcp_loopback_with_config(
     })
 }
 
+// --- Real remote-worker execution -----------------------------------------
+//
+// Everything above this point (`execute_pipeline_distributed`,
+// `execute_pipeline_tcp_loopback_with_config`, ...) runs entirely within one
+// process: every stage's TCP bridge both binds *and* connects to a local
+// interface, so even in "TCP transport" mode there is no way to reach a
+// genuinely separate machine — `bind()` only ever succeeds for addresses
+// this host actually owns. The two functions below are the real thing: a
+// worker process that binds and accepts on a second machine, and a
+// coordinator function that *connects out* to it (`TcpStream::connect`, not
+// `TcpListener::bind`) instead of simulating both ends locally.
+//
+// Scope is intentionally narrow (exactly one local stage + one remote
+// stage, one connection, one-shot) to match `flow`'s existing local+remote
+// 2-node model rather than building a general N-worker mesh. The "compute"
+// on both ends is still `run_stage_compute`'s synthetic proxy workload
+// (real CPU time, not real LLM inference) — what's genuinely new here is
+// the *transport*: a real socket between two real OS processes, optionally
+// on two real machines, not the numbers `run_stage_compute` produces.
+
+/// A minimal wire handshake sent once when a coordinator connects to a
+/// `run_stage_worker`: just enough for the worker to reconstruct the
+/// `StagePlacement` it needs to call the same `run_stage_compute` the local
+/// path uses, so timing is produced by identical code on both ends.
+fn write_stage_handshake(writer: &mut impl Write, stage: &StagePlacement) -> Result<(), String> {
+    let num_layers = stage.num_layers() as u32;
+    let device_byte: u8 = match stage.device {
+        DeviceKind::Npu => 0,
+        DeviceKind::Gpu => 1,
+        DeviceKind::Cpu => 2,
+    };
+    writer
+        .write_all(&num_layers.to_le_bytes())
+        .and_then(|_| writer.write_all(&[device_byte]))
+        .map_err(|e| format!("failed to write stage handshake: {e}"))
+}
+
+fn read_stage_handshake(reader: &mut impl Read) -> Result<StagePlacement, String> {
+    let mut layers_bytes = [0u8; 4];
+    reader
+        .read_exact(&mut layers_bytes)
+        .map_err(|e| format!("failed to read stage handshake: {e}"))?;
+    let num_layers = u32::from_le_bytes(layers_bytes) as usize;
+
+    let mut device_byte = [0u8; 1];
+    reader
+        .read_exact(&mut device_byte)
+        .map_err(|e| format!("failed to read stage handshake: {e}"))?;
+    let device = match device_byte[0] {
+        0 => DeviceKind::Npu,
+        1 => DeviceKind::Gpu,
+        _ => DeviceKind::Cpu,
+    };
+
+    Ok(StagePlacement {
+        node_id: "remote".to_string(),
+        start_layer: 0,
+        end_layer: num_layers,
+        device,
+        est_latency_ms: 0.0,
+    })
+}
+
+/// Summary a `stage-worker` process reports (to its own stdout, and back to
+/// any caller driving it directly) once its one coordinator connection
+/// closes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StageWorkerSummary {
+    pub batches_processed: usize,
+    pub avg_compute_ms: f32,
+}
+
+/// Runs as a real, separate OS process (see `ghost-link stage-worker`):
+/// accepts exactly one coordinator connection on `listener`, reads the
+/// stage handshake, then loops read-batch → compute → write-result until
+/// the coordinator closes the connection. One-shot, matching how
+/// `cluster-start`'s child `listen` processes already behave.
+///
+/// Takes an already-bound `TcpListener` rather than binding internally so
+/// the caller controls exactly when/how the port is chosen — the CLI binds
+/// the address the user passed on `--bind`, while tests bind `:0` to get a
+/// real OS-assigned free port and can read it back via `local_addr()`
+/// before this function (which blocks until a peer connects) is called.
+pub fn run_stage_worker(
+    listener: TcpListener,
+    config: &TcpTransportConfig,
+) -> Result<StageWorkerSummary, String> {
+    let (mut stream, peer) = listener
+        .accept()
+        .map_err(|e| format!("failed to accept a connection: {e}"))?;
+    let _ = stream.set_nodelay(true);
+
+    let stage = read_stage_handshake(&mut stream)?;
+    eprintln!(
+        "[stage-worker] connection from {peer}; assigned {} layers on {}",
+        stage.num_layers(),
+        stage.device.as_str()
+    );
+
+    let mut frame_buf = Vec::new();
+    let mut read_buf = Vec::new();
+    let mut batches_processed = 0usize;
+    let mut total_compute_ms = 0.0_f32;
+
+    loop {
+        let batch =
+            match read_transport_batch(&mut stream, 0, config.auth_token.as_deref(), &mut read_buf)
+            {
+                Ok(Some(batch)) => batch,
+                Ok(None) => break, // coordinator closed the connection cleanly
+                Err(e) => return Err(format!("failed to read batch from coordinator: {e}")),
+            };
+
+        let mut payload = batch.payload;
+        let compute_start = Instant::now();
+        run_stage_compute(&mut payload, &stage);
+        total_compute_ms += compute_start.elapsed().as_secs_f32() * 1000.0;
+
+        let result = TransportBatch {
+            batch_id: batch.batch_id,
+            tokens_in_batch: batch.tokens_in_batch,
+            payload,
+        };
+        write_transport_batch(
+            &mut stream,
+            &result,
+            0,
+            config.auth_token.as_deref(),
+            &mut frame_buf,
+        )
+        .map_err(|e| format!("failed to write result batch to coordinator: {e}"))?;
+        batches_processed += 1;
+    }
+
+    let avg_compute_ms = if batches_processed > 0 {
+        total_compute_ms / batches_processed as f32
+    } else {
+        0.0
+    };
+    eprintln!(
+        "[stage-worker] coordinator disconnected after {batches_processed} batch(es), avg compute {avg_compute_ms:.2} ms"
+    );
+    Ok(StageWorkerSummary {
+        batches_processed,
+        avg_compute_ms,
+    })
+}
+
+/// Collapses every stage assigned to one node into a single logical
+/// `StagePlacement` spanning that node's full layer range. The real layer
+/// assignment algorithm doesn't hand each node one contiguous chunk — a
+/// 60-layer/2-node `flow` plan produces ~11 raw stages (verified: 6 small
+/// chunks for the local node, 5 for the remote one, each capped at roughly
+/// 3GB), not the 2 this function originally assumed. The chunks for a given
+/// node ARE always contiguous relative to each other, so merging them into
+/// one placement per node is behaviorally sound: `run_stage_compute`'s
+/// synthetic cost model only depends on total layer count and device kind,
+/// not on how finely a node's range happens to be subdivided.
+fn merge_stages_for_node(
+    node_id: &str,
+    stages: &[StagePlacement],
+) -> Result<StagePlacement, String> {
+    let matching: Vec<&StagePlacement> = stages.iter().filter(|s| s.node_id == node_id).collect();
+    let Some(first) = matching.first() else {
+        return Err(format!("no pipeline stages assigned to node '{node_id}'"));
+    };
+    let start_layer = matching.iter().map(|s| s.start_layer).min().unwrap_or(0);
+    let end_layer = matching.iter().map(|s| s.end_layer).max().unwrap_or(0);
+    Ok(StagePlacement {
+        node_id: node_id.to_string(),
+        start_layer,
+        end_layer,
+        device: first.device,
+        est_latency_ms: matching.iter().map(|s| s.est_latency_ms).sum(),
+    })
+}
+
+/// Coordinator side of real remote execution. `plan` must have at least one
+/// stage assigned to `local_node_id` and at least one assigned to
+/// `remote_node_id` — matching `flow`'s existing local+remote 2-*node*
+/// model, though each node's stages get merged (see `merge_stages_for_node`)
+/// since the real assignment algorithm splits one node's layers into
+/// several raw stages, not necessarily one. The merged local stage runs
+/// in-process as usual; the merged remote stage's batches are sent over a
+/// real outbound connection (`TcpStream::connect(remote_addr)`) to a
+/// separate `run_stage_worker` process, so the round-trip time recorded
+/// here is genuine network + remote-compute time, not a local simulation.
+pub fn execute_pipeline_with_remote_stage(
+    plan: &PipelinePlan,
+    local_node_id: &str,
+    remote_node_id: &str,
+    token_count: usize,
+    micro_batch: usize,
+    config: TcpTransportConfig,
+    remote_addr: SocketAddr,
+) -> Result<ExecutionResult, String> {
+    let local_stage = merge_stages_for_node(local_node_id, &plan.stages)?;
+    let remote_stage = merge_stages_for_node(remote_node_id, &plan.stages)?;
+    let local_stage = &local_stage;
+    let remote_stage = &remote_stage;
+
+    let micro_batch = micro_batch.max(1);
+    let batch_count = token_count.div_ceil(micro_batch);
+    if token_count == 0 {
+        return Ok(ExecutionResult {
+            token_count,
+            micro_batch,
+            batch_count,
+            stage_count: 2,
+            total_time_ms: 0.0,
+            throughput_tokens_per_sec: 0.0,
+            avg_token_latency_ms: 0.0,
+            p95_token_latency_ms: 0.0,
+            stage_stats: Vec::new(),
+        });
+    }
+
+    let mut stream = TcpStream::connect(remote_addr).map_err(|e| {
+        format!(
+            "failed to connect to remote stage worker at {remote_addr}: {e} \
+             (is `ghost-link stage-worker --bind {remote_addr}` running there?)"
+        )
+    })?;
+    let _ = stream.set_nodelay(true);
+    write_stage_handshake(&mut stream, remote_stage)?;
+
+    let mut frame_buf = Vec::new();
+    let mut read_buf = Vec::new();
+    let mut token_latencies = Vec::with_capacity(token_count);
+    let mut local_compute_ms = 0.0_f32;
+    let mut remote_round_trip_ms = 0.0_f32;
+
+    let exec_start = Instant::now();
+    for batch_idx in 0..batch_count {
+        let batch_start_token = batch_idx * micro_batch;
+        let tokens_in_batch = (token_count - batch_start_token).min(micro_batch);
+        let payload_len = (tokens_in_batch.max(1) * 16).max(32);
+        let mut payload: Vec<f32> = (0..payload_len)
+            .map(|idx| (batch_idx as f32 * 0.01) + (idx as f32 * 0.0001))
+            .collect();
+
+        let batch_started = Instant::now();
+
+        let local_start = Instant::now();
+        run_stage_compute(&mut payload, local_stage);
+        local_compute_ms += local_start.elapsed().as_secs_f32() * 1000.0;
+
+        let outgoing = TransportBatch {
+            batch_id: batch_idx,
+            tokens_in_batch,
+            payload,
+        };
+        let rt_start = Instant::now();
+        write_transport_batch(
+            &mut stream,
+            &outgoing,
+            0,
+            config.auth_token.as_deref(),
+            &mut frame_buf,
+        )
+        .map_err(|e| format!("failed to send batch {batch_idx} to remote worker: {e}"))?;
+        let result = read_transport_batch(&mut stream, 0, config.auth_token.as_deref(), &mut read_buf)
+            .map_err(|e| format!("failed to read batch {batch_idx} result from remote worker: {e}"))?
+            .ok_or_else(|| {
+                format!("remote worker at {remote_addr} closed the connection before batch {batch_idx} completed")
+            })?;
+        remote_round_trip_ms += rt_start.elapsed().as_secs_f32() * 1000.0;
+
+        let batch_latency_ms = batch_started.elapsed().as_secs_f32() * 1000.0;
+        for _ in 0..result.tokens_in_batch {
+            token_latencies.push(batch_latency_ms);
+        }
+    }
+    let total_time_ms = exec_start.elapsed().as_secs_f32() * 1000.0;
+    drop(stream); // signals the worker's read loop to exit cleanly
+
+    let divisor = batch_count.max(1) as f32;
+    let throughput_tokens_per_sec = if total_time_ms > 0.0 {
+        token_count as f32 / (total_time_ms / 1000.0)
+    } else {
+        0.0
+    };
+    let avg_token_latency_ms = if token_latencies.is_empty() {
+        0.0
+    } else {
+        token_latencies.iter().sum::<f32>() / token_latencies.len() as f32
+    };
+    let mut sorted = token_latencies.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let p95_idx = (sorted.len().saturating_sub(1) as f32 * 0.95).round() as usize;
+    let p95_token_latency_ms = sorted.get(p95_idx).copied().unwrap_or(0.0);
+
+    Ok(ExecutionResult {
+        token_count,
+        micro_batch,
+        batch_count,
+        stage_count: 2,
+        total_time_ms,
+        throughput_tokens_per_sec,
+        avg_token_latency_ms,
+        p95_token_latency_ms,
+        stage_stats: vec![
+            StageExecutionStats {
+                stage_idx: 0,
+                processed_batches: batch_count,
+                avg_compute_ms: local_compute_ms / divisor,
+                avg_recv_wait_ms: 0.0,
+                avg_send_wait_ms: 0.0,
+                avg_bridge_write_ms: 0.0,
+                avg_bridge_read_ms: 0.0,
+            },
+            StageExecutionStats {
+                stage_idx: 1,
+                processed_batches: batch_count,
+                // The remote side's own compute time isn't observable from
+                // here without a second telemetry channel — what IS real
+                // and observable is the round trip, reported as bridge
+                // write time so it's visible in `ExecutionResult::summary()`
+                // without inventing a number for compute we didn't measure.
+                avg_compute_ms: 0.0,
+                avg_recv_wait_ms: 0.0,
+                avg_send_wait_ms: 0.0,
+                avg_bridge_write_ms: remote_round_trip_ms / divisor,
+                avg_bridge_read_ms: 0.0,
+            },
+        ],
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2133,5 +2462,154 @@ mod tests {
         assert_eq!(result.stage_stats.len(), 2);
         assert!(result.total_time_ms > 0.0);
         assert!(result.throughput_tokens_per_sec > 0.0);
+    }
+
+    #[test]
+    fn stage_handshake_round_trips_layer_count_and_device() {
+        let stage = StagePlacement {
+            node_id: "coordinator-local".to_string(),
+            start_layer: 5,
+            end_layer: 37,
+            device: DeviceKind::Gpu,
+            est_latency_ms: 12.0,
+        };
+        let mut buf = Vec::new();
+        write_stage_handshake(&mut buf, &stage).expect("handshake write failed");
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = read_stage_handshake(&mut cursor).expect("handshake read failed");
+        assert_eq!(decoded.num_layers(), stage.num_layers());
+        assert_eq!(decoded.device, DeviceKind::Gpu);
+    }
+
+    #[test]
+    fn execute_pipeline_with_remote_stage_rejects_when_remote_node_has_no_stages() {
+        let plan = PipelinePlan {
+            stages: vec![StagePlacement {
+                node_id: "solo".to_string(),
+                start_layer: 0,
+                end_layer: 10,
+                device: DeviceKind::Cpu,
+                est_latency_ms: 1.0,
+            }],
+        };
+        let err = execute_pipeline_with_remote_stage(
+            &plan,
+            "solo",
+            "nowhere",
+            8,
+            2,
+            TcpTransportConfig::default(),
+            "127.0.0.1:1".parse().unwrap(),
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("no pipeline stages assigned to node 'nowhere'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn merge_stages_for_node_collapses_multiple_chunks_into_one_placement() {
+        // Regression: real layer assignment splits one node's range into
+        // several raw stages (verified manually: 60 layers / 2 nodes
+        // produced 11 raw stages, not 2) — merging must still produce the
+        // node's FULL range, not just its first chunk.
+        let stages = vec![
+            StagePlacement {
+                node_id: "node-remote".to_string(),
+                start_layer: 32,
+                end_layer: 38,
+                device: DeviceKind::Gpu,
+                est_latency_ms: 1.0,
+            },
+            StagePlacement {
+                node_id: "node-remote".to_string(),
+                start_layer: 38,
+                end_layer: 44,
+                device: DeviceKind::Gpu,
+                est_latency_ms: 1.5,
+            },
+            StagePlacement {
+                node_id: "node-local".to_string(),
+                start_layer: 0,
+                end_layer: 32,
+                device: DeviceKind::Cpu,
+                est_latency_ms: 3.0,
+            },
+        ];
+        let merged = merge_stages_for_node("node-remote", &stages).expect("merge failed");
+        assert_eq!(merged.start_layer, 32);
+        assert_eq!(merged.end_layer, 44);
+        assert_eq!(merged.num_layers(), 12);
+        assert_eq!(merged.device, DeviceKind::Gpu);
+        assert!((merged.est_latency_ms - 2.5).abs() < 1e-6);
+    }
+
+    /// The real thing, end to end: a genuine second OS thread (standing in
+    /// for a genuine second OS *process*, which the CLI-level integration
+    /// test in the ghost-link crate covers) binds a real TCP listener on an
+    /// OS-assigned port, and the coordinator function connects out to it —
+    /// not the local-bind-on-both-ends simulation every other function in
+    /// this file uses. Proves the round trip is real by asserting non-zero
+    /// bridge time was actually measured, and that the worker's own
+    /// independently-tracked batch count agrees with the coordinator's.
+    #[test]
+    fn execute_pipeline_with_remote_stage_does_a_real_tcp_round_trip() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind test listener");
+        let worker_addr = listener.local_addr().expect("failed to read local_addr");
+
+        let worker_handle =
+            thread::spawn(move || run_stage_worker(listener, &TcpTransportConfig::default()));
+
+        let plan = PipelinePlan {
+            stages: vec![
+                StagePlacement {
+                    node_id: "local".to_string(),
+                    start_layer: 0,
+                    end_layer: 10,
+                    device: DeviceKind::Cpu,
+                    est_latency_ms: 1.0,
+                },
+                StagePlacement {
+                    node_id: "remote".to_string(),
+                    start_layer: 10,
+                    end_layer: 20,
+                    device: DeviceKind::Cpu,
+                    est_latency_ms: 1.0,
+                },
+            ],
+        };
+
+        let result = execute_pipeline_with_remote_stage(
+            &plan,
+            "local",
+            "remote",
+            16,
+            2,
+            TcpTransportConfig::default(),
+            worker_addr,
+        )
+        .expect("real remote-stage execution failed");
+
+        let worker_summary = worker_handle
+            .join()
+            .expect("worker thread panicked")
+            .expect("worker returned an error");
+
+        assert_eq!(result.token_count, 16);
+        assert_eq!(result.batch_count, 8);
+        assert_eq!(result.stage_stats.len(), 2);
+        assert_eq!(worker_summary.batches_processed, 8);
+        assert_eq!(
+            result.stage_stats[1].processed_batches,
+            worker_summary.batches_processed,
+            "coordinator's batch count must agree with what the independent worker process actually processed"
+        );
+        assert!(
+            result.stage_stats[1].avg_bridge_write_ms > 0.0,
+            "remote round-trip time must be non-zero for a real socket hop, got {}",
+            result.stage_stats[1].avg_bridge_write_ms
+        );
     }
 }

--- a/docker-compose.test-fabric.yml
+++ b/docker-compose.test-fabric.yml
@@ -1,7 +1,12 @@
 version: '3.9'
 
 services:
-  # Worker node 1: 16GB GPU equivalent
+  # Worker node 1: 16GB GPU equivalent. NOT dialed by the coordinator's
+  # `flow` command below — `flow` is a local+one-remote model, and its
+  # "local" stage always runs inside the coordinator's own process
+  # regardless of which node id labels it. This container stays as an
+  # independent OpenAI-API-compatible server for standalone manual testing
+  # of the fabric network, not as part of the flow demo path.
   ghostlink-worker-1:
     build:
       context: .
@@ -27,7 +32,10 @@ services:
     cpus: '2'
     mem_limit: 2g
 
-  # Worker node 2: 32GB GPU equivalent
+  # Worker node 2: 32GB GPU equivalent. This is the node the coordinator's
+  # `flow --remote-addr` actually connects out to — a real stage-worker
+  # process on its own container, not the same-process simulation the
+  # `flow` command falls back to when --remote-addr is omitted.
   ghostlink-worker-2:
     build:
       context: .
@@ -42,11 +50,11 @@ services:
       GHOSTLINK_TCP_MAX_INFLIGHT: "512"
       GHOSTLINK_DISTRIBUTED_SMOKE: "true"
       RUST_LOG: info
-    command: ["serve", "--port", "8002"]
+    command: ["stage-worker", "172.20.0.3:9500"]
     ports:
-      - "8002:8002"
+      - "9500:9500"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8002/health"]
+      test: ["CMD", "sh", "-c", "netstat -an | grep 9500 | grep -q LISTEN"]
       interval: 5s
       timeout: 3s
       retries: 3
@@ -73,7 +81,7 @@ services:
         condition: service_healthy
       ghostlink-worker-2:
         condition: service_healthy
-    command: ["flow", "iprada-16gb", "zenbook-32gb", "32", "32", "256", "8", "tcp"]
+    command: ["flow", "iprada-16gb", "zenbook-32gb", "32", "32", "256", "8", "tcp", "--remote-addr", "172.20.0.3:9500"]
     cpus: '1'
     mem_limit: 1g
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -157,19 +157,71 @@ Tested default vs. this host's documented 4GB-VRAM-tier recommendation
 
 ## Multi-Node Performance
 
-### LAN Performance (1 Gbps Ethernet)
+### LAN Performance (1 Gbps Ethernet) — UNVERIFIED, pending a real multi-host run
+
+The table below predates this session's investigation and cannot be traced
+to any real run: no date, no host inventory, no methodology, and — more
+fundamentally — until the `stage-worker`/`flow --remote-addr` work landed
+(see [DEPLOYMENT.md's Stage 3b](DEPLOYMENT.md#stage-3b-real-cross-machine-flow-execution)),
+`flow` never actually reached a second machine at all, so no version of
+Ghost-Link could have produced these particular numbers. Leaving it here
+with this label rather than deleting it, so it's clear this is a
+placeholder to replace, not evidence of past measurement:
 
 | Node Count | Throughput | Latency | Notes |
 |------------|------------|---------|-------|
-| 2 nodes | ~580K tokens/s | 2.5ms | TCP transport |
-| 3 nodes | ~550K tokens/s | 3.2ms | TCP transport |
-| 4 nodes | ~520K tokens/s | 4.1ms | TCP transport |
+| 2 nodes | ~580K tokens/s | 2.5ms | TCP transport — **unverified placeholder** |
+| 3 nodes | ~550K tokens/s | 3.2ms | TCP transport — **unverified placeholder** |
+| 4 nodes | ~520K tokens/s | 4.1ms | TCP transport — **unverified placeholder** |
+
+Do not cite this table. To get real numbers, run
+[`scripts/remote_flow_benchmark.py`](../scripts/remote_flow_benchmark.py)
+across two physical machines on your own network (see below).
+
+### Real cross-process benchmark harness
+
+`scripts/remote_flow_benchmark.py` drives the genuine `stage-worker` /
+`flow --remote-addr` path repeatedly and summarizes real measured
+throughput and remote round-trip time (`avg_bridge_write_ms`) — not
+placeholder constants. Real two-machine LAN numbers require hardware this
+session doesn't have access to (one dev machine, not a two-node LAN), so
+none are published here yet; running it is the way to replace the
+placeholder table above with real data.
+
+What *was* verified on this single machine — a same-host loopback smoke
+test, proving the harness and the underlying transport work end-to-end,
+explicitly **not** a network benchmark (no real NIC, no real latency):
+
+```bash
+python scripts/remote_flow_benchmark.py --spawn-local-worker \
+  --remote-addr 127.0.0.1:19748 --runs 3 --exec-tokens 32 --micro-batch 4
+```
+
+| Runs | Throughput (avg) | P95 | Remote bridge-write (avg) |
+|---|---|---|---|
+| 3 | 21,621 tok/s | 0.38 ms | 0.19 ms |
+
+Low run count and tiny `exec-tokens` (32) — this is a smoke test
+confirming the path works, not a tuned performance number; don't compare it
+against the Full-Spectrum session's in-process numbers above, which use a
+much larger token count and a different code path entirely.
+
+For a real LAN run: on a second machine, run
+`GHOSTLINK_TCP_AUTH_TOKEN=<token> ghost-link stage-worker <bind-addr>`,
+then on the coordinator run the script without `--spawn-local-worker`,
+pointing `--remote-addr` at that machine. The script pauses between runs
+so you can restart the (one-shot) worker each time.
 
 ### Notes on Multi-Node Performance
 
 - Throughput decreases slightly with more nodes due to network overhead
 - Latency increases linearly with node count
 - Network bandwidth is the primary bottleneck for multi-node setups
+
+These three notes above are inherited from the same placeholder as the
+table and are directional assumptions, not measurements — treat them as
+hypotheses to check once real multi-host numbers exist, not established
+fact.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -85,6 +85,59 @@ Recommended rollout sequence:
 3. Run perf snapshot + drift checks.
 4. Expand to 4+ nodes only after stable daily runs.
 
+## Stage 3b: Real Cross-Machine Flow Execution
+
+`flow` on its own only ever runs in one process — even when you give it a
+`remote_id`, without more it registers that node as a label and simulates
+its stage locally. To make `flow` actually reach a second machine, pass
+`--remote-addr` and have a `stage-worker` process already listening there.
+
+**On the remote machine** (or a second terminal/container on the same
+host for a quick local check), start the worker and give it the address to
+bind:
+
+```bash
+cargo run -p ghost-link -- stage-worker 0.0.0.0:9500
+```
+
+The worker accepts exactly one coordinator connection, runs whatever stage
+it's assigned, prints a summary, and exits — the same one-shot lifecycle
+`cluster-start`'s child listeners already use. Start a fresh one for each
+run.
+
+**On the coordinator**, point `flow` at that address:
+
+```bash
+cargo run -p ghost-link -- flow local-node remote-node 32 32 128 4 tcp \
+  --remote-addr <remote-host>:9500
+```
+
+Watch for `REAL execution: ...` in the coordinator's output — if you
+instead see `SIMULATED execution: ...`, `--remote-addr` was omitted, not
+reachable, or mistyped, and nothing left this machine.
+
+**What this does and doesn't prove**: the transport is genuinely
+cross-process — a real outbound `TcpStream::connect`, real framed
+batches, real measured round-trip latency fed back into the cluster's
+health metrics (not the placeholder `record_latency(3.2)` constants the
+simulated path seeds). What it does *not* prove is distributed LLM
+inference: the per-stage compute (`run_stage_compute`) is a synthetic
+timing proxy — sine-wave arithmetic scaled to look like layer/device
+cost, not real model math. A real cross-machine `flow` run demonstrates
+the pipeline-splitting and networking layer working end-to-end; it is not
+evidence of correct distributed generation output.
+
+An automated version of this same two-process check lives in
+[../crates/ghost-link/tests/stage_worker_integration.rs](../crates/ghost-link/tests/stage_worker_integration.rs),
+which spawns both binaries as real child processes and asserts on the
+`REAL execution` path.
+
+For a containerized two-machine-shaped example, see
+[../docker-compose.test-fabric.yml](../docker-compose.test-fabric.yml) —
+`ghostlink-worker-2` runs `stage-worker` and `ghostlink-coordinator` runs
+`flow --remote-addr` against it across the compose network, closer to a
+real multi-host topology than loopback.
+
 ## Configuration File Usage
 
 Ghost-Link supports TOML config defaults via:

--- a/scripts/remote_flow_benchmark.py
+++ b/scripts/remote_flow_benchmark.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Run repeatable REAL cross-process `flow --remote-addr` benchmarks.
+
+Unlike flow_perf_snapshot.py (which only ever runs the single-process
+simulated path), this drives the genuine remote-worker path added for
+multi-node execution: a `ghost-link stage-worker` process actually accepts
+a TCP connection and exchanges batches with the coordinator's `flow`
+process. Each run's metrics JSON (via GHOSTLINK_FLOW_METRICS_JSON) carries
+a real measured `avg_bridge_write_ms` for the remote stage, not a
+placeholder constant.
+
+Two ways to use this:
+
+1. Same-host smoke test (--spawn-local-worker): spawns a fresh
+   stage-worker on loopback before each run. Useful for validating the
+   harness and the transport path itself, but these are loopback numbers —
+   NOT a real network benchmark. The summary is labeled accordingly.
+
+2. Real two-machine run (default): point --remote-addr at a second
+   machine's address. Because stage-worker is one-shot (it handles exactly
+   one coordinator connection, then exits), you must start a fresh one on
+   that machine before each run; the script pauses and waits for Enter
+   between runs so you can do that by hand — it does not SSH out and start
+   it for you.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import time
+from pathlib import Path
+
+# stage-worker's TcpListener::accept() call handles exactly one connection
+# for its whole lifetime, so readiness can't be polled with a real TCP
+# connect (that probe connection would itself consume the one slot and
+# starve the actual coordinator). A fixed settle delay is the only safe
+# option here; 2s comfortably covers `cargo run`'s own build-check overhead
+# even when the binary is already built.
+
+
+def quantile_linear(sorted_values: list[float], q: float) -> float:
+    if not sorted_values:
+        raise ValueError("quantile requires non-empty values")
+    if q <= 0.0:
+        return sorted_values[0]
+    if q >= 1.0:
+        return sorted_values[-1]
+
+    position = (len(sorted_values) - 1) * q
+    lower = int(position)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    frac = position - lower
+    return sorted_values[lower] * (1.0 - frac) + sorted_values[upper] * frac
+
+
+def build_command(args: argparse.Namespace, subcommand: list[str]) -> list[str]:
+    command = ["cargo", "run"]
+    if args.release:
+        command.append("--release")
+    command.extend(["-p", "ghost-link", "--"])
+    command.extend(subcommand)
+    return command
+
+
+def run_once(run_index: int, args: argparse.Namespace, output_dir: Path) -> Path:
+    worker_proc = None
+    if args.spawn_local_worker:
+        worker_env = dict(os.environ)
+        worker_env["GHOSTLINK_TCP_AUTH_TOKEN"] = args.tcp_auth_token
+        worker_proc = subprocess.Popen(
+            build_command(args, ["stage-worker", args.remote_addr]),
+            cwd=args.repo_root,
+            env=worker_env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        time.sleep(args.worker_settle_seconds)
+    else:
+        input(
+            f"[run {run_index}] Start a fresh `GHOSTLINK_TCP_AUTH_TOKEN={args.tcp_auth_token} "
+            f"ghost-link stage-worker {args.remote_addr}` on the remote machine now (the auth "
+            "token must match exactly, or the coordinator's connection will be reset), then "
+            "press Enter to continue..."
+        )
+
+    out_file = output_dir / f"remote-{run_index}.json"
+    env = dict(os.environ)
+    env["GHOSTLINK_FLOW_METRICS_JSON"] = str(out_file)
+    env["GHOSTLINK_TCP_AUTH_TOKEN"] = args.tcp_auth_token
+
+    command = build_command(
+        args,
+        [
+            "flow",
+            args.local_id,
+            args.remote_id,
+            str(args.remote_vram_gb),
+            str(args.remote_mem_gb),
+            str(args.exec_tokens),
+            str(args.micro_batch),
+            "tcp",
+            "--remote-addr",
+            args.remote_addr,
+        ],
+    )
+
+    result = subprocess.run(
+        command,
+        cwd=args.repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    if worker_proc is not None:
+        worker_proc.wait(timeout=30)
+
+    if result.returncode != 0 or "REAL execution" not in result.stdout:
+        raise RuntimeError(
+            f"run {run_index} did not take the real remote-execution path "
+            f"(exit={result.returncode}):\n{result.stdout}"
+        )
+
+    return out_file
+
+
+def summarize(files: list[Path]) -> dict[str, float]:
+    values = [json.loads(path.read_text(encoding="utf-8")) for path in files]
+    throughput = [float(v["throughput_tokens_per_sec"]) for v in values]
+    p95 = [float(v["p95_token_latency_ms"]) for v in values]
+    wall = [float(v["total_time_ms"]) for v in values]
+
+    # Remote-stage round-trip time, straight from the real socket exchange —
+    # this is the number that's meaningless on the simulated path (it isn't
+    # emitted there at all) and is the whole point of this script.
+    remote_bridge_write_ms = []
+    for v in values:
+        for stage in v.get("stage_stats", []):
+            if stage.get("stage_idx") == 1:
+                remote_bridge_write_ms.append(float(stage["avg_bridge_write_ms"]))
+
+    sorted_throughput = sorted(throughput)
+    summary = {
+        "runs": len(values),
+        "throughput_avg": statistics.mean(throughput),
+        "throughput_min": min(throughput),
+        "throughput_max": max(throughput),
+        "throughput_p10": quantile_linear(sorted_throughput, 0.10),
+        "throughput_p90": quantile_linear(sorted_throughput, 0.90),
+        "p95_avg": statistics.mean(p95),
+        "wall_avg": statistics.mean(wall),
+    }
+    if remote_bridge_write_ms:
+        summary["remote_bridge_write_ms_avg"] = statistics.mean(remote_bridge_write_ms)
+        summary["remote_bridge_write_ms_min"] = min(remote_bridge_write_ms)
+        summary["remote_bridge_write_ms_max"] = max(remote_bridge_write_ms)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run repeatable real cross-process flow --remote-addr benchmarks"
+    )
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-dir", default="tmp/remote_flow_benchmark")
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument(
+        "--remote-addr",
+        required=True,
+        help="host:port of the stage-worker to connect to (e.g. 192.168.1.50:9500 "
+        "for a real LAN run, or 127.0.0.1:9500 with --spawn-local-worker for a smoke test)",
+    )
+    parser.add_argument(
+        "--spawn-local-worker",
+        action="store_true",
+        help="Spawn a fresh local stage-worker before each run instead of pausing for a "
+        "manually-started remote one. Produces LOOPBACK numbers only, not a real network benchmark.",
+    )
+    parser.add_argument("--worker-settle-seconds", type=float, default=2.0)
+    parser.add_argument("--local-id", default="iprada-16gb")
+    parser.add_argument("--remote-id", default="zenbook-32gb")
+    parser.add_argument("--remote-vram-gb", type=float, default=32.0)
+    parser.add_argument("--remote-mem-gb", type=float, default=32.0)
+    parser.add_argument("--exec-tokens", type=int, default=256)
+    parser.add_argument("--micro-batch", type=int, default=4)
+    parser.add_argument("--release", action="store_true")
+    parser.add_argument("--tcp-auth-token", default="local-token")
+    args = parser.parse_args()
+
+    if args.runs <= 0:
+        parser.error("--runs must be greater than 0")
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = [run_once(i, args, output_dir) for i in range(1, args.runs + 1)]
+    summary = summarize(files)
+    summary["mode"] = "loopback-smoke-test" if args.spawn_local_worker else "real-remote"
+
+    print(
+        summary["mode"],
+        int(summary["runs"]),
+        f"throughput_avg={summary['throughput_avg']:.2f}",
+        f"p95_avg={summary['p95_avg']:.2f}",
+        f"remote_bridge_write_ms_avg={summary.get('remote_bridge_write_ms_avg', float('nan')):.4f}",
+    )
+    if args.spawn_local_worker:
+        print(
+            "NOTE: --spawn-local-worker was used — this is a same-host loopback smoke test, "
+            "not a real network benchmark. Re-run with a genuine --remote-addr on a second "
+            "machine (no --spawn-local-worker) for real LAN numbers."
+        )
+
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `ghost-link flow` previously simulated its "remote" node entirely in-process — it registered a fake node and hand-seeded metrics (`record_latency(3.2)`, `record_delivery_ratio(0.95)`), never actually contacting a second machine even when `docker-compose.test-fabric.yml` stood up real worker containers for it.
- Adds a genuine remote-worker mode: `ghost-link stage-worker --bind <addr>` runs as its own process and accepts one real TCP connection from a `flow --remote-addr <host:port>` coordinator, exchanging real framed batches and deriving health metrics from actual measured round-trip time.
- Fixes `docker-compose.test-fabric.yml` so `ghostlink-worker-2` runs `stage-worker` and the coordinator's `flow` command actually connects to it via `--remote-addr` across the compose network.
- Fixes a latent bug found while building the benchmark harness: `stage-worker` ignored `GHOSTLINK_TCP_AUTH_TOKEN` and other TCP transport env vars entirely (always used `TcpTransportConfig::default()`), which would have silently broken the exact auth-token setup this PR wires into the compose file.
- Ships `scripts/remote_flow_benchmark.py` — a runnable harness for getting real two-machine LAN numbers — and relabels `docs/BENCHMARKS.md`'s old Multi-Node/LAN table as unverified (it predates this PR and can't have been produced by any real run, since `flow` couldn't reach a second machine until now).
- `docs/DEPLOYMENT.md` gains a "Stage 3b" section documenting the real remote-worker path, with an explicit callout that transport is genuinely cross-process but `run_stage_compute` remains a synthetic timing proxy, not real distributed LLM inference.

## Test plan

- [x] New `crates/ghost-link/tests/stage_worker_integration.rs` spawns the real `ghost-link` binary as two separate OS processes (via `CARGO_BIN_EXE_ghost-link`) and asserts the `REAL execution` path with a nonzero batch count — not an in-process/thread simulation.
- [x] 4 new `ghostlink-core` unit tests (handshake round-trip, missing-stage rejection, stage-merging, real TCP round-trip).
- [x] Manually verified end-to-end via two real separate processes on loopback (worker log shows `connection from 127.0.0.1:...`, `coordinator disconnected after N batch(es)`; flow log shows `REAL execution` and non-zero `bridge-write` timing).
- [x] Benchmark harness smoke-tested (`--spawn-local-worker`, 3/3 runs succeeded) after fixing the auth-token bug it surfaced.
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass (138 ghostlink-core + 99 ghost-link unit + 1 new integration + 10 mcp-rag tests, all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)