### PR TITLE
fix(tests): serialize tests that mutate process-global env vars

### DIFF
--- a/crates/ghost-link/src/backend_api.rs
+++ b/crates/ghost-link/src/backend_api.rs
@@ -265,6 +265,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_switch_backend_endpoint_accepts_cpu() {
+        // Switching backends mutates process-global env vars (OLLAMA_NUM_THREAD etc.)
+        // via RuntimeSwitcher/EnvironmentManager. Serialize against other tests that
+        // touch the same vars (see runtime_switcher::env_test_lock) so parallel test
+        // execution can't interleave the set_var/remove_var calls.
+        let _guard = crate::runtime_switcher::env_test_lock().lock().await;
+
         let response = handle_switch_backend(Json(SwitchBackendRequest {
             backend: "cpu".to_string(),
         }))

--- a/crates/ghost-link/src/runtime_switcher.rs
+++ b/crates/ghost-link/src/runtime_switcher.rs
@@ -284,6 +284,23 @@ pub struct SwitchResult {
     pub message: String,
 }
 
+/// Serializes tests (in this module and in `backend_api`) that mutate
+/// process-global environment variables via `EnvironmentManager`/
+/// `RuntimeSwitcher`. Env vars are process-global, not thread-local, and
+/// `cargo test` runs tests within a binary in parallel by default, so
+/// without this lock two such tests can interleave their `set_var`/
+/// `remove_var` calls and read back each other's values.
+///
+/// A `tokio::sync::Mutex` is used (rather than `std::sync::Mutex`) so async
+/// tests can hold the guard across `.await` points; sync tests use
+/// `blocking_lock()` instead.
+#[cfg(test)]
+pub(crate) fn env_test_lock() -> &'static tokio::sync::Mutex<()> {
+    use std::sync::OnceLock;
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -312,6 +329,8 @@ mod tests {
 
     #[test]
     fn test_environment_manager_set_env() {
+        let _guard = env_test_lock().blocking_lock();
+
         let config = SwitchingConfig::default();
         let manager = EnvironmentManager::new(config);
 


### PR DESCRIPTION
## Summary

- `test_environment_manager_set_env` (`runtime_switcher.rs`) and `test_switch_backend_endpoint_accepts_cpu` (`backend_api.rs`) both go through `EnvironmentManager`/`RuntimeSwitcher`, which calls `std::env::set_var`/`remove_var` on backend env vars (`OLLAMA_NUM_THREAD`, `OLLAMA_GPU_MEMORY`, etc).
- Env vars are process-global, not thread-local, and `cargo test` runs a binary's tests in parallel by default — without synchronization, these two tests could interleave their set/remove calls and read back each other's values, a source of real (if currently unobserved) flakiness.
- Adds a `#[cfg(test)]`-only `tokio::sync::Mutex` (`env_test_lock`) shared between the two modules' test code. Uses `tokio::sync::Mutex` rather than `std`'s so the async test can hold the guard across `.await`.

This was found as leftover uncommitted work sitting in an orphaned git worktree from an earlier, unrelated session (never committed, never pushed). The branch it was on was based off a point in history several PRs behind current `main`, so I reapplied the same change fresh against current `main` rather than trying to push the stale branch, and reverified everything from scratch.

## Test plan

- [x] `cargo test -p ghost-link` — 96 passed, 0 failed, 6 ignored.
- [x] Repeated 3x at `--test-threads=16` to sanity-check the fix doesn't itself deadlock or reintroduce flakiness — all green.
- [x] `cargo fmt --all --check` and `cargo clippy -p ghost-link --all-targets -- -D warnings` clean.