### PR TITLE
fix(ci): add missing shell: bash to release-artifacts.yml

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -60,6 +60,7 @@ jobs:
           gpgconf --kill gpg-agent
 
       - name: Build release bundle
+        shell: bash
         env:
           GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.15.1] - 2026-07-28 (Release workflow fix)
+
+- **`release-artifacts.yml`'s "Build release bundle" step was missing an
+  explicit `shell: bash`.** On `ubuntu-latest`/`macos-latest` that default
+  shell already is bash, so it went unnoticed there — but `windows-latest`
+  defaults to PowerShell, which fails immediately on the step's bash `[[
+  ]]` syntax. v1.15.0's release shipped with Linux and macOS binaries only;
+  this release adds the missing Windows binary under a clean version tag
+  rather than rewriting v1.15.0's already-published release.
+
+---
+
 ## [1.15.0] - 2026-07-28 (Real distributed inference via llama.cpp RPC backend)
 
 Closes the gap between what Ghostlink's clustering claimed to do and what

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
 [![MSRV](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/msrv.yml/badge.svg)](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/msrv.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/Docs-GitHub%20Pages-0ea5e9)](https://rwilliamspbg-ops.github.io/Ghostlink/)
-[![Version](https://img.shields.io/badge/version-1.15.0-blueviolet)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.15.1-blueviolet)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust)](Cargo.toml)
 [![Platforms](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-lightgrey)](#quick-start)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

v1.15.0's release shipped with Linux and macOS binaries only — the Windows leg of `release-artifacts.yml`'s matrix build failed immediately with a PowerShell parser error, because the "Build release bundle" step had no explicit `shell: bash` and `windows-latest` defaults to PowerShell for `run:` steps without one. Every other bash-scripted step in this workflow already specified `shell: bash`; this one was missed when the workflow was extended from ubuntu-only to the 3-OS matrix.

One-line fix. `v1.15.1` (tagged after this merges) will carry it and produce a complete 3-platform release; `v1.15.0`'s already-published release (Linux/macOS assets) is left as-is rather than rewritten.

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses
- Not a Rust change — no `cargo fmt`/`clippy`/`test` impact; relying on this PR's own CI run (which itself exercises `windows-latest`, `ubuntu-latest`, `macos-latest` runners) as validation of the actual fix

## Security / Ops Impact

- [x] No secrets/credentials touched — this only adds an explicit shell selector to an existing step

## Rollback Plan

Revert this PR; the original bug only affects the `windows-latest` leg of tag-triggered releases, no impact on any other workflow or on `main` outside of `.github/workflows/release-artifacts.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)