### PR TITLE
🎨 Palette: Cluster Worker Disconnect Confirmation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -3,3 +3,7 @@
 ## 2026-07-20 - [Clear Chat Confirmation & Tooltip]
 **Learning:** Destructive actions placed immediately adjacent to common utility actions (like Save and Load) without tooltips or confirmation dialogs lead to high rates of accidental data loss and user frustration. Sighted users need hover tooltips (`title`) to understand icon-only buttons, and all users benefit from a non-blocking confirmation dialog before clearing an active session.
 **Action:** Always add a clear confirmation dialog and descriptive tooltips to header actions that discard user-generated state.
+
+## 2026-07-21 - [Disconnect Worker Confirmation]
+**Learning:** Instantly triggering disruptive cluster actions (like disconnecting a worker node) on single click without warning leads to operator frustration and unstable network environments. Adding a standard confirmation dialog before executing the action prevents accidents and provides peace of mind.
+**Action:** Always prompt for confirmation before executing any state-destructive or cluster-disruptive operations.

--- a/ghostlink_gui_modern/src/components/WorkersTab.tsx
+++ b/ghostlink_gui_modern/src/components/WorkersTab.tsx
@@ -36,7 +36,10 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
   }, [api, setWorkers]);
 
   // CRITICAL FIX #3: Add disconnect handler
-  const handleDisconnectWorker = async (workerId: string) => {
+  const handleDisconnectWorker = async (workerId: string, workerHost: string) => {
+    if (!window.confirm(`Are you sure you want to disconnect worker ${workerHost}? This will remove it from the active cluster pool.`)) {
+      return;
+    }
     const result = await api.disconnectWorker(workerId);
     if (result.success) {
       refreshWorkers();
@@ -218,7 +221,7 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
                             </div>
                             <div className="flex items-end justify-end">
                                 <button
-                                  onClick={() => handleDisconnectWorker(worker.id)}
+                                  onClick={() => handleDisconnectWorker(worker.id, worker.host)}
                                   className="p-2 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition"
                                   title="Disconnect worker"
                                   aria-label={`Disconnect worker ${worker.host}`}


### PR DESCRIPTION
💡 What: Added a clear confirmation dialog when disconnecting a cluster worker.
🎯 Why: Prevents accidental and disruptive evictions of active compute nodes from the distributed cluster.
♿ Accessibility: Uses browser-native window.confirm, making it keyboard navigable and screen-reader accessible by default.

---
*PR created automatically by Jules for task [18271610058031911234](https://jules.google.com/task/18271610058031911234) started by @rwilliamspbg-ops*