### PR TITLE
Real bearer-token auth + PQC-hybrid TLS, replacing mocked security endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,11 @@ models/*.gguf
 models/
 models.json
 sessions.json
+# Generated on first run — a real per-install secret / self-signed cert,
+# never something to commit or share across installs.
+api_key.txt
+tls_cert.pem
+tls_key.pem
 ghostlink_gui_modern/dist/
 .ghostlink-npm-platform
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,84 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.11.0] - 2026-07-26 (Real bearer-token auth + PQC-hybrid TLS)
+
+Closes the last item from a gap analysis against LM Studio/vLLM: the API
+server had no authentication anywhere, and the existing `/api/security/*`
+endpoints were fully mocked — `handle_gui_jwt_refresh` always returned a
+hardcoded `"new-token-123"`, and the PQC endpoints always reported
+`enabled: true` regardless of anything. Both are now real.
+
+### ✨ Features
+
+- **Real bearer-token auth on every route but `/health`.** A 256-bit API
+  key is generated once on first run, persisted to `api_key.txt`, and
+  printed to the console — the only way to learn it, since it's never
+  returned by any API response. Send it directly as
+  `Authorization: Bearer <key>`, or exchange it for a short-lived JWT via
+  `POST /api/security/jwt/refresh` (`jsonwebtoken`, HS256, signed with the
+  same key — genuine issuance/verification, not the old stub).
+- **Real HTTPS with a genuine PQC-hybrid (X25519MLKEM768) key exchange
+  preference**, via `rustls`'s `prefer-post-quantum` feature (aws-lc-rs
+  backend) — the same mechanism Chrome/Cloudflare/AWS use today, not a
+  bespoke handshake. Opt-in via a new `parallel_slots`-style
+  `enable_tls` setting, off by default for today's plain-localhost dev
+  flow, forced on when the server binds a non-loopback address (the
+  LAN/remote scenario this actually protects). A self-signed cert is
+  generated once via `rcgen` and reused across restarts.
+- **`/api/security/pqc/state` and `pqc/enable` are now real**: `state`
+  reports whether *this running process's* listener is actually serving
+  HTTPS (not the persisted setting, which only applies on next restart —
+  tracked separately so the two can't be conflated); `enable` writes the
+  setting and honestly says a restart is required rather than pretending
+  it's already live.
+- **Go control-plane gateway now verifies the same shared secret** before
+  proxying — real JWT signature verification (`golang-jwt/jwt/v5`), not a
+  shape-only check, so it doesn't reject legitimate short-lived tokens the
+  GUI uses. Degrades gracefully (no extra edge rejection, not a lockout)
+  if the key file isn't readable — the proxy already forwarded
+  `Authorization` through to ghost-link's own auth either way.
+- **GUI now sends the token on every request** — an axios interceptor plus
+  the two hand-rolled `fetch` calls that bypassed it, reading a key the
+  user pastes into a new "API Key" field on the Security tab (persisted to
+  `localStorage`). The PQC panel's copy was also corrected — it previously
+  claimed "Kyber-768/Dilithium... across all distributed nodes" and
+  "AES-GCM 256-bit encryption" when disabled, neither of which was ever
+  real; it now accurately describes the actual TLS/PQC-hybrid mechanism
+  and states plainly that disabled means unencrypted plain HTTP.
+
+### 🐛 Fixed
+
+- The API key would only ever have been generated (and its one-time
+  console banner printed) lazily on first *authenticated* request — a
+  fresh install with zero traffic yet would have had no way to discover
+  it at all. Now generated eagerly at server startup.
+
+### ✅ Validation
+
+- **Live, end-to-end manual verification** (not just unit tests): started
+  a real server, confirmed 401 with no token, 200 with the raw key, a real
+  JWT round-trip (issue → use → success), and real `enabled:false` →
+  `enable` → restart → `enabled:true` PQC state transitions. Independently
+  proved the PQC claim using `openssl s_client -tls1_3 -groups
+  X25519MLKEM768` against the running HTTPS listener — output confirmed
+  `Negotiated TLS1.3 group: X25519MLKEM768`, and a normal client with no
+  forced group still connected fine (not a hard requirement, a
+  preference).
+- New Rust tests: `auth.rs` (key generation/persistence, bearer
+  verification, tampered/garbage rejection), `tls.rs` (loopback
+  detection, idempotent cert generation with real file I/O).
+- New Go tests: `pkg/auth` (key loading, bearer/JWT verification including
+  a genuinely expired and a genuinely tampered token, full middleware
+  integration via `httptest`).
+- New frontend tests: `SecurityTab.test.tsx` (API key persistence, and
+  that enabling PQC shows a real "restart required" message rather than
+  falsely claiming it's already active).
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D
+  warnings`, `cargo test --workspace` all green. `go build`, `go vet`,
+  `go test ./...` all green. `tsc --noEmit`, `vitest run` (118 passed)
+  clean.
+
 ## [1.10.0] - 2026-07-26 (Real request batching and multi-turn context reuse)
 
 Closes the top item from a gap analysis against LM Studio/vLLM: Ghostlink

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +114,30 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -144,6 +207,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +240,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -163,6 +248,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -219,6 +313,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -310,6 +406,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "compact_str"
@@ -522,6 +627,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +798,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -805,12 +958,16 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "axum",
+ "axum-server",
  "chrono",
  "futures",
  "ghostlink-core",
+ "jsonwebtoken",
  "rand 0.8.6",
+ "rcgen",
  "reqwest 0.12.28",
  "rmcp",
+ "rustls",
  "serde",
  "serde_json",
  "sysinfo",
@@ -849,6 +1006,25 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -955,6 +1131,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1212,6 +1389,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1407,24 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1368,6 +1573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1603,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1410,12 +1631,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1466,6 +1721,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1747,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -1519,6 +1790,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1559,7 +1836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand 0.9.4",
@@ -1790,6 +2067,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,7 +2235,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2004,6 +2295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2335,8 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2059,9 +2361,10 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2279,6 +2582,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2799,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2797,6 +3151,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3305,6 +3665,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3373,6 +3761,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "zerotrie"

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -1,3 +1,5 @@
 module github.com/rwilliamspbg-ops/Ghostlink/control-plane
 
 go 1.24.3
+
+require github.com/golang-jwt/jwt/v5 v5.3.1 // indirect

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=

--- a/control-plane/main.go
+++ b/control-plane/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/rwilliamspbg-ops/Ghostlink/control-plane/pkg/auth"
 	"github.com/rwilliamspbg-ops/Ghostlink/control-plane/pkg/proxy"
 	"github.com/rwilliamspbg-ops/Ghostlink/control-plane/pkg/ratelimit"
 )
@@ -72,8 +73,10 @@ func envInt(key string, def int) int {
 
 // buildHandler wires the full route table + middleware chain. Factored out
 // of main() so tests can exercise the exact same routing/middleware setup
-// against a fake backend instead of a hand-rolled subset of it.
-func buildHandler(backendURL string, rateLimit int, rateWindow time.Duration) http.Handler {
+// against a fake backend instead of a hand-rolled subset of it. apiKey may
+// be empty (see auth.Middleware) — auth still applies via the proxy
+// forwarding Authorization through to ghost-link either way.
+func buildHandler(backendURL string, rateLimit int, rateWindow time.Duration, apiKey string) http.Handler {
 	chatProxy := proxy.NewChatProxy(backendURL)
 	limiter := ratelimit.New(rateLimit, rateWindow)
 
@@ -103,7 +106,12 @@ func buildHandler(backendURL string, rateLimit int, rateWindow time.Duration) ht
 	// always deferring to ghost-link's actual implementation.
 	mux.HandleFunc("/api/", chatProxy.HandleBackendProxy)
 
-	return loggingMiddleware(corsMiddleware(limiter.Middleware(mux)))
+	// auth runs inside cors (cors already fully short-circuits OPTIONS
+	// preflight before reaching anything wrapped inside it, so ordering
+	// relative to preflight isn't in question here) and outside the rate
+	// limiter, so an unauthenticated request gets rejected before it
+	// consumes any of a client's rate-limit budget.
+	return loggingMiddleware(corsMiddleware(auth.Middleware(apiKey)(limiter.Middleware(mux))))
 }
 
 func main() {
@@ -124,7 +132,13 @@ func main() {
 	rateLimit := envInt("GHOSTLINK_RATE_LIMIT", 120)
 	rateWindowSec := envInt("GHOSTLINK_RATE_WINDOW_SECONDS", 10)
 
-	handler := buildHandler(backendURL, rateLimit, time.Duration(rateWindowSec)*time.Second)
+	apiKey, err := auth.LoadAPIKey()
+	if err != nil {
+		log.Printf("warning: could not read ghost-link's API key (%v) — the gateway won't reject unauthenticated requests itself; ghost-link's own auth still applies to proxied traffic", err)
+		apiKey = ""
+	}
+
+	handler := buildHandler(backendURL, rateLimit, time.Duration(rateWindowSec)*time.Second, apiKey)
 
 	log.Printf("Ghostlink Control Plane starting on :%s", port)
 	log.Printf("Proxying GUI/API routes to backend: %s", backendURL)

--- a/control-plane/main_test.go
+++ b/control-plane/main_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHealthEndpoint(t *testing.T) {
-	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second)
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "")
 
 	req := httptest.NewRequest("GET", "/health", nil)
 	w := httptest.NewRecorder()
@@ -32,7 +32,7 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestHealthRejectsPost(t *testing.T) {
-	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second)
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "")
 
 	req := httptest.NewRequest("POST", "/health", nil)
 	w := httptest.NewRecorder()
@@ -56,7 +56,7 @@ func TestWorkersProxiesToBackend(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	handler := buildHandler(backend.URL, 1000, time.Second)
+	handler := buildHandler(backend.URL, 1000, time.Second, "")
 
 	req := httptest.NewRequest("GET", "/api/workers", nil)
 	w := httptest.NewRecorder()
@@ -76,7 +76,7 @@ func TestWorkersProxiesToBackend(t *testing.T) {
 }
 
 func TestCORSHeaders(t *testing.T) {
-	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second)
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "")
 
 	req := httptest.NewRequest("OPTIONS", "/api/models", nil)
 	w := httptest.NewRecorder()
@@ -96,7 +96,7 @@ func TestRateLimitingBlocksExcessRequests(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	handler := buildHandler(backend.URL, 2, time.Minute)
+	handler := buildHandler(backend.URL, 2, time.Minute, "")
 
 	makeReq := func() int {
 		req := httptest.NewRequest("GET", "/health", nil)
@@ -118,7 +118,7 @@ func TestRateLimitingBlocksExcessRequests(t *testing.T) {
 }
 
 func TestRateLimitingIsolatesByClient(t *testing.T) {
-	handler := buildHandler("http://127.0.0.1:19999", 1, time.Minute)
+	handler := buildHandler("http://127.0.0.1:19999", 1, time.Minute, "")
 
 	req1 := httptest.NewRequest("GET", "/health", nil)
 	req1.RemoteAddr = "10.0.0.1:1111"
@@ -154,7 +154,7 @@ func TestStreamingResponsesAreFlushed(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	handler := buildHandler(backend.URL, 1000, time.Second)
+	handler := buildHandler(backend.URL, 1000, time.Second, "")
 
 	req := httptest.NewRequest("POST", "/api/inference/chat", nil)
 	w := httptest.NewRecorder()

--- a/control-plane/pkg/auth/auth.go
+++ b/control-plane/pkg/auth/auth.go
@@ -1,0 +1,94 @@
+// Package auth verifies the same bearer token ghost-link's own API server
+// requires (see crates/ghost-link/src/auth.rs) — real edge-rejection, not
+// just relying on the proxy transparently forwarding the Authorization
+// header through to ghost-link (which it already does; this middleware
+// stops unauthenticated traffic here too, before it's proxied at all).
+//
+// Accepts either the raw shared API key as the bearer token, or a JWT
+// issued by ghost-link's /api/security/jwt/refresh (HS256, signed with
+// that same key) — genuine signature verification via golang-jwt, not a
+// shape-only check, so it doesn't reject legitimate short-lived tokens the
+// GUI actually uses.
+package auth
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// LoadAPIKey reads the API key from the same file ghost-link itself
+// generates and persists on first run (default api_key.txt, overridable
+// via GHOSTLINK_API_KEY_PATH — the exact env var name ghost-link's own
+// auth.rs uses, so both processes agree on where to look without extra
+// configuration when they share a working directory, the typical
+// same-host deployment this gateway assumes).
+func LoadAPIKey() (string, error) {
+	path := os.Getenv("GHOSTLINK_API_KEY_PATH")
+	if path == "" {
+		path = "api_key.txt"
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func extractBearerToken(header string) string {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(header, prefix))
+}
+
+// verify reports whether token is either an exact match for apiKey or a
+// currently-valid (unexpired, correctly-signed) JWT signed with apiKey.
+func verify(token, apiKey string) bool {
+	if token == "" {
+		return false
+	}
+	if token == apiKey {
+		return true
+	}
+
+	claims := jwt.RegisteredClaims{}
+	parsed, err := jwt.ParseWithClaims(token, &claims, func(t *jwt.Token) (interface{}, error) {
+		return []byte(apiKey), nil
+	}, jwt.WithValidMethods([]string{"HS256"}))
+	return err == nil && parsed.Valid
+}
+
+// Middleware guards every route except /health behind the shared bearer
+// token. If apiKey is empty (the key file wasn't readable at startup —
+// e.g. ghost-link hasn't generated one yet, or the gateway is misconfigured
+// with a different path), it logs nothing itself and lets every request
+// through unchecked: ghost-link's own auth still applies end to end via the
+// forwarded Authorization header, so this degrades to "no extra edge
+// rejection" rather than "locks everyone out" or "silently insecure in a
+// new way" — the pre-this-change baseline either way.
+func Middleware(apiKey string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if apiKey == "" {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			token := extractBearerToken(r.Header.Get("Authorization"))
+			if !verify(token, apiKey) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":{"message":"missing or invalid Authorization: Bearer <token>","type":"unauthorized"}}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/control-plane/pkg/auth/auth_test.go
+++ b/control-plane/pkg/auth/auth_test.go
@@ -1,0 +1,178 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestLoadAPIKeyReadsAndTrimsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "api_key.txt")
+	if err := os.WriteFile(path, []byte("  abc123\n"), 0o600); err != nil {
+		t.Fatalf("write test key file: %v", err)
+	}
+	t.Setenv("GHOSTLINK_API_KEY_PATH", path)
+
+	key, err := LoadAPIKey()
+	if err != nil {
+		t.Fatalf("LoadAPIKey: %v", err)
+	}
+	if key != "abc123" {
+		t.Errorf("expected trimmed key %q, got %q", "abc123", key)
+	}
+}
+
+func TestLoadAPIKeyReturnsErrorWhenMissing(t *testing.T) {
+	t.Setenv("GHOSTLINK_API_KEY_PATH", filepath.Join(t.TempDir(), "does-not-exist.txt"))
+	if _, err := LoadAPIKey(); err == nil {
+		t.Fatal("expected an error for a missing key file, got nil")
+	}
+}
+
+func TestExtractBearerTokenParsesWellFormedHeaderOnly(t *testing.T) {
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{"Bearer abc123", "abc123"},
+		{"bearer abc123", ""}, // case-sensitive, matches the real Authorization scheme
+		{"abc123", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := extractBearerToken(c.header); got != c.want {
+			t.Errorf("extractBearerToken(%q) = %q, want %q", c.header, got, c.want)
+		}
+	}
+}
+
+func TestVerifyAcceptsRawKeyMatchAndRejectsWrongOne(t *testing.T) {
+	const key = "the-real-key"
+	if !verify(key, key) {
+		t.Error("exact key match should verify")
+	}
+	if verify("wrong-key", key) {
+		t.Error("wrong key should not verify")
+	}
+	if verify("", key) {
+		t.Error("empty token should not verify")
+	}
+}
+
+func TestVerifyAcceptsAGenuinelyValidJWTAndRejectsTamperedOrExpired(t *testing.T) {
+	const key = "the-real-key"
+
+	valid := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		Subject:   "ghostlink-client",
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	})
+	signed, err := valid.SignedString([]byte(key))
+	if err != nil {
+		t.Fatalf("sign test JWT: %v", err)
+	}
+	if !verify(signed, key) {
+		t.Error("a genuinely valid JWT signed with the right key should verify")
+	}
+
+	if verify(signed+"tampered", key) {
+		t.Error("a tampered JWT must not verify")
+	}
+	if verify(signed, "different-key") {
+		t.Error("a JWT signed with a different key must not verify against this one")
+	}
+
+	expired := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		Subject:   "ghostlink-client",
+		IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+	})
+	expiredSigned, err := expired.SignedString([]byte(key))
+	if err != nil {
+		t.Fatalf("sign expired test JWT: %v", err)
+	}
+	if verify(expiredSigned, key) {
+		t.Error("an expired JWT must not verify")
+	}
+}
+
+func TestMiddlewareIsANoOpWhenAPIKeyIsEmpty(t *testing.T) {
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := Middleware("")(inner)
+
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("with an empty API key, requests should pass through unchecked")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMiddlewareAllowsHealthWithoutAuth(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := Middleware("real-key")(inner)
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("/health should bypass auth even with no token, got %d", w.Code)
+	}
+}
+
+func TestMiddlewareRejectsMissingOrWrongTokenAndAcceptsCorrectOne(t *testing.T) {
+	const key = "real-key"
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := Middleware(key)(inner)
+
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no Authorization header: expected 401, got %d", w.Code)
+	}
+	if called {
+		t.Error("inner handler must not run for an unauthenticated request")
+	}
+
+	req = httptest.NewRequest("GET", "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("wrong bearer token: expected 401, got %d", w.Code)
+	}
+
+	called = false
+	req = httptest.NewRequest("GET", "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("correct bearer token: expected 200, got %d", w.Code)
+	}
+	if !called {
+		t.Error("inner handler should run for an authenticated request")
+	}
+}

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -59,3 +59,7 @@ rmcp = { version = "2", default-features = false, features = [
     "transport-child-process",
     "transport-streamable-http-client-reqwest",
 ] }
+rustls = { version = "0.23.42", features = ["prefer-post-quantum"] }
+axum-server = { version = "0.8.0", features = ["tls-rustls"] }
+jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
+rcgen = "0.14.7"

--- a/crates/ghost-link/src/auth.rs
+++ b/crates/ghost-link/src/auth.rs
@@ -1,0 +1,209 @@
+//! Real bearer-token auth: a persisted API key generated once on first
+//! run, and short-lived JWTs (`jsonwebtoken`, HS256, signed with that same
+//! key) issued by exchanging it — replacing the previous hardcoded
+//! `"new-token-123"` JWT-refresh stub. Independent of whether TLS (see
+//! `tls.rs`) is on, though obviously weaker without it: a bearer token
+//! sent over plaintext HTTP can be observed in transit.
+
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static ACTIVE_API_KEY: OnceLock<String> = OnceLock::new();
+
+const JWT_LIFETIME_SECS: u64 = 3600;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    exp: u64,
+    iat: u64,
+}
+
+fn api_key_path() -> PathBuf {
+    std::env::var("GHOSTLINK_API_KEY_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("api_key.txt"))
+}
+
+fn generate_api_key() -> String {
+    let bytes: [u8; 32] = rand::random();
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Loads the persisted API key, generating and persisting a new one on
+/// first run (and printing it once, the same "show the first-run secret
+/// exactly once" convention tools like Jupyter use — there's no other way
+/// for the operator to learn it, since it's never returned by any API
+/// response). Reused across restarts once the file exists.
+fn load_or_create_api_key() -> String {
+    let path = api_key_path();
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        let trimmed = existing.trim().to_string();
+        if !trimmed.is_empty() {
+            return trimmed;
+        }
+    }
+
+    let key = generate_api_key();
+    if let Err(err) = std::fs::write(&path, &key) {
+        eprintln!(
+            "warning: failed to persist API key to {}: {err} (a new one will be generated next restart)",
+            path.display()
+        );
+    }
+    println!("=======================================================================");
+    println!(
+        "Generated a new Ghostlink API key (saved to {}):",
+        path.display()
+    );
+    println!("  {key}");
+    println!("Send it as `Authorization: Bearer {key}` on every API request, or");
+    println!("exchange it for a short-lived token via POST /api/security/jwt/refresh.");
+    println!("=======================================================================");
+    key
+}
+
+/// The process-wide API key, loaded (or generated) once and cached —
+/// every auth check and the JWT signing secret both derive from this
+/// single value.
+pub fn active_api_key() -> &'static str {
+    ACTIVE_API_KEY.get_or_init(load_or_create_api_key)
+}
+
+/// Issues a short-lived JWT for the given subject, signed with the active
+/// API key. Real issuance/verification, not the previous
+/// `"new-token-123"` stub.
+pub fn issue_jwt(subject: &str) -> Result<String, String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| format!("system clock error: {e}"))?
+        .as_secs();
+    let claims = Claims {
+        sub: subject.to_string(),
+        iat: now,
+        exp: now + JWT_LIFETIME_SECS,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(active_api_key().as_bytes()),
+    )
+    .map_err(|e| format!("failed to sign JWT: {e}"))
+}
+
+fn verify_jwt(token: &str) -> bool {
+    decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(active_api_key().as_bytes()),
+        &Validation::default(),
+    )
+    .is_ok()
+}
+
+/// Accepts either the raw API key itself as a bearer token (simplest path
+/// for a script or `curl`) or a JWT issued by `issue_jwt` that hasn't
+/// expired — both derive from the same secret, so either proves the
+/// caller knows the API key.
+pub fn verify_bearer_token(token: &str) -> bool {
+    let token = token.trim();
+    if token.is_empty() {
+        return false;
+    }
+    // Constant-time-ish compare isn't critical here (the key is 256 bits
+    // of real entropy — timing side channels aren't the realistic threat
+    // for a locally-generated secret), but avoid the obviously-wrong
+    // early-exit shape anyway.
+    let matches_raw_key = token.len() == active_api_key().len() && token == active_api_key();
+    matches_raw_key || verify_jwt(token)
+}
+
+/// Extracts the bearer token from an `Authorization: Bearer <token>`
+/// header value, if present and well-formed.
+pub fn extract_bearer_token(header_value: Option<&str>) -> Option<&str> {
+    header_value?.strip_prefix("Bearer ").map(str::trim)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Real filesystem + real env var mutation — serialized like this
+    // project's other env-var-mutating tests (see
+    // runtime_switcher::env_test_lock) since `GHOSTLINK_API_KEY_PATH` is
+    // process-global and `cargo test` runs in parallel by default.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn generate_api_key_produces_64_hex_chars_of_real_entropy() {
+        let a = generate_api_key();
+        let b = generate_api_key();
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, b, "two generated keys should not collide");
+    }
+
+    #[test]
+    fn load_or_create_api_key_persists_and_reuses_across_calls() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let path =
+            std::env::temp_dir().join(format!("ghostlink-test-api-key-{}.txt", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        std::env::set_var("GHOSTLINK_API_KEY_PATH", &path);
+
+        let first = load_or_create_api_key();
+        assert!(path.exists());
+        let second = load_or_create_api_key();
+        assert_eq!(
+            first, second,
+            "second call should reuse the persisted key, not regenerate"
+        );
+
+        std::env::remove_var("GHOSTLINK_API_KEY_PATH");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn extract_bearer_token_parses_well_formed_header_only() {
+        assert_eq!(extract_bearer_token(Some("Bearer abc123")), Some("abc123"));
+        assert_eq!(extract_bearer_token(Some("bearer abc123")), None);
+        assert_eq!(extract_bearer_token(Some("abc123")), None);
+        assert_eq!(extract_bearer_token(None), None);
+    }
+
+    #[test]
+    fn verify_bearer_token_accepts_raw_key_and_issued_jwt_rejects_garbage() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let path = std::env::temp_dir().join(format!(
+            "ghostlink-test-api-key-verify-{}.txt",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        std::env::set_var("GHOSTLINK_API_KEY_PATH", &path);
+        // Reset the OnceLock's effective value for this test process by
+        // reading the key freshly through the same path the real code
+        // uses — `active_api_key()` is a OnceLock so it can only be
+        // initialized once per test binary run; this test therefore
+        // exercises whatever key was already cached, not a fresh one. That
+        // is fine: it still proves round-trip correctness, just not
+        // isolation across tests within this one process.
+        let key = active_api_key().to_string();
+
+        assert!(verify_bearer_token(&key));
+        assert!(!verify_bearer_token("not-the-key"));
+        assert!(!verify_bearer_token(""));
+
+        let jwt = issue_jwt("test-subject").expect("issue_jwt should succeed");
+        assert!(verify_bearer_token(&jwt));
+        assert!(!verify_bearer_token(&format!("{jwt}tampered")));
+
+        std::env::remove_var("GHOSTLINK_API_KEY_PATH");
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1569,6 +1569,13 @@ struct BackendState {
     /// last-writer-wins race with no relation to which process actually
     /// survived the taskkill/spawn collision.
     model_lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Whether the *currently running* listener is actually serving HTTPS
+    /// with the PQC-hybrid key exchange preference — set once at server
+    /// startup from the same `use_tls` decision that picked the listener
+    /// branch. Distinct from `settings.enable_tls`, which is the persisted
+    /// setting and only takes effect on next restart; this field is what
+    /// `/api/security/pqc/state` actually reports.
+    enable_tls_active: bool,
 }
 
 /// Real byte-level progress for an in-flight (or just-finished) model download.
@@ -1622,6 +1629,16 @@ struct RuntimeSettings {
     /// falling back to `RuntimeSettings::default()` in its entirety.
     #[serde(default = "default_conversation_token_limit")]
     conversation_token_limit: usize,
+    /// Serve over HTTPS with a self-signed cert and a real PQC-hybrid
+    /// (X25519MLKEM768) key exchange preference (see `tls.rs`), instead of
+    /// plain HTTP. Off by default so today's plain-localhost dev flow sees
+    /// zero disruption; forced on regardless of this setting when the
+    /// server binds a non-loopback address (`tls::is_loopback_host`),
+    /// since that's the LAN/remote scenario PQC-hybrid TLS protects.
+    /// `#[serde(default)]` (false) so settings.json files saved before
+    /// this field existed still deserialize.
+    #[serde(default)]
+    enable_tls: bool,
 }
 
 // Kept as named constants (rather than inlined in both `RuntimeSettings::default()`
@@ -1682,6 +1699,7 @@ impl Default for RuntimeSettings {
             tcp_auth_token: String::new(),
             xdp_interface: "eth0".to_string(),
             conversation_token_limit: default_conversation_token_limit(),
+            enable_tls: false,
         }
     }
 }
@@ -2261,7 +2279,9 @@ fn select_best_gguf_group(groups: &[Vec<String>], vram_gb: f32) -> Option<Vec<St
 
 fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     use axum::{
-        extract::{Path, Query, State},
+        extract::{Path, Query, Request, State},
+        http::StatusCode,
+        middleware::{self, Next},
         response::{
             sse::{Event, Sse},
             IntoResponse,
@@ -2279,6 +2299,35 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
     fn lock_state(state: &Arc<Mutex<BackendState>>) -> std::sync::MutexGuard<'_, BackendState> {
         state.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    /// Guards every route except `/health` behind a real bearer token
+    /// (the persisted API key itself, or a JWT issued from it — see
+    /// `auth.rs`). Replaces having no auth check anywhere on this server.
+    async fn auth_middleware(req: Request, next: Next) -> axum::response::Response {
+        if req.uri().path() == "/health" {
+            return next.run(req).await;
+        }
+
+        let header = req
+            .headers()
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok());
+        let token = auth::extract_bearer_token(header);
+
+        match token {
+            Some(t) if auth::verify_bearer_token(t) => next.run(req).await,
+            _ => (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": "missing or invalid Authorization: Bearer <token> — see the API key printed at server startup, or POST /api/security/jwt/refresh with it to get a short-lived token",
+                        "type": "unauthorized"
+                    }
+                })),
+            )
+                .into_response(),
+        }
     }
 
     /// Waits for Ctrl+C, then force-tears-down every connected MCP server before
@@ -3812,16 +3861,61 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }))
     }
 
+    /// Real JWT issuance (was a hardcoded `"new-token-123"`). Reaching this
+    /// handler at all already proves the caller presented a valid bearer
+    /// token (`auth_middleware` gates every route but `/health`) — no
+    /// separate credential to check here, just mint a fresh short-lived
+    /// token signed with the same API key that got them past the gate.
     async fn handle_gui_jwt_refresh() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "status": "ok", "token": "new-token-123" }))
+        match auth::issue_jwt("ghostlink-client") {
+            Ok(token) => Json(serde_json::json!({ "status": "ok", "token": token })),
+            Err(err) => Json(serde_json::json!({ "status": "error", "error": err })),
+        }
     }
 
-    async fn handle_gui_pqc_enable() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "status": "ok", "enabled": true }))
+    /// Turns on `enable_tls` in persisted settings (was a no-op that always
+    /// reported `enabled: true`). The listener is bound once at server
+    /// startup, so this takes effect on next restart — said plainly in the
+    /// response rather than implying it's already live.
+    async fn handle_gui_pqc_enable(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let backend = &mut *lock_state(&state);
+        let mut current = backend.settings.clone();
+        current.enable_tls = true;
+        backend.settings = current.clone();
+        save_settings(&current);
+        Json(serde_json::json!({
+            "status": "ok",
+            "enabled": true,
+            "restart_required": true,
+            "message": "enable_tls saved — restart the server for the HTTPS/PQC-hybrid listener to take effect"
+        }))
     }
 
-    async fn handle_gui_pqc_state() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "enabled": true, "algorithm": "ml-kem-768" }))
+    /// Reports the real, current server configuration (was hardcoded
+    /// `enabled: true`): whether `enable_tls` is on for THIS running
+    /// process (not just persisted — a setting saved via
+    /// `handle_gui_pqc_enable` doesn't apply until restart, so this
+    /// reflects what's actually serving right now) and the hybrid group
+    /// rustls is configured to prefer whenever TLS is active. This is
+    /// server-level config state, not a genuine per-connection
+    /// introspection of whether a given client actually negotiated the
+    /// hybrid group — independently verifiable via `openssl s_client
+    /// -groups X25519MLKEM768` against a TLS-enabled instance.
+    async fn handle_gui_pqc_state(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let active = lock_state(&state).enable_tls_active;
+        Json(serde_json::json!({
+            "enabled": active,
+            "algorithm": "X25519MLKEM768",
+            "note": if active {
+                "TLS is active on this server; rustls is configured to prefer the X25519MLKEM768 post-quantum hybrid key-exchange group (via the prefer-post-quantum feature)."
+            } else {
+                "TLS is not active on this server (plain HTTP) — no key exchange is happening. Enable via POST /api/security/pqc/enable and restart."
+            }
+        }))
     }
 
     async fn handle_gui_audit_log() -> Json<serde_json::Value> {
@@ -5699,6 +5793,15 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                                 .resize_slots(current.parallel_slots);
                         }
                     }
+                    "enable_tls" => {
+                        if let Some(v) = value.as_bool() {
+                            // Takes effect on next server restart — the
+                            // listener is bound once at startup (main.rs's
+                            // `start_openai_api_server`), not re-bound on a
+                            // settings change.
+                            current.enable_tls = v;
+                        }
+                    }
                     "conversation_token_limit" => {
                         if let Some(v) = value.as_u64() {
                             current.conversation_token_limit = v as usize;
@@ -6005,6 +6108,20 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
     // Load settings to get initial inference backend
     let settings = load_settings();
+    // Captured before `settings` moves into `BackendState` below — used
+    // once at the very end of this function to pick the TLS vs. plain
+    // listener.
+    // Computed once here (rather than at the final serve call, after
+    // `settings` has moved into `BackendState`) so both the listener
+    // choice below and `BackendState.enable_tls_active` (read by
+    // `/api/security/pqc/state`) share one source of truth.
+    let use_tls = settings.enable_tls || !tls::is_loopback_host(host);
+    // Eagerly generate/load (and, on first run, print) the API key here —
+    // `active_api_key()` is otherwise lazy-initialized on first use, which
+    // would mean the one-time "here's your key" banner never prints at
+    // all unless some request happens to trigger it first, leaving a
+    // fresh install with no way to discover the key it needs.
+    auth::active_api_key();
     let inference_backend = InferenceBackend::parse(&settings.inference_backend);
     let native_engine_client = native_engine::NativeEngineClient::new();
     let ollama_client = ollama::OllamaClient::new(ollama_url);
@@ -6078,6 +6195,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         pending_tool_calls: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         download_progress: HashMap::new(),
         model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
+        enable_tls_active: use_tls,
     }));
 
     // Background CPU/RAM/GPU sampler — keeps /api/metrics non-blocking.
@@ -6197,21 +6315,50 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 post(handle_toggle_mcp_server),
             )
             .with_state(state)
+            // Auth runs inside CORS (added first here = innermost = runs
+            // *after* CORS on the way in), so a browser's CORS preflight
+            // OPTIONS request is still handled without needing a bearer
+            // token — matches how CORS preflight is expected to work.
+            .layer(middleware::from_fn(auth_middleware))
             .layer(CorsLayer::permissive());
 
-        // addr already parsed above
-        let listener = tokio::net::TcpListener::bind(addr)
-            .await
-            .map_err(|err| anyhow::anyhow!("failed to bind API server on {}: {}", addr, err))?;
-        println!(
-            "
+        // addr already parsed above; `use_tls` computed earlier alongside
+        // `BackendState.enable_tls_active`.
+        if use_tls {
+            let tls_config = tls::build_rustls_config(host)
+                .await
+                .map_err(|err| anyhow::anyhow!("failed to prepare TLS: {}", err))?;
+            println!(
+                "
+API Server Online (HTTPS, PQC-hybrid key exchange preferred). Ready for connections."
+            );
+            let shutdown_handle = axum_server::Handle::new();
+            tokio::spawn({
+                let shutdown_handle = shutdown_handle.clone();
+                async move {
+                    mcp_shutdown_on_ctrl_c(mcp_registry).await;
+                    shutdown_handle.graceful_shutdown(None);
+                }
+            });
+            axum_server::bind_rustls(addr, tls_config)
+                .handle(shutdown_handle)
+                .serve(app.into_make_service())
+                .await
+                .map_err(|err| anyhow::anyhow!("HTTPS API server terminated with error: {}", err))
+        } else {
+            let listener = tokio::net::TcpListener::bind(addr)
+                .await
+                .map_err(|err| anyhow::anyhow!("failed to bind API server on {}: {}", addr, err))?;
+            println!(
+                "
 API Server Online. Ready for connections."
-        );
+            );
 
-        axum::serve(listener, app)
-            .with_graceful_shutdown(mcp_shutdown_on_ctrl_c(mcp_registry))
-            .await
-            .map_err(|err| anyhow::anyhow!("API server terminated with error: {}", err))
+            axum::serve(listener, app)
+                .with_graceful_shutdown(mcp_shutdown_on_ctrl_c(mcp_registry))
+                .await
+                .map_err(|err| anyhow::anyhow!("API server terminated with error: {}", err))
+        }
     })?;
 
     Ok(())
@@ -8211,6 +8358,7 @@ fn run_gui_preflight_checks() -> Result<()> {
     Ok(())
 }
 
+mod auth;
 mod backend_api;
 mod backend_config;
 mod backend_registry;
@@ -8220,6 +8368,7 @@ mod native_engine;
 mod ollama;
 mod runtime;
 mod runtime_switcher;
+mod tls;
 
 static ACTIVE_BACKEND_REGISTRY: OnceLock<Arc<backend_registry::BackendRegistry>> = OnceLock::new();
 static ACTIVE_RUNTIME_SWITCHER: OnceLock<runtime_switcher::RuntimeSwitcher> = OnceLock::new();

--- a/crates/ghost-link/src/tls.rs
+++ b/crates/ghost-link/src/tls.rs
@@ -1,0 +1,147 @@
+//! Self-signed TLS termination with a real ML-KEM-768 hybrid (PQC) key
+//! exchange preference (via rustls's `prefer-post-quantum` feature, backed
+//! by aws-lc-rs — the same mechanism Chrome/Cloudflare/AWS use today), not
+//! a bespoke handshake protocol. Opt-in via `RuntimeSettings.enable_tls`,
+//! forced on when the server binds a non-loopback address (see
+//! `is_loopback_host`) since that's the LAN/remote scenario PQC-hybrid TLS
+//! is meant to protect. This is a self-hosted local tool, not a public
+//! service, so a self-signed cert generated once on first use — no CA
+//! involved — is the right call.
+
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Once;
+
+static INSTALL_PROVIDER: Once = Once::new();
+
+/// Installs the aws-lc-rs-backed rustls crypto provider (the one built
+/// with the `prefer-post-quantum` Cargo feature) as the process default,
+/// if not already installed. Idempotent — safe to call on every listener
+/// start, including in tests.
+pub fn ensure_crypto_provider_installed() {
+    INSTALL_PROVIDER.call_once(|| {
+        // Only fails if a default was already installed by someone else;
+        // fine to ignore since that means a provider is active either way.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
+pub fn cert_path() -> PathBuf {
+    std::env::var("GHOSTLINK_TLS_CERT_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("tls_cert.pem"))
+}
+
+pub fn key_path() -> PathBuf {
+    std::env::var("GHOSTLINK_TLS_KEY_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("tls_key.pem"))
+}
+
+/// Generates a self-signed cert+key for `san_names` if the files at
+/// `cert_path`/`key_path` don't already both exist. Idempotent — an
+/// existing pair is reused across restarts rather than regenerated, so a
+/// client that already trusted the cert once doesn't see a new one every
+/// launch.
+pub fn ensure_self_signed_cert(
+    cert_path: &Path,
+    key_path: &Path,
+    san_names: Vec<String>,
+) -> Result<(), String> {
+    if cert_path.exists() && key_path.exists() {
+        return Ok(());
+    }
+
+    let certified_key = rcgen::generate_simple_self_signed(san_names)
+        .map_err(|e| format!("failed to generate self-signed certificate: {e}"))?;
+
+    std::fs::write(cert_path, certified_key.cert.pem())
+        .map_err(|e| format!("failed to write TLS cert to {}: {e}", cert_path.display()))?;
+    std::fs::write(key_path, certified_key.signing_key.serialize_pem())
+        .map_err(|e| format!("failed to write TLS key to {}: {e}", key_path.display()))?;
+
+    Ok(())
+}
+
+/// `true` for loopback/localhost-only hosts — the boundary used to decide
+/// whether TLS is forced on by default. Binding a non-loopback address is
+/// exactly the LAN/remote scenario PQC-hybrid TLS protects; pure-localhost
+/// dev flow stays plaintext by default so existing setups see zero
+/// disruption.
+pub fn is_loopback_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
+/// Loads (generating if needed) a self-signed cert/key pair and builds an
+/// `axum-server` Rustls config from it, with the process's PQC-preferring
+/// crypto provider installed first.
+pub async fn build_rustls_config(
+    host: &str,
+) -> Result<axum_server::tls_rustls::RustlsConfig, String> {
+    ensure_crypto_provider_installed();
+
+    let cert = cert_path();
+    let key = key_path();
+    let mut san_names = vec!["localhost".to_string(), "127.0.0.1".to_string()];
+    if !is_loopback_host(host) {
+        san_names.push(host.to_string());
+    }
+    ensure_self_signed_cert(&cert, &key, san_names)?;
+
+    axum_server::tls_rustls::RustlsConfig::from_pem_file(&cert, &key)
+        .await
+        .map_err(|e| format!("failed to load TLS cert/key into rustls config: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_loopback_host_recognizes_common_local_forms() {
+        assert!(is_loopback_host("localhost"));
+        assert!(is_loopback_host("LOCALHOST"));
+        assert!(is_loopback_host("127.0.0.1"));
+        assert!(is_loopback_host("::1"));
+    }
+
+    #[test]
+    fn is_loopback_host_rejects_lan_and_remote_addresses() {
+        assert!(!is_loopback_host("0.0.0.0"));
+        assert!(!is_loopback_host("192.168.1.50"));
+        assert!(!is_loopback_host("example.com"));
+        assert!(!is_loopback_host(""));
+    }
+
+    #[test]
+    fn ensure_self_signed_cert_generates_once_and_is_idempotent() {
+        let dir = std::env::temp_dir().join(format!("ghostlink-tls-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let cert_path = dir.join("cert.pem");
+        let key_path = dir.join("key.pem");
+        let _ = std::fs::remove_file(&cert_path);
+        let _ = std::fs::remove_file(&key_path);
+
+        ensure_self_signed_cert(&cert_path, &key_path, vec!["localhost".to_string()])
+            .expect("first generation should succeed");
+        assert!(cert_path.exists());
+        assert!(key_path.exists());
+
+        let cert_bytes_before = std::fs::read(&cert_path).expect("read cert");
+
+        // Second call must be a no-op — same cert reused, not regenerated.
+        ensure_self_signed_cert(&cert_path, &key_path, vec!["localhost".to_string()])
+            .expect("idempotent call should succeed");
+        let cert_bytes_after = std::fs::read(&cert_path).expect("read cert again");
+        assert_eq!(cert_bytes_before, cert_bytes_after);
+
+        let _ = std::fs::remove_file(&cert_path);
+        let _ = std::fs::remove_file(&key_path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+}

--- a/ghostlink_gui_modern/src/api.ts
+++ b/ghostlink_gui_modern/src/api.ts
@@ -10,6 +10,12 @@ export interface CircuitBreakerState {
   lastFailureTime: number;
 }
 
+// The backend has no way to hand this to the GUI automatically — it's
+// printed once in the server's own startup console output (never returned
+// by any API response, on purpose) — so the user pastes it in manually
+// once (see SecurityTab) and it's remembered here across reloads.
+const API_KEY_STORAGE_KEY = 'ghostlink-api-key';
+
 export class GhostlinkAPI {
   private http: AxiosInstance;
   private requestTimeout = [5000, 120000] as const;
@@ -25,6 +31,42 @@ export class GhostlinkAPI {
       baseURL: apiBase.trim(),
       timeout: this.requestTimeout[1],
     });
+
+    this.http.interceptors.request.use((config) => {
+      const apiKey = this.getApiKey();
+      if (apiKey) {
+        config.headers = config.headers ?? {};
+        config.headers.Authorization = `Bearer ${apiKey}`;
+      }
+      return config;
+    });
+  }
+
+  /** Reads the persisted API key/token, if the user has entered one. */
+  getApiKey(): string {
+    try {
+      return localStorage.getItem(API_KEY_STORAGE_KEY) ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  /** Persists the API key (or JWT) used to authenticate every request from
+   * here on — every call already in flight keeps its old header, but the
+   * interceptor reads fresh on each new request, so this takes effect
+   * immediately. Pass an empty string to clear it. */
+  setApiKey(key: string): void {
+    try {
+      if (key) {
+        localStorage.setItem(API_KEY_STORAGE_KEY, key);
+      } else {
+        localStorage.removeItem(API_KEY_STORAGE_KEY);
+      }
+    } catch {
+      // localStorage unavailable (private browsing, etc.) — the key just
+      // won't survive a reload; not fatal, every other request this
+      // session still works via the in-memory read above failing closed.
+    }
   }
 
   private isNotFound(error: any): boolean {
@@ -262,10 +304,12 @@ export class GhostlinkAPI {
             ? `${this.http.defaults.baseURL}/api/inference/chat`
             : '/api/inference/chat';
 
+        const apiKey = this.getApiKey();
         const response = await fetch(url, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
           },
           body: JSON.stringify(payload),
         });
@@ -679,9 +723,13 @@ export class GhostlinkAPI {
 
   async pullOllamaModelStream(modelName: string, onProgress: (progress: any) => void): Promise<{ success: boolean; error?: string }> {
     try {
+      const apiKey = this.getApiKey();
       const response = await fetch(`${this.http.defaults.baseURL}/api/ollama/pull/stream`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+        },
         body: JSON.stringify({ model: modelName }),
       });
 

--- a/ghostlink_gui_modern/src/components/SecurityTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/SecurityTab.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SecurityTab } from './SecurityTab';
+
+function createMockApi(overrides: Partial<ReturnType<typeof baseMock>> = {}) {
+  return { ...baseMock(), ...overrides };
+}
+
+function baseMock() {
+  let storedKey = '';
+  return {
+    getApiKey: vi.fn(() => storedKey),
+    setApiKey: vi.fn((key: string) => {
+      storedKey = key;
+    }),
+    getPQCState: vi.fn().mockResolvedValue({ enabled: false }),
+    enablePQC: vi.fn().mockResolvedValue({ success: true, data: { restart_required: true, enabled: true } }),
+    getAuditLog: vi.fn().mockResolvedValue({ entries: [] }),
+    refreshJWT: vi.fn().mockResolvedValue({ success: true, data: { token: 'a.b.c' } }),
+  };
+}
+
+describe('SecurityTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads the currently-stored API key into the input on mount', async () => {
+    const api = createMockApi();
+    api.getApiKey.mockReturnValue('existing-key-123');
+
+    render(<SecurityTab api={api} />);
+
+    await waitFor(() => {
+      const input = screen.getByLabelText('API key') as HTMLInputElement;
+      expect(input.value).toBe('existing-key-123');
+    });
+  });
+
+  it('saves the entered API key via api.setApiKey and shows confirmation', async () => {
+    const api = createMockApi();
+    render(<SecurityTab api={api} />);
+
+    const input = screen.getByLabelText('API key');
+    fireEvent.change(input, { target: { value: 'new-key-456' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(api.setApiKey).toHaveBeenCalledWith('new-key-456');
+    expect(await screen.findByText('Saved')).toBeInTheDocument();
+  });
+
+  it('shows a restart-required message rather than claiming PQC is already active', async () => {
+    const api = createMockApi();
+    render(<SecurityTab api={api} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /enable https \+ pqc-hybrid tls/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/restart the server/i)).toBeInTheDocument();
+    });
+    // Must not claim the hardened state is already live.
+    expect(screen.queryByText(/HTTPS \+ PQC-hybrid active/i)).not.toBeInTheDocument();
+  });
+
+  it('reflects a real enabled PQC state from the backend without requiring a click', async () => {
+    const api = createMockApi({ getPQCState: vi.fn().mockResolvedValue({ enabled: true }) });
+    render(<SecurityTab api={api} />);
+
+    expect(await screen.findByText(/HTTPS \+ PQC-hybrid active/i)).toBeInTheDocument();
+  });
+});

--- a/ghostlink_gui_modern/src/components/SecurityTab.tsx
+++ b/ghostlink_gui_modern/src/components/SecurityTab.tsx
@@ -15,6 +15,20 @@ export const SecurityTab: React.FC<{ api: any }> = ({ api }) => {
   const [pqcEnabled, setPqcEnabled] = useState(false);
   const [token, setToken] = useState('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
   const [auditLog, setAuditLog] = useState<AuditEntry[]>([]);
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [apiKeySaved, setApiKeySaved] = useState(false);
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [pqcRestartRequired, setPqcRestartRequired] = useState(false);
+
+  useEffect(() => {
+    setApiKeyInput(api.getApiKey?.() ?? '');
+  }, [api]);
+
+  const handleSaveApiKey = () => {
+    api.setApiKey?.(apiKeyInput.trim());
+    setApiKeySaved(true);
+    setTimeout(() => setApiKeySaved(false), 2000);
+  };
 
   useEffect(() => {
     const fetchPqcState = async () => {
@@ -50,7 +64,14 @@ export const SecurityTab: React.FC<{ api: any }> = ({ api }) => {
     setLoading(true);
     try {
       const result = await api.enablePQC();
-      if (result.success) setPqcEnabled(true);
+      // Saves the enable_tls setting for next restart — the listener is
+      // bound once at server startup, so this isn't live yet. Reflect
+      // that honestly rather than flipping straight to "enabled".
+      if (result.success && result.data?.restart_required) {
+        setPqcRestartRequired(true);
+      } else if (result.success) {
+        setPqcEnabled(true);
+      }
     } finally {
       setLoading(false);
     }
@@ -64,6 +85,47 @@ export const SecurityTab: React.FC<{ api: any }> = ({ api }) => {
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="max-w-5xl mx-auto space-y-6">
+          {/* API Key Section */}
+          <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6 space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="p-3 bg-blue-500/10 rounded-2xl text-blue-400">
+                <Key size={24} />
+              </div>
+              <div>
+                <h3 className="font-bold text-slate-100">API Key</h3>
+                <p className="text-xs text-slate-500">
+                  Required for every request to this server. Printed once in the server's console output
+                  on first run (or check <code className="text-slate-400 bg-slate-800 px-1 rounded font-mono">api_key.txt</code> next
+                  to the running server) — paste it here to authenticate this browser.
+                </p>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <input
+                type={showApiKey ? 'text' : 'password'}
+                value={apiKeyInput}
+                onChange={(e) => setApiKeyInput(e.target.value)}
+                placeholder="Paste the API key printed at server startup"
+                aria-label="API key"
+                className="flex-1 bg-slate-950 border border-slate-800 rounded-xl px-4 py-2.5 text-sm font-mono text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-blue-500"
+              />
+              <button
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="px-3 text-slate-500 hover:text-white transition"
+                aria-label={showApiKey ? 'Hide API key' : 'Show API key'}
+                aria-pressed={showApiKey}
+              >
+                {showApiKey ? <EyeOff size={16} aria-hidden="true" /> : <Eye size={16} aria-hidden="true" />}
+              </button>
+              <button
+                onClick={handleSaveApiKey}
+                className="px-5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white rounded-xl text-sm font-bold transition"
+              >
+                {apiKeySaved ? 'Saved' : 'Save'}
+              </button>
+            </div>
+          </div>
+
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {/* JWT Section */}
             <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6 space-y-6">
@@ -112,7 +174,7 @@ export const SecurityTab: React.FC<{ api: any }> = ({ api }) => {
                 </div>
                 <div>
                   <h3 className="font-bold text-slate-100">Quantum Hardening</h3>
-                  <p className="text-xs text-slate-500">Post-Quantum Cryptography (PQC)</p>
+                  <p className="text-xs text-slate-500">HTTPS with a real PQC-hybrid key exchange (X25519MLKEM768)</p>
                 </div>
               </div>
 
@@ -127,24 +189,26 @@ export const SecurityTab: React.FC<{ api: any }> = ({ api }) => {
                   )}
                   <div>
                     <p className={`text-sm font-bold ${pqcEnabled ? 'text-green-400' : 'text-orange-400'}`}>
-                      {pqcEnabled ? 'Fabric Hardened' : 'Standard Encryption'}
+                      {pqcEnabled ? 'HTTPS + PQC-hybrid active' : 'Plain HTTP — no transport encryption'}
                     </p>
                     <p className="text-xs text-slate-500 mt-1 leading-relaxed">
                       {pqcEnabled
-                        ? 'Kyber-768/Dilithium key exchange is active across all distributed nodes.'
-                        : 'Currently using standard AES-GCM 256-bit encryption. Enable PQC for future-proof security.'}
+                        ? 'This server is running HTTPS with rustls configured to prefer the X25519MLKEM768 post-quantum hybrid key-exchange group (the same mechanism Chrome/Cloudflare/AWS use). Bearer-token auth on every request is independent of this and always active regardless.'
+                        : pqcRestartRequired
+                          ? 'Saved — restart the server for the HTTPS/PQC-hybrid listener to take effect. Bearer-token auth on every request is already active regardless.'
+                          : 'This server is on plain HTTP — requests aren’t encrypted in transit (bearer-token auth still applies, but a token sent over plain HTTP can be observed). Enabling generates a local self-signed certificate.'}
                     </p>
                   </div>
                 </div>
               </div>
 
-              {!pqcEnabled && (
+              {!pqcEnabled && !pqcRestartRequired && (
                 <button
                   onClick={handlePqc}
                   disabled={loading}
                   className="w-full py-3 bg-purple-600 hover:bg-purple-500 text-white rounded-xl text-sm font-bold transition shadow-lg shadow-purple-500/20"
                 >
-                  Enable Post-Quantum Defense
+                  Enable HTTPS + PQC-Hybrid TLS
                 </button>
               )}
             </div>

--- a/scripts/ci_gui_backend_smoke.py
+++ b/scripts/ci_gui_backend_smoke.py
@@ -22,18 +22,46 @@ BINARY_PATH = Path(os.environ.get("CARGO_TARGET_DIR") or ROOT / "target") / "deb
 )
 
 
-def _get_json(path: str, timeout: float = 5.0) -> dict:
-    req = Request(f"{BASE_URL}{path}", method="GET")
+API_KEY_PATH = ROOT / "api_key.txt"
+
+
+def _wait_for_api_key(max_wait_s: int = 20) -> str:
+    """The server generates and persists a real API key at startup (see
+    crates/ghost-link/src/auth.rs) — every route but /health now requires
+    it as a bearer token. Polls for the file rather than assuming it's
+    already there the instant the process starts."""
+    deadline = time.time() + max_wait_s
+    while time.time() < deadline:
+        try:
+            key = API_KEY_PATH.read_text(encoding="utf-8").strip()
+            if key:
+                return key
+        except FileNotFoundError:
+            pass
+        time.sleep(0.2)
+    raise RuntimeError(f"API key file never appeared at {API_KEY_PATH}")
+
+
+def _auth_headers() -> dict:
+    return {"Authorization": f"Bearer {_wait_for_api_key()}"}
+
+
+def _get_json(path: str, timeout: float = 5.0, auth: bool = True) -> dict:
+    headers = _auth_headers() if auth else {}
+    req = Request(f"{BASE_URL}{path}", method="GET", headers=headers)
     with urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
 
-def _post_json(path: str, payload: dict, timeout: float = 10.0) -> dict:
+def _post_json(path: str, payload: dict, timeout: float = 10.0, auth: bool = True) -> dict:
     body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if auth:
+        headers.update(_auth_headers())
     req = Request(
         f"{BASE_URL}{path}",
         data=body,
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     with urlopen(req, timeout=timeout) as resp:
@@ -44,7 +72,7 @@ def _wait_for_health(max_wait_s: int = 45) -> None:
     deadline = time.time() + max_wait_s
     while time.time() < deadline:
         try:
-            health = _get_json("/health", timeout=1.5)
+            health = _get_json("/health", timeout=1.5, auth=False)
             if health.get("status") == "healthy":
                 return
         except (URLError, HTTPError, TimeoutError, OSError, ValueError):
@@ -76,7 +104,7 @@ def main() -> int:
     try:
         _wait_for_health()
 
-        health = _get_json("/health")
+        health = _get_json("/health", auth=False)
         if health.get("status") != "healthy":
             raise RuntimeError("health endpoint returned non-healthy status")
 

--- a/scripts/test_api_contract.py
+++ b/scripts/test_api_contract.py
@@ -18,18 +18,46 @@ PORT = 18014
 BASE_URL = f"http://{HOST}:{PORT}"
 
 
-def _get(path: str, timeout: float = 5.0) -> dict:
-    req = Request(f"{BASE_URL}{path}", method="GET")
+API_KEY_PATH = ROOT / "api_key.txt"
+
+
+def _wait_for_api_key(max_wait_s: int = 20) -> str:
+    """The server generates and persists a real API key at startup (see
+    crates/ghost-link/src/auth.rs) — every route but /health now requires
+    it as a bearer token. Polls for the file rather than assuming it's
+    already there the instant the process starts."""
+    deadline = time.time() + max_wait_s
+    while time.time() < deadline:
+        try:
+            key = API_KEY_PATH.read_text(encoding="utf-8").strip()
+            if key:
+                return key
+        except FileNotFoundError:
+            pass
+        time.sleep(0.2)
+    raise RuntimeError(f"API key file never appeared at {API_KEY_PATH}")
+
+
+def _auth_headers() -> dict:
+    return {"Authorization": f"Bearer {_wait_for_api_key()}"}
+
+
+def _get(path: str, timeout: float = 5.0, auth: bool = True) -> dict:
+    headers = _auth_headers() if auth else {}
+    req = Request(f"{BASE_URL}{path}", method="GET", headers=headers)
     with urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
 
-def _post(path: str, payload: dict, timeout: float = 10.0) -> dict:
+def _post(path: str, payload: dict, timeout: float = 10.0, auth: bool = True) -> dict:
     body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if auth:
+        headers.update(_auth_headers())
     req = Request(
         f"{BASE_URL}{path}",
         data=body,
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     with urlopen(req, timeout=timeout) as resp:
@@ -40,7 +68,7 @@ def _wait_ready(max_wait_s: int = 45) -> None:
     deadline = time.time() + max_wait_s
     while time.time() < deadline:
         try:
-            data = _get("/health", timeout=1.5)
+            data = _get("/health", timeout=1.5, auth=False)
             if data.get("status") == "healthy":
                 return
         except (URLError, HTTPError, TimeoutError, OSError, ValueError):


### PR DESCRIPTION
## Summary

Closes the last item from a gap analysis against LM Studio/vLLM: the API server had zero authentication anywhere, and `/api/security/*` was entirely mocked — `handle_gui_jwt_refresh` always returned a hardcoded `"new-token-123"`, PQC endpoints always claimed `enabled: true` regardless of anything. Both are now real.

- **Real bearer-token auth** on every route but `/health`: a 256-bit API key generated once on first run, printed to console (never returned by any API response — that's the only way to learn it), required as `Authorization: Bearer <key>`. Exchangeable for a short-lived JWT via `POST /api/security/jwt/refresh` (genuine `jsonwebtoken` HS256 issuance/verification).
- **Real HTTPS with a genuine PQC-hybrid key exchange** (X25519MLKEM768, via rustls's `prefer-post-quantum` feature / aws-lc-rs — the same mechanism Chrome/Cloudflare/AWS use, not a bespoke protocol). Opt-in via a new `enable_tls` setting, forced on for non-loopback binds. Self-signed cert generated once via `rcgen`.
- **`/api/security/pqc/state`/`pqc/enable` now report real state** instead of hardcoded values — `state` reflects the *currently running* listener, not just the persisted setting (which only applies on restart); `enable` says so honestly.
- **Go control-plane gateway verifies the same shared secret** before proxying (real JWT signature verification via `golang-jwt/jwt/v5`, not a shape-only check — so it doesn't reject legitimate GUI-issued tokens). Degrades gracefully if the key file isn't readable.
- **GUI sends the token on every request** via an axios interceptor (plus the two raw `fetch` calls that bypassed it), with a new "API Key" field on the Security tab. Also fixed the PQC panel's copy, which previously claimed "Kyber-768/Dilithium key exchange... across all distributed nodes" and "AES-GCM 256-bit encryption" when disabled — neither was ever real.
- **Bug found and fixed along the way**: the API key was only generated lazily on the first *authenticated* request, so a fresh install with zero traffic yet would never see the one-time console banner at all. Now generated eagerly at startup.

## Test plan

- [x] **Live, end-to-end manual verification** against a real running server: `401` with no token, `200` with the raw API key, a real JWT round-trip (issue → use → success), real `enabled:false` → `enable` → restart → `enabled:true` PQC state transitions.
- [x] **Independently proved the PQC claim** with `openssl s_client -tls1_3 -groups X25519MLKEM768` against the live HTTPS listener — output: `Negotiated TLS1.3 group: X25519MLKEM768`. Confirmed a normal client (no forced group) still connects fine — it's a preference, not a hard requirement.
- [x] New Rust tests: `auth.rs` (key generation/persistence, bearer/JWT verification, tampered-token rejection), `tls.rs` (loopback detection, idempotent real-file-I/O cert generation).
- [x] New Go tests: `pkg/auth` (key loading, bearer/JWT verification including genuinely expired/tampered tokens, full middleware integration via `httptest`).
- [x] New frontend tests: `SecurityTab.test.tsx` (API key persistence, honest "restart required" messaging instead of a false "already active" claim).
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all green.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green.
- [x] `tsc --noEmit`, `vitest run` (118 passed) clean.

## Notes on dependencies

New: `rustls` (`prefer-post-quantum` feature), `axum-server` (`tls-rustls`), `jsonwebtoken` (`aws_lc_rs` feature — its own separate crypto-provider requirement from rustls, a real gotcha caught by tests before it ever hit production), `rcgen` on the Rust side; `github.com/golang-jwt/jwt/v5` on the Go side. All verified to actually build in this environment, including `aws-lc-sys` compiling from source (needs a C toolchain + CMake, both already present here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)