### PR TITLE
fix: trim crate keywords to satisfy crates.io's limits

### DIFF
--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://rwilliamspbg-ops.github.io/Ghostlink/"
 repository = "https://github.com/rwilliamspbg-ops/Ghostlink"
 readme = "../../README.md"
 license = "MIT"
-keywords = ["networking", "spsc", "zero-copy", "async", "distributed-inference", "llm", "inference"]
+keywords = ["networking", "zero-copy", "async", "distributed", "llm"]
 categories = ["asynchronous", "network-programming", "command-line-utilities"]
 
 # Minimum Supported Rust Version (MSRV)

--- a/crates/ghostlink-core/Cargo.toml
+++ b/crates/ghostlink-core/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://rwilliamspbg-ops.github.io/Ghostlink/"
 repository = "https://github.com/rwilliamspbg-ops/Ghostlink"
 readme = "../../README.md"
 license = "MIT"
-keywords = ["networking", "xdp", "zero-copy", "async", "llm", "inference"]
+keywords = ["networking", "zero-copy", "async", "llm", "inference"]
 categories = ["asynchronous", "network-programming"]
 
 [features]


### PR DESCRIPTION
## Summary

Live publish attempt failed: `ghostlink-core` v1.3.0 was rejected by crates.io with `expected at most 5 keywords per crate` (had 6). While fixing it, also caught that `ghost-link` had 7 keywords, and one of them — `"distributed-inference"` (21 chars) — exceeds crates.io's 20-character-per-keyword limit, which would have failed the very next publish step even after trimming the count.

- `ghostlink-core`: dropped `"xdp"` (narrowest/most implementation-detail term of the six)
- `ghost-link`: dropped `"spsc"` and `"inference"` (redundant with `"distributed"` + `"llm"`), replaced the too-long `"distributed-inference"` with `"distributed"`

## Validation

- [x] `cargo publish -p ghostlink-core --dry-run` — packages cleanly
- [x] Independently confirmed `"asynchronous"`/`"network-programming"`/`"command-line-utilities"` are all valid crates.io category slugs (the other metadata field with server-side validation crates.io enforces), to avoid a third failed publish attempt on that front

## Rollback Plan

Pure Cargo.toml metadata change, no code/behavior impact. Revert if needed with no side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)