### PR TITLE
⚡ Bolt: Optimize Cosine Similarity Calculation in MCP RAG Server

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2026-07-20 - [Cosine Similarity Query Norm Cache & Single-Pass Loop]
+**Learning:** In brute-force vector search / RAG interfaces, calculating the query embedding's norm inside a pairwise similarity function causes $O(M)$ redundant computations of the query norm (where $M$ is the number of indexed entries). Pre-calculating the query embedding's norm exactly once before the search loop reduces complexity from $O(M \cdot D)$ to $O(D)$ for query norm overhead. Additionally, fusing dot product and candidate norm square calculations into a single-pass loop reduces candidate embedding memory traversals, significantly improving memory throughput and cache locality.
+**Action:** Always pre-compute query vector norms outside of similarity search loops, and use fused single-pass loops to compute multiple vector metrics concurrently.
+
 ## 2026-07-20 - [Compare Mode O(n) rendering optimization]
 **Learning:** Performing nested array scans like `messages.find(...)` inside React list mapping (`messages.map(...)`) causes $O(n^2)$ time complexity for list rendering on the main thread. This is especially problematic in fast-paced streaming interfaces where the list is re-rendered with every incoming token. Pre-computing a `Map` of partners/related messages outside the map via `useMemo` reduces the rendering lookup cost to $O(1)$ and the overall render loop complexity to $O(n)$.
 **Action:** Always pre-compute lookup maps/objects for related messages or group keys in lists to avoid nested $O(n^2)$ iterations during React rendering loops.

--- a/crates/mcp-rag/src/main.rs
+++ b/crates/mcp-rag/src/main.rs
@@ -93,17 +93,29 @@ fn chunk_text(text: &str, max_chars: usize) -> Vec<String> {
     chunks
 }
 
-fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.len() != b.len() || a.is_empty() {
+/// Helper to calculate cosine similarity using a precomputed query embedding norm.
+/// Also uses a single-pass loop to calculate the dot product and entry's norm square simultaneously,
+/// reducing memory traversals and improving CPU cache locality.
+fn cosine_similarity_precomputed(a: &[f32], b: &[f32], norm_b: f32) -> f32 {
+    if a.len() != b.len() || a.is_empty() || norm_b == 0.0 {
         return 0.0;
     }
-    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 {
+    let mut dot = 0.0;
+    let mut norm_a_sq = 0.0;
+    for (&x, &y) in a.iter().zip(b) {
+        dot += x * y;
+        norm_a_sq += x * x;
+    }
+    let norm_a = norm_a_sq.sqrt();
+    if norm_a == 0.0 {
         return 0.0;
     }
     dot / (norm_a * norm_b)
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    cosine_similarity_precomputed(a, b, norm_b)
 }
 
 /// Ranks `entries` against `query_embedding`, highest similarity first,
@@ -114,9 +126,13 @@ fn rank<'a>(
     query_embedding: &[f32],
     top_k: usize,
 ) -> Vec<(f32, &'a IndexEntry)> {
+    let norm_b: f32 = query_embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm_b == 0.0 {
+        return Vec::new();
+    }
     let mut scored: Vec<(f32, &IndexEntry)> = entries
         .iter()
-        .map(|e| (cosine_similarity(&e.embedding, query_embedding), e))
+        .map(|e| (cosine_similarity_precomputed(&e.embedding, query_embedding, norm_b), e))
         .collect();
     scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(top_k);

--- a/crates/mcp-rag/src/main.rs
+++ b/crates/mcp-rag/src/main.rs
@@ -113,6 +113,7 @@ fn cosine_similarity_precomputed(a: &[f32], b: &[f32], norm_b: f32) -> f32 {
     dot / (norm_a * norm_b)
 }
 
+#[allow(dead_code)]
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
     cosine_similarity_precomputed(a, b, norm_b)
@@ -132,7 +133,12 @@ fn rank<'a>(
     }
     let mut scored: Vec<(f32, &IndexEntry)> = entries
         .iter()
-        .map(|e| (cosine_similarity_precomputed(&e.embedding, query_embedding, norm_b), e))
+        .map(|e| {
+            (
+                cosine_similarity_precomputed(&e.embedding, query_embedding, norm_b),
+                e,
+            )
+        })
         .collect();
     scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(top_k);


### PR DESCRIPTION
Optimizes the brute-force pairwise cosine similarity calculations in the RAG MCP server. This is achieved by precalculating the query embedding norm exactly once per search/ranking operation (rather than redundantly recalculating it M times inside the loop), and fusing the dot product and entry norm square calculation into a single-pass loop. This drastically reduces CPU cycles and enhances memory cache locality.

---
*PR created automatically by Jules for task [4550940159515728326](https://jules.google.com/task/4550940159515728326) started by @rwilliamspbg-ops*