### PR TITLE
chore(deps): ignore dtolnay/rust-toolchain updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     labels:
       - dependencies
       - ci
+    ignore:
+      # Version tag pins the actual Rust toolchain installed (not the action's
+      # own version) and must track the MSRV declared in msrv.yml, not latest.
+      - dependency-name: "dtolnay/rust-toolchain"
 
   - package-ecosystem: pip
     directory: /third_party/mohawk_gui


### PR DESCRIPTION
## Summary
- Prevents Dependabot from proposing bumps to `dtolnay/rust-toolchain` in `.github/workflows/msrv.yml`
- That action's version tag pins the actual Rust toolchain installed (not the action's own version), and this workflow exists specifically to verify compatibility with the project's declared MSRV. An automated bump would silently change what MSRV is being tested rather than update a dependency — see closed #187.

## Test plan
- [x] N/A — CI config only, no build-affecting change

🤖 Generated with [Claude Code](https://claude.com/claude-code)