### PR TITLE
fix: correct rate limiter misconfiguration causing sustained 429s

### DIFF
--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -7016,9 +7016,21 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         // Per-IP request rate limiting — protects the API from runaway
         // clients/retry loops. Applied as the outermost layer so it gates
         // requests before CORS/auth do any work.
+        //
+        // NOTE: tower_governor's `.per_second(n)` is NOT "n requests per
+        // second" — it's "replenish 1 token every n seconds". `.per_second(2)`
+        // was clearly meant to read as a generous 2 req/s, but actually capped
+        // sustained throughput at 0.5 req/s per client IP. The GUI's own
+        // background polling alone (metrics+sessions every 3s, workers every
+        // 15s, MCP status every 10s, plus CORS preflights, all sharing one
+        // bucket behind control-plane's single IP) comfortably exceeds that,
+        // so the burst allowance drained fast and every request after it —
+        // including /api/models — got permanently 429'd. `.per_millisecond(100)`
+        // gives the actually-intended ~10 req/s sustained rate, generous enough
+        // for normal polling while still bounding a genuine runaway retry loop.
         let governor_conf = std::sync::Arc::new(
             tower_governor::governor::GovernorConfigBuilder::default()
-                .per_second(2)
+                .per_millisecond(100)
                 .burst_size(30)
                 .finish()
                 .expect("static governor config is always valid"),


### PR DESCRIPTION
## Summary
- `tower_governor`'s `.per_second(n)` doesn't mean "n requests per second" — per its docs, it means "replenish 1 token every n seconds". `.per_second(2)` (crates/ghost-link/src/main.rs) was clearly meant to allow a generous 2 req/s, but actually capped sustained throughput at **0.5 req/s per client IP**, with a 30-request burst cushion.
- The GUI's own background polling alone (metrics+sessions every 3s, workers every 15s, MCP status every 10s, plus CORS preflights — all sharing one bucket since they arrive via control-plane's single source IP) comfortably exceeds 0.5 req/s. The burst drains within seconds of startup, and every request after it — including `/api/models` — gets permanently `429`'d.
- That's what surfaced as "a lot of 429 errors" and an empty model library: the models fetch was failing with 429, not returning empty data.
- Fix: `.per_millisecond(100)` gives the actually-intended ~10 req/s sustained rate — generous headroom for normal polling while still bounding a genuine runaway retry loop, which was the stated intent of this limiter.

## Test plan
- [x] Reproduced against a live running instance: a single fresh `curl` to `/api/models` returned `429` immediately (burst already drained by the GUI's own polling).
- [x] Rebuilt `ghost-link` with the fix, restarted it and `control-plane`.
- [x] 40 requests to `/api/models` over ~4s (well above the old 0.5 req/s cap): 0 blocked.
- [x] 15 requests through `control-plane` over ~2s: 0 blocked.
- [x] Confirmed via browser network log that the GUI's real traffic now gets clean `401` (auth-required) responses instead of `429` — request are reaching the handler, not being rate-limited.

## Note
Restarting `ghost-link` to apply this fix also reset its child `llama-server` process and the browser's short-lived auth token — that's expected server-restart behavior, unrelated to this bug (just requires reloading the page and reloading the model afterward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)