### PR TITLE
🎨 Palette: Prompt Suggestion Chips for Empty Chat Onboarding

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2026-07-21 - [Disconnect Worker Confirmation]
 **Learning:** Instantly triggering disruptive cluster actions (like disconnecting a worker node) on single click without warning leads to operator frustration and unstable network environments. Adding a standard confirmation dialog before executing the action prevents accidents and provides peace of mind.
 **Action:** Always prompt for confirmation before executing any state-destructive or cluster-disruptive operations.
+
+## 2026-07-22 - [Empty Chat Onboarding Suggestion Chips]
+**Learning:** Empty conversational states create a high cognitive load for users who may not know how to start. Providing pre-configured prompt suggestion buttons under the welcome message reduces onboarding friction. Ensuring these buttons are semantic elements (`<button>`), fully accessible with descriptive ARIA labels, and focus-linked to the main chat composer creates a smooth, intuitive keyboard and mouse experience.
+**Action:** Always include interactive, accessible suggestion cards/chips in blank conversational views to guide users and focus the text composer when selected.

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -179,6 +179,14 @@ const CompareRow: React.FC<{
   </div>
 );
 
+// Pre-configured start prompts to improve immediate UX and help-seeking onboarding.
+const SUGGESTIONS = [
+  { text: 'Check active cluster node health', label: 'Ask about active cluster node health' },
+  { text: 'Detail GGUF local model execution', label: 'Ask about GGUF local model execution' },
+  { text: 'List all available capabilities', label: 'Ask about available capabilities' },
+  { text: 'Show performance metrics overview', label: 'Ask about performance metrics overview' },
+];
+
 export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const {
     currentModel, models, setCurrentModel, mcpServers, setMcpServers,
@@ -192,6 +200,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [isRecording, setIsRecording] = useState(false);
   const recognitionRef = useRef<any>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   // What was already in the input box when recording started, and the
   // finalized (non-interim) transcript so far — combined with the current
   // interim chunk on every onresult event to rebuild the full input value
@@ -981,12 +990,27 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
       <div className="flex-1 overflow-y-auto px-4 py-8 space-y-8">
         <div className="max-w-3xl mx-auto space-y-10">
             {messages.length === 0 && (
-                <div className="flex flex-col items-center justify-center h-[50vh] text-center space-y-4">
+                <div className="flex flex-col items-center justify-center h-[50vh] text-center space-y-4 animate-in fade-in duration-500">
                     <div className="w-16 h-16 bg-slate-900 rounded-2xl flex items-center justify-center mb-2 shadow-2xl border border-slate-800">
                         <Bot size={32} className="text-blue-500" />
                     </div>
                     <h2 className="text-2xl font-bold text-white">How can I help you today?</h2>
-                    <p className="text-slate-500 max-w-sm">Ask me to execute build pipelines, audit cryptography, or validate network topologies.</p>
+                    <p className="text-slate-500 max-w-sm mb-4">Ask me to execute build pipelines, audit cryptography, or validate network topologies.</p>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 max-w-xl w-full px-4">
+                        {SUGGESTIONS.map((s) => (
+                            <button
+                                key={s.text}
+                                onClick={() => {
+                                    setInput(s.text);
+                                    textareaRef.current?.focus();
+                                }}
+                                aria-label={s.label}
+                                className="p-3.5 text-left bg-slate-900/50 hover:bg-slate-800/80 border border-slate-800 hover:border-slate-700 text-xs text-slate-300 hover:text-white rounded-xl transition duration-200 active:scale-[0.98]"
+                            >
+                                {s.text}
+                            </button>
+                        ))}
+                    </div>
                 </div>
             )}
 
@@ -1229,6 +1253,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             onKeyDown={(e) => { if (e.key === 'Escape') setShowTools(false); }}
           >
             <textarea
+              ref={textareaRef}
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={(e) => {


### PR DESCRIPTION
This change introduces interactive, keyboard-accessible prompt suggestion chips to the empty chat screen in Ghostlink Studio (ChatTab.tsx). When clicked, a chip populates the input composer and focuses the textarea. Palette's UX journal was also updated with key learnings from this onboarding UX enhancement. All tests, TypeScript validation, and production packaging builds pass successfully.

---
*PR created automatically by Jules for task [15736657234780746997](https://jules.google.com/task/15736657234780746997) started by @rwilliamspbg-ops*