### PR TITLE
feat(gui): Editor tab with copilot features (Explain/Fix/Refactor, multi-file refactor, ghost-text autocomplete, repo-aware RAG context)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,58 +1,91 @@
-# Ghostlink State — July 15, 2026 (Session 6)
+# Ghostlink State — July 30, 2026 (Session 7)
 
 ## Last Commit
-`HEAD` — "feat: comprehensive reliability improvements for GUI API calls and interactions"
+`HEAD` — "feat(gui): Editor tab with copilot features (Explain/Fix/Refactor, multi-file refactor, ghost-text autocomplete, repo-aware RAG context)"
 
-## What Was Done (Session 6 — July 15)
+## What Was Done (Session 7 — July 30)
 
-### Phase 1: API Client Hardening (`ghostlink_gui_modern/src/api.ts`)
-- **Retry logic**: Exponential backoff (3 retries, 1s base, 30s max) for 5xx, 429, 408 errors
-- **Circuit breaker**: Opens after 5 failures, 30s timeout, half-open after 2 successes
-- **Request deduplication**: Identical GET requests within 5s window share single response
-- **URL validation**: Trims whitespace, validates protocol/host — fixes trailing space bug
-- **Structured errors**: Typed `ApiError` with status, code, retryable flag
+### Phase 1: Editor Tab Core (`ghostlink_gui_modern/src/components/EditorTab.tsx`)
+- New Monaco-based Editor tab (registered as GUI tab 8) backed by three new
+  backend routes in `crates/ghost-link/src/main.rs`:
+  `GET /api/workspace/tree`, `GET`/`PUT /api/workspace/file` — confined to a
+  canonicalized `GHOSTLINK_WORKSPACE_ROOT` with a path-traversal guard
+  (verified against real `../` escape attempts on read, tree, and write).
+- Monaco self-hosted locally (no CDN) via `vite-plugin-monaco-editor-esm` +
+  `monacoSetup.ts` — consistent with the rest of the app's local-first
+  stance.
+- Fixed a real Monaco+flex layout bug found during verification: Monaco's
+  own `automaticLayout` locked onto a bogus 5×5px size in this nested-flex
+  pane and never self-corrected; fixed with an explicit `.layout()` call on
+  mount plus a `ResizeObserver` on a container we control.
 
-### Phase 2: Launch Script Hardening
-- **`launch-complete.bat`**: Pre-flight validation (URL format, required commands), trims `VITE_GHOSTLINK_API_BASE`, waits for `/api/health` endpoint
-- **`launch-complete.sh`**: Same validation + mirror download support (hf-mirror.com), resume capability (Range headers), SHA256 verification
-- **`launch.sh`**: Added `/api/health` readiness check
+### Phase 2: Copilot Features
+- **Explain / Fix / Refactor** — scoped to selection or whole file;
+  Fix/Refactor propose changes via a side-by-side `DiffEditor` with explicit
+  Accept/Reject (nothing writes until accepted).
+- **Multi-file refactor** — tree checkboxes select files, one batched
+  prompt (`### FILE: <path>` sections), sequential per-file diff review
+  queue (Accept/Reject/Skip).
+- **Ghost-text autocomplete** (opt-in toggle) — Monaco's native
+  inline-completions provider, debounced against the existing chat
+  endpoint. MVP: no FIM model support, no suffix awareness.
+- **Repo-aware chat context**: `POST /api/workspace/index` feeds the
+  workspace into the `rag` MCP server's `index_document` tool directly
+  (not via an LLM tool-calling loop). Triggered once per page load from the
+  Editor tab; `"skipped"` (not an error) when `rag`/Ollama isn't reachable.
 
-### Phase 3: Frontend Error Boundaries & Retry UI
-- **`ErrorBoundary`**: Catches React errors, shows retry button + error details
-- **`OfflineBanner`**: Auto-shows on network disconnect, auto-hides on reconnect
-- **`useApiRetry` hook**: Generic retry wrapper with configurable backoff
-- **`useOnlineStatus`**: Browser online/offline event listener
-- **`useApi`**: Retry-wrapped versions of all API methods
+### Phase 3: RAG / MCP Fixes
+- **`rag` MCP server enabled by default** (`mcp_servers.example.toml`) —
+  needs `ollama pull nomic-embed-text` to do anything.
+- **Fixed unbounded duplicate growth in `mcp-rag`**: `index_document` only
+  ever appended chunks, never removed a document's prior ones — every
+  re-index (which happens every page load) grew `rag_index.json` forever.
+  Now replaces by doc-id prefix before inserting. Verified live: indexed a
+  directory (10 chunks), re-indexed, still exactly 10.
+- **Hardened the "is rag usable" check**: `rag`'s own MCP handshake never
+  touches Ollama, so it reports "connected" even with Ollama down. Added a
+  direct `OllamaClient::health()` probe before the indexing loop so a
+  native-only machine with no Ollama still gets the clean `"skipped"`
+  response instead of a wall of per-file failures.
 
-### Phase 4: Backend Resilience (`crates/ghost-link/src/main.rs`)
-- **`/api/health` endpoint**: Returns `gpu_available`, `inference_backend`, `native_engine`
-- **`/health` endpoint**: Enhanced with GPU availability detection (NVIDIA/AMD/Apple)
-- **Model downloads**: Mirror fallback (hf-mirror.com), HTTP Range resume, checksum verification
-- **Metrics**: Added `gpu_available` field for graceful degradation
+### Phase 4: Real Security Audit Log
+- `/api/security/audit-log` was a hardcoded stub (always empty). Now
+  records failed auth, JWT refresh, PQC enable, and tool-call approve/deny
+  in-memory (capped at 500, most-recent-first). Required adding
+  `ConnectInfo<SocketAddr>` + `State` extraction to `auth_middleware` (via
+  `middleware::from_fn_with_state`) to log the client IP on auth failures.
+  Verified live through the Security tab.
 
-### Phase 5: Integration Tests & Monitoring
-- **`tests/integration/reliability.test.ts`**: 16 tests for URL validation, retry delays, retryable errors
-- **`src/config.test.ts`**: 21 tests for Zod config schema validation
-- **All existing tests pass**: 94 frontend + 28 backend = 122 total
-
-### Phase 6: Config Validation & Health Checks
-- **`src/config.ts`**: Zod schema for all 25 settings with validation rules
-- **`validateEnvVars()`**: Runtime check for `VITE_GHOSTLINK_API_BASE` format
+### Phase 5: Tests & Docs
+- `EditorTab.test.tsx` — 10 tests (tree load/expand, open/save,
+  Explain/Fix/Refactor, diff accept/reject, multi-file refactor,
+  autocomplete toggle, error handling).
+- `mcp-rag`: 2 new unit tests for the dedup-by-doc-id logic.
+- `ghost-link`: 2 new unit tests for the audit-log cap/ordering logic.
+- `README.md`, `CHANGELOG.md` (`[1.16.0]`), `docs/API_REFERENCE.md`,
+  `docs/openapi.yaml` updated for the new endpoints and the no-longer-a-stub
+  audit log.
 
 ## Build Verification
-- `npx vitest run` — **94/94 passed**
-- `npx tsc --noEmit` — **OK**
 - `cargo fmt --all --check` — **OK**
 - `cargo clippy --workspace --all-targets -- -D warnings` — **OK**
-- `cargo test --workspace` — **122/122 passed**
+- `cargo test --workspace` — **all passed** (150 in `ghost-link`, 12 in
+  `mcp-rag`, plus `ghostlink-core` integration suites — 0 failed)
+- `npx tsc --noEmit` (ghostlink_gui_modern) — **OK**
+- `npx vitest run` — **128/128 passed**
+- Manual: verified the Editor tab, audit log, and workspace-index endpoint
+  live against the built release binary through the actual GUI (not just
+  curl).
 
-## Known Issues
-1. `Qwen3.5-4B-BF16.gguf` is corrupt — renamed to `.bak`
-2. ~~`/api/metrics` hangs~~ — fixed: background host sampler + real tok/s/p50/p95 from chat
-3. Worker networking is local-only — discovery only detects same LAN
-4. No auth enforcement — discovery token configured but not enforced
-5. Linux OOM with large models — default models now tiny (15M/1.1B); avoid loading 7B+ without sufficient RAM
-6. Download from HuggingFace may fail — if `GHOSTLINK_INSECURE_TLS=1` helps, TLS cert bundle may need updating
+## Known Issues / Follow-ups
+1. Ghost-text autocomplete and multi-file refactor are explicitly MVP-scoped
+   (see CHANGELOG) — not exercised against a live completion-capable model
+   this session (no model was loaded in the test environment).
+2. Audit log is in-memory only — resets on restart. A persistent
+   append-only trail is a bigger follow-up, not done here.
+3. Everything from Session 6's "Known Issues" list still applies (worker
+   networking is local-only, no discovery-token enforcement, etc.) — not
+   touched this session.
 
 ## To Restart
 ```powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.16.0] - 2026-07-30 (Editor tab: in-GUI code editor + copilot features)
+
+Ghostlink Studio was chat-only — code blocks rendered as read-only Markdown,
+with no way to browse, open, or edit a real project file from the GUI, and no
+diff-preview step before an AI-proposed change touched disk. This release
+adds a Monaco-based Editor tab wired directly into the existing chat/MCP
+infrastructure to close that gap.
+
+### ✨ Features
+
+- **Editor tab** (`ghostlink_gui_modern/src/components/EditorTab.tsx`): a
+  Monaco editor over three new backend routes —
+  `GET /api/workspace/tree`, `GET`/`PUT /api/workspace/file` — confined to a
+  canonicalized workspace root (`GHOSTLINK_WORKSPACE_ROOT`, defaults to the
+  launch directory) with a path-traversal guard verified against real `../`
+  escape attempts on read, tree, and write. Distinct from the sandboxed
+  `file_operations` MCP tool: this is the GUI talking to real project files
+  directly, not a model-invoked tool call.
+- **Explain / Fix / Refactor** — scoped to the current selection or the
+  whole file. Fix/Refactor render their proposed change as a side-by-side
+  `DiffEditor` with explicit Accept/Reject; nothing is written until
+  accepted.
+- **Multi-file refactor** — select several files via tree checkboxes, send
+  them in one prompt (`### FILE: <path>` sections), then step through each
+  proposed change individually (Accept/Reject/Skip).
+- **Ghost-text autocomplete** (opt-in toggle) — Monaco's native
+  inline-completions provider, debounced against the same chat-completion
+  endpoint. Explicitly an MVP: no fill-in-the-middle model support, no
+  suffix awareness — continuation-only, and a real network round trip per
+  suggestion rather than a fast local model.
+- **Repo-aware chat context**: `POST /api/workspace/index` walks the
+  workspace (skipping `node_modules`/`target`/`.git`/etc., capped at 400
+  files / 4MB) and feeds eligible text files into the `rag` MCP server's
+  `index_document` tool directly — not through an LLM tool-calling loop,
+  which would be slow and unreliable for bulk indexing. The Editor tab
+  triggers this once per page load; a `"skipped"` (not error) status is the
+  expected outcome when `rag`/Ollama isn't reachable, verified by probing
+  Ollama's `/api/tags` before the indexing loop rather than trusting MCP
+  connection state (`rag`'s own handshake never touches Ollama, so it
+  reports "connected" even with Ollama down).
+- **`rag` MCP server enabled by default** (`mcp_servers.example.toml`) — was
+  disabled out of the box; needs `ollama pull nomic-embed-text` (or another
+  embedding model via `OLLAMA_EMBED_MODEL`) to actually do anything, and
+  degrades to the `"skipped"` status above otherwise.
+- **Real security audit log** (`/api/security/audit-log`): was a hardcoded
+  stub that always returned an empty list. Now records failed auth attempts,
+  JWT refresh, PQC/TLS enable, and tool-call approve/deny decisions
+  in-memory, capped at 500 entries, most-recent-first — verified live
+  through the Security tab (triggered a JWT refresh, watched the real entry
+  appear).
+
+### 🐛 Fixed
+
+- **`mcp-rag`'s `index_document` only ever appended chunks, never removed a
+  document's prior ones.** Re-indexing the same file (which the Editor tab's
+  auto-index does on every page load) silently grew `rag_index.json` with
+  duplicate chunks forever, and `search()` would return multiple stale
+  copies of the same source. `index_document` now replaces a document's
+  existing chunks by id prefix before inserting the new ones. Verified live:
+  indexed a directory (10 chunks), re-indexed the same files, still exactly
+  10.
+
+### 📚 Documentation
+
+- `README.md`: new "Editor Tab & Copilot Features" section, updated API
+  endpoint table (`/api/workspace/*`, corrected `/api/security/audit-log`
+  description), updated MCP tools table (`rag` now enabled by default).
+
+---
+
 ## [1.15.1] - 2026-07-28 (Release workflow fix)
 
 - **`release-artifacts.yml`'s "Build release bundle" step was missing an

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
 [![MSRV](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/msrv.yml/badge.svg)](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/msrv.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/Docs-GitHub%20Pages-0ea5e9)](https://rwilliamspbg-ops.github.io/Ghostlink/)
-[![Version](https://img.shields.io/badge/version-1.15.1-blueviolet)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.16.0-blueviolet)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust)](Cargo.toml)
 [![Platforms](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-lightgrey)](#quick-start)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -42,6 +42,7 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
 - [Launch Scripts](#launch-scripts)
 - [Usage (Developer)](#usage-developer)
 - [MCP Tools](#mcp-tools-model-context-protocol)
+- [Editor Tab & Copilot Features](#editor-tab--copilot-features)
 - [Troubleshooting](#troubleshooting)
 - [Environment Variables](#environment-variables)
 - [Architecture](#architecture)
@@ -61,6 +62,9 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
 - TCP and Unix domain socket transport for multi-process pipelines
 - Session-level authentication on transport frames
 - Dynamic system profile watching with auto-tuning cache
+- In-GUI code editor (Monaco) with copilot-style actions — Explain/Fix/Refactor
+  with diff preview before anything is written, multi-file refactor, opt-in
+  ghost-text autocomplete, and repo-aware chat via local RAG indexing
 - A strong open-source foundation with a commercial support path
 
 ## Why Ghostlink
@@ -294,7 +298,10 @@ for a machine-readable spec.
 | `/api/security/jwt/refresh` | POST | Exchange the API key for a short-lived JWT |
 | `/api/security/pqc/state` | GET | Whether this running server is serving HTTPS/PQC-hybrid TLS |
 | `/api/security/pqc/enable` | POST | Persist `enable_tls: true` (takes effect on next restart) |
-| `/api/security/audit-log` | GET | Security audit log entries (not yet populated — always empty today) |
+| `/api/security/audit-log` | GET | Security audit log entries (failed auth, JWT refresh, PQC enable, tool-call approve/deny — last 500, most recent first) |
+| `/api/workspace/tree` | GET | List a directory under the Editor tab's workspace root (`?path=`) |
+| `/api/workspace/file` | GET / PUT | Read or write a workspace file (`?path=` / `{path, content}`) — both reject any path that escapes the workspace root |
+| `/api/workspace/index` | POST | Index the workspace into the `rag` MCP server for repo-aware chat context; `"skipped"` if `rag`/Ollama isn't reachable |
 | `/metrics` | GET | Prometheus-exposition-format metrics (same data as `/api/metrics`) |
 
 ### Python client
@@ -329,7 +336,7 @@ Default servers:
 | `image_generation` | *(not yet configured — no default backend picked)* | ❌ |
 | — | `sequential-thinking` (npx) | ✅ |
 | — | `vision` (this repo, wraps local Ollama) | needs a pulled vision model |
-| — | `rag` (this repo — `index_document`/`search`, local Ollama embeddings + brute-force cosine index, no external vector DB) | needs a pulled embedding model (e.g. `nomic-embed-text`) |
+| — | `rag` (this repo — `index_document`/`search`, local Ollama embeddings + brute-force cosine index, no external vector DB) | ✅ (needs a pulled embedding model, e.g. `nomic-embed-text` — the Editor tab's auto-index degrades to a no-op `"skipped"` if Ollama isn't reachable) |
 
 The model decides whether and which tool to call (a ReAct-style prompt works
 with any local GGUF/Ollama model; Ollama models whose chat template declares
@@ -339,6 +346,33 @@ for explicit user approval before executing — see the MCP tab in the GUI.
 
 Requires `npx`/`node` (bundled MCP servers) and `uvx`/`python` (Python-distributed
 ones) on `PATH`; Docker Desktop for the terminal/code_execution slots.
+
+## Editor Tab & Copilot Features
+
+Ghostlink Studio's **Editor** tab is a Monaco-based code editor over the
+running server's real filesystem (`/api/workspace/*`, confined to a
+canonicalized workspace root — no path traversal outside it), separate from
+the sandboxed `file_operations` MCP tool above.
+
+- **Browse, open, and save** any file under the workspace root, with syntax
+  highlighting per extension.
+- **Explain / Fix / Refactor** — scoped to the current selection, or the
+  whole file if nothing's selected. Fix/Refactor render their proposed change
+  as a side-by-side diff (Monaco's `DiffEditor`) with explicit Accept/Reject
+  — nothing is written to disk until you accept it.
+- **Multi-file refactor** — select several files in the tree, send them in
+  one prompt, then step through each proposed change individually
+  (Accept/Reject/Skip).
+- **Ghost-text autocomplete** (opt-in, via the lightning-bolt toggle) —
+  Monaco's native inline-completion UI, driven by the same chat-completion
+  endpoint as everything else here. Not true fill-in-the-middle (no suffix
+  awareness, no model-specific FIM tokens) — a real network+inference round
+  trip on a debounce, not per-keystroke-fast.
+- **Repo-aware chat context** — on first load, the Editor tab feeds the
+  workspace into the `rag` MCP server (enabled by default; needs a pulled
+  Ollama embedding model) so chat can pull in relevant file content without
+  anyone calling `index_document` by hand. Re-indexing a file replaces its
+  prior chunks rather than duplicating them.
 
 ## Troubleshooting
 

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1601,6 +1601,59 @@ struct BackendState {
     /// setting and only takes effect on next restart; this field is what
     /// `/api/security/pqc/state` actually reports.
     enable_tls_active: bool,
+    /// Real security-relevant events (failed auth, tool-call approvals,
+    /// PQC/JWT actions) for `/api/security/audit-log` — was previously
+    /// hardcoded to always return an empty list. In-memory only (resets on
+    /// restart) and capped at `AUDIT_LOG_CAP`; a genuinely persistent trail
+    /// would need an append-only file, which is a bigger step than this
+    /// first real version takes.
+    audit_log: std::collections::VecDeque<AuditLogEntry>,
+}
+
+/// One row for the GUI's Security tab audit log — field names/shape match
+/// what `SecurityTab.tsx` already expects (it predates a real backend for
+/// this and was rendering against a permanently-empty list).
+#[derive(Debug, Clone, Serialize)]
+struct AuditLogEntry {
+    event: String,
+    /// "SUCCESS"/"AUTHENTICATED" render green in the GUI; anything else
+    /// (e.g. "FAILED", "DENIED") renders as a yellow warning badge.
+    status: String,
+    ip: String,
+    /// RFC3339 — the GUI does `new Date(e.time)` on this directly.
+    time: String,
+    detail: Option<String>,
+}
+
+const AUDIT_LOG_CAP: usize = 500;
+
+/// Appends one entry and trims from the front once over `AUDIT_LOG_CAP` —
+/// split out from `record_audit_event` so it's unit-testable against a bare
+/// `VecDeque` without needing to construct a full `BackendState`.
+fn push_audit_entry(log: &mut std::collections::VecDeque<AuditLogEntry>, entry: AuditLogEntry) {
+    log.push_back(entry);
+    while log.len() > AUDIT_LOG_CAP {
+        log.pop_front();
+    }
+}
+
+fn record_audit_event(
+    backend: &mut BackendState,
+    event: &str,
+    status: &str,
+    ip: String,
+    detail: Option<String>,
+) {
+    push_audit_entry(
+        &mut backend.audit_log,
+        AuditLogEntry {
+            event: event.to_string(),
+            status: status.to_string(),
+            ip,
+            time: chrono::Utc::now().to_rfc3339(),
+            detail,
+        },
+    );
 }
 
 /// Real byte-level progress for an in-flight (or just-finished) model download.
@@ -2446,7 +2499,7 @@ fn detect_node_id() -> String {
 
 fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     use axum::{
-        extract::{Path, Query, Request, State},
+        extract::{ConnectInfo, Path, Query, Request, State},
         http::StatusCode,
         middleware::{self, Next},
         response::{
@@ -2471,7 +2524,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     /// Guards every route except `/health` behind a real bearer token
     /// (the persisted API key itself, or a JWT issued from it — see
     /// `auth.rs`). Replaces having no auth check anywhere on this server.
-    async fn auth_middleware(req: Request, next: Next) -> axum::response::Response {
+    async fn auth_middleware(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
+        req: Request,
+        next: Next,
+    ) -> axum::response::Response {
         if req.uri().path() == "/health" {
             return next.run(req).await;
         }
@@ -2484,16 +2542,25 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
         match token {
             Some(t) if auth::verify_bearer_token(t) => next.run(req).await,
-            _ => (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({
-                    "error": {
-                        "message": "missing or invalid Authorization: Bearer <token> — see the API key printed at server startup, or POST /api/security/jwt/refresh with it to get a short-lived token",
-                        "type": "unauthorized"
-                    }
-                })),
-            )
-                .into_response(),
+            _ => {
+                record_audit_event(
+                    &mut lock_state(&state),
+                    "auth",
+                    "FAILED",
+                    addr.ip().to_string(),
+                    Some(format!("{} {}", req.method(), req.uri().path())),
+                );
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({
+                        "error": {
+                            "message": "missing or invalid Authorization: Bearer <token> — see the API key printed at server startup, or POST /api/security/jwt/refresh with it to get a short-lived token",
+                            "type": "unauthorized"
+                        }
+                    })),
+                )
+                    .into_response()
+            }
         }
     }
 
@@ -4596,6 +4663,352 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }
     }
 
+    // --- Workspace file API (Editor tab) ---
+    //
+    // Separate from the `file_operations` MCP server (which is sandboxed to
+    // `./mcp_workspace` and only reachable by the model mid tool-call): these
+    // routes let the GUI itself browse/open/save real project files directly,
+    // confined to GHOSTLINK_WORKSPACE_ROOT (defaults to the launch directory).
+
+    /// Files/dirs over this size are refused by both read and write — plenty
+    /// for source files, guards against loading a huge binary/log into the
+    /// in-browser editor.
+    const MAX_WORKSPACE_FILE_BYTES: u64 = 5 * 1024 * 1024;
+
+    fn workspace_root() -> std::path::PathBuf {
+        std::env::var("GHOSTLINK_WORKSPACE_ROOT")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+            })
+    }
+
+    /// Resolves a client-supplied relative path against the workspace root
+    /// and rejects anything that escapes it. Canonicalizing both sides and
+    /// checking the prefix is what actually catches `..` traversal and
+    /// symlink escapes — a naive string check on the raw path does not.
+    fn resolve_workspace_path(
+        root: &std::path::Path,
+        rel: &str,
+    ) -> Result<std::path::PathBuf, String> {
+        let rel = rel.trim_start_matches(['/', '\\']);
+        let canon_root = root
+            .canonicalize()
+            .map_err(|e| format!("workspace root: {e}"))?;
+        if rel.is_empty() {
+            return Ok(canon_root);
+        }
+        let candidate = canon_root.join(rel);
+        let resolved = if candidate.exists() {
+            candidate.canonicalize().map_err(|e| e.to_string())?
+        } else {
+            // A not-yet-existing file (e.g. the target of a fresh write) can't
+            // be canonicalized itself — canonicalize its parent instead and
+            // reattach the file name, which still catches `..` in `rel`.
+            let parent = candidate.parent().ok_or("invalid path")?;
+            let canon_parent = parent
+                .canonicalize()
+                .map_err(|_| "parent directory does not exist".to_string())?;
+            canon_parent.join(candidate.file_name().ok_or("invalid path")?)
+        };
+        if !resolved.starts_with(&canon_root) {
+            return Err("path escapes workspace root".to_string());
+        }
+        Ok(resolved)
+    }
+
+    #[derive(serde::Serialize)]
+    struct WorkspaceEntry {
+        name: String,
+        path: String,
+        is_dir: bool,
+        size: u64,
+    }
+
+    async fn handle_workspace_tree(
+        Query(params): Query<HashMap<String, String>>,
+    ) -> Json<serde_json::Value> {
+        let root = workspace_root();
+        let rel = params.get("path").map(|s| s.as_str()).unwrap_or("");
+        let dir = match resolve_workspace_path(&root, rel) {
+            Ok(p) => p,
+            Err(e) => return Json(serde_json::json!({ "error": e })),
+        };
+        if !dir.is_dir() {
+            return Json(serde_json::json!({ "error": "not a directory" }));
+        }
+        let canon_root = match root.canonicalize() {
+            Ok(p) => p,
+            Err(e) => return Json(serde_json::json!({ "error": format!("workspace root: {e}") })),
+        };
+        let read_dir = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            Err(e) => return Json(serde_json::json!({ "error": e.to_string() })),
+        };
+        let mut entries: Vec<WorkspaceEntry> = Vec::new();
+        for entry in read_dir.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            // Keeps the tree readable — skip VCS/build/dependency noise the
+            // user is never going to open in a code editor pane.
+            if name.starts_with('.') || matches!(name.as_str(), "node_modules" | "target" | "dist")
+            {
+                continue;
+            }
+            let metadata = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let entry_path = entry.path();
+            let rel_path = entry_path
+                .strip_prefix(&canon_root)
+                .unwrap_or(&entry_path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            entries.push(WorkspaceEntry {
+                name,
+                path: rel_path,
+                is_dir: metadata.is_dir(),
+                size: metadata.len(),
+            });
+        }
+        entries.sort_by(|a, b| {
+            b.is_dir
+                .cmp(&a.is_dir)
+                .then(a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+        });
+        Json(serde_json::json!({ "path": rel, "entries": entries }))
+    }
+
+    async fn handle_workspace_file_read(
+        Query(params): Query<HashMap<String, String>>,
+    ) -> Json<serde_json::Value> {
+        let rel = match params.get("path") {
+            Some(p) if !p.trim().is_empty() => p.clone(),
+            _ => return Json(serde_json::json!({ "error": "path query parameter is required" })),
+        };
+        let root = workspace_root();
+        let file_path = match resolve_workspace_path(&root, &rel) {
+            Ok(p) => p,
+            Err(e) => return Json(serde_json::json!({ "error": e })),
+        };
+        let metadata = match std::fs::metadata(&file_path) {
+            Ok(m) => m,
+            Err(e) => return Json(serde_json::json!({ "error": e.to_string() })),
+        };
+        if metadata.is_dir() {
+            return Json(serde_json::json!({ "error": "path is a directory" }));
+        }
+        if metadata.len() > MAX_WORKSPACE_FILE_BYTES {
+            return Json(serde_json::json!({
+                "error": format!("file exceeds {}MB limit", MAX_WORKSPACE_FILE_BYTES / (1024 * 1024))
+            }));
+        }
+        let bytes = match std::fs::read(&file_path) {
+            Ok(b) => b,
+            Err(e) => return Json(serde_json::json!({ "error": e.to_string() })),
+        };
+        match String::from_utf8(bytes) {
+            Ok(content) => Json(serde_json::json!({ "path": rel, "content": content })),
+            Err(_) => {
+                Json(serde_json::json!({ "error": "file is not valid UTF-8 text (binary?)" }))
+            }
+        }
+    }
+
+    #[derive(serde::Deserialize)]
+    struct WorkspaceFileWriteRequest {
+        path: String,
+        content: String,
+    }
+
+    async fn handle_workspace_file_write(
+        Json(req): Json<WorkspaceFileWriteRequest>,
+    ) -> Json<serde_json::Value> {
+        if req.path.trim().is_empty() {
+            return Json(serde_json::json!({ "error": "path is required" }));
+        }
+        if req.content.len() as u64 > MAX_WORKSPACE_FILE_BYTES {
+            return Json(serde_json::json!({
+                "error": format!("content exceeds {}MB limit", MAX_WORKSPACE_FILE_BYTES / (1024 * 1024))
+            }));
+        }
+        let root = workspace_root();
+        let file_path = match resolve_workspace_path(&root, &req.path) {
+            Ok(p) => p,
+            Err(e) => return Json(serde_json::json!({ "error": e })),
+        };
+        if file_path.is_dir() {
+            return Json(serde_json::json!({ "error": "path is a directory" }));
+        }
+        match std::fs::write(&file_path, req.content.as_bytes()) {
+            Ok(_) => Json(serde_json::json!({ "status": "ok", "path": req.path })),
+            Err(e) => Json(serde_json::json!({ "error": e.to_string() })),
+        }
+    }
+
+    // --- Repo-aware chat context (RAG auto-index) ---
+    //
+    // Walks the workspace root and feeds each eligible text file into the
+    // `rag` MCP server's index_document tool directly (not via a chat
+    // completion — asking a model to call index_document once per file over
+    // a ReAct loop would be slow and unreliable), so chat gets repo context
+    // without the user calling index_document by hand. A soft "skipped"
+    // status, not an error, when `rag` isn't connected — most installs won't
+    // have it configured (disabled by default, needs a pulled embedding model).
+
+    /// Bounds a single indexing pass so it can't turn into a multi-minute
+    /// crawl (or feed gigabytes into the embedding model) on a large repo —
+    /// generous enough for typical project sizes once noise dirs are excluded.
+    const INDEX_MAX_FILES: usize = 400;
+    /// Tighter than MAX_WORKSPACE_FILE_BYTES (the editor's read/write cap) —
+    /// indexing many large files is slow and not useful for MVP repo context.
+    const INDEX_MAX_FILE_BYTES: u64 = 200 * 1024;
+    const INDEX_MAX_TOTAL_BYTES: u64 = 4 * 1024 * 1024;
+
+    fn is_index_noise_dir(name: &str) -> bool {
+        name.starts_with('.')
+            || matches!(
+                name,
+                "node_modules"
+                    | "target"
+                    | "dist"
+                    | "build"
+                    | "third_party"
+                    | "logs"
+                    | "artifacts"
+                    | "benchmarks"
+                    | "models"
+                    | "mcp_workspace"
+                    | "tmp"
+                    | "_archived"
+            )
+    }
+
+    fn collect_index_candidates(
+        dir: &std::path::Path,
+        out: &mut Vec<std::path::PathBuf>,
+        total_bytes: &mut u64,
+    ) {
+        if out.len() >= INDEX_MAX_FILES || *total_bytes >= INDEX_MAX_TOTAL_BYTES {
+            return;
+        }
+        let Ok(read_dir) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in read_dir.flatten() {
+            if out.len() >= INDEX_MAX_FILES || *total_bytes >= INDEX_MAX_TOTAL_BYTES {
+                return;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.is_dir() {
+                if is_index_noise_dir(&name) {
+                    continue;
+                }
+                collect_index_candidates(&entry.path(), out, total_bytes);
+            } else {
+                if name.starts_with('.') {
+                    continue;
+                }
+                if metadata.len() == 0 || metadata.len() > INDEX_MAX_FILE_BYTES {
+                    continue;
+                }
+                *total_bytes += metadata.len();
+                out.push(entry.path());
+            }
+        }
+    }
+
+    async fn handle_workspace_index(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let mcp_registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+
+        let servers = match mcp_registry.list_all_servers().await {
+            Ok(s) => s,
+            Err(err) => return Json(serde_json::json!({ "status": "error", "error": err })),
+        };
+        let rag_connected = servers.iter().any(|s| s.name == "rag" && s.connected);
+        if !rag_connected {
+            return Json(serde_json::json!({
+                "status": "skipped",
+                "reason": "rag MCP server is not connected (disabled) — see mcp_servers.toml"
+            }));
+        }
+
+        // `rag`'s own MCP handshake never actually touches Ollama (its tools
+        // are registered eagerly, connectivity is only checked lazily on the
+        // first embed call) — so `rag_connected` above is true even on a
+        // native-llama.cpp-only machine with no Ollama running at all. Probe
+        // Ollama directly here so that case still gets the same graceful
+        // "skipped" response instead of a wall of per-file failures.
+        let ollama_url = mcp_registry
+            .env_var_for("rag", "OLLAMA_URL")
+            .filter(|u| !u.is_empty())
+            .unwrap_or_else(|| "http://127.0.0.1:11434".to_string());
+        let ollama_reachable = ollama::OllamaClient::new(ollama_url.clone())
+            .health()
+            .await
+            .unwrap_or(false);
+        if !ollama_reachable {
+            return Json(serde_json::json!({
+                "status": "skipped",
+                "reason": format!("Ollama isn't reachable at {ollama_url} — is `ollama serve` running?")
+            }));
+        }
+
+        let root = match workspace_root().canonicalize() {
+            Ok(p) => p,
+            Err(e) => {
+                return Json(
+                    serde_json::json!({ "status": "error", "error": format!("workspace root: {e}") }),
+                )
+            }
+        };
+
+        let mut candidates = Vec::new();
+        let mut total_bytes = 0u64;
+        collect_index_candidates(&root, &mut candidates, &mut total_bytes);
+        let capped = candidates.len() >= INDEX_MAX_FILES || total_bytes >= INDEX_MAX_TOTAL_BYTES;
+
+        let mut indexed = 0usize;
+        let mut failed = 0usize;
+        for path in &candidates {
+            let Ok(bytes) = std::fs::read(path) else {
+                failed += 1;
+                continue;
+            };
+            // Binary files fail UTF-8 decoding — silently skip them rather
+            // than counting as a failure, same as the file-read route.
+            let Ok(text) = String::from_utf8(bytes) else {
+                continue;
+            };
+            let rel = path
+                .strip_prefix(&root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let args = serde_json::json!({ "text": text, "id": rel, "source": rel });
+            match mcp_registry.call_tool("rag", "index_document", args).await {
+                Some(outcome) if outcome.success => indexed += 1,
+                _ => failed += 1,
+            }
+        }
+
+        Json(serde_json::json!({
+            "status": "ok",
+            "scanned": candidates.len(),
+            "indexed": indexed,
+            "failed": failed,
+            "capped": capped,
+        }))
+    }
+
     async fn handle_gui_queue() -> Json<serde_json::Value> {
         let request_tracker = active_runtime_switcher().request_tracker().clone();
         Json(serde_json::json!({
@@ -4610,10 +5023,31 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     /// token (`auth_middleware` gates every route but `/health`) — no
     /// separate credential to check here, just mint a fresh short-lived
     /// token signed with the same API key that got them past the gate.
-    async fn handle_gui_jwt_refresh() -> Json<serde_json::Value> {
+    async fn handle_gui_jwt_refresh(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    ) -> Json<serde_json::Value> {
         match auth::issue_jwt("ghostlink-client") {
-            Ok(token) => Json(serde_json::json!({ "status": "ok", "token": token })),
-            Err(err) => Json(serde_json::json!({ "status": "error", "error": err })),
+            Ok(token) => {
+                record_audit_event(
+                    &mut lock_state(&state),
+                    "jwt_refresh",
+                    "SUCCESS",
+                    addr.ip().to_string(),
+                    None,
+                );
+                Json(serde_json::json!({ "status": "ok", "token": token }))
+            }
+            Err(err) => {
+                record_audit_event(
+                    &mut lock_state(&state),
+                    "jwt_refresh",
+                    "FAILED",
+                    addr.ip().to_string(),
+                    Some(err.clone()),
+                );
+                Json(serde_json::json!({ "status": "error", "error": err }))
+            }
         }
     }
 
@@ -4623,12 +5057,20 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     /// response rather than implying it's already live.
     async fn handle_gui_pqc_enable(
         State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
     ) -> Json<serde_json::Value> {
         let backend = &mut *lock_state(&state);
         let mut current = backend.settings.clone();
         current.enable_tls = true;
         backend.settings = current.clone();
         save_settings(&current);
+        record_audit_event(
+            backend,
+            "pqc_enable",
+            "SUCCESS",
+            addr.ip().to_string(),
+            Some("enable_tls persisted; takes effect on restart".to_string()),
+        );
         Json(serde_json::json!({
             "status": "ok",
             "enabled": true,
@@ -4662,8 +5104,13 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }))
     }
 
-    async fn handle_gui_audit_log() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "entries": [] }))
+    async fn handle_gui_audit_log(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let backend = lock_state(&state);
+        // Most-recent-first — a log feed reads top-to-bottom as newest-first.
+        let entries: Vec<&AuditLogEntry> = backend.audit_log.iter().rev().collect();
+        Json(serde_json::json!({ "entries": entries }))
     }
 
     async fn handle_gui_runtime_select(
@@ -6123,6 +6570,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     /// generating from exactly where the original request left off.
     async fn handle_gui_chat_tool_confirm(
         State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
         Json(req): Json<ToolConfirmRequest>,
     ) -> axum::response::Response {
         let (pending_map, mcp_registry, ollama_available) = {
@@ -6153,6 +6601,14 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             server,
             args,
         } = pending;
+
+        record_audit_event(
+            &mut lock_state(&state),
+            "tool_confirm",
+            if req.approve { "APPROVED" } else { "DENIED" },
+            addr.ip().to_string(),
+            Some(format!("{tool} @ {server}")),
+        );
 
         if req.approve {
             let (tool_result, observation_json) =
@@ -6998,6 +7454,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
         plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
         enable_tls_active: use_tls,
+        audit_log: std::collections::VecDeque::new(),
     }));
 
     // Background CPU/RAM/GPU sampler — keeps /api/metrics non-blocking.
@@ -7045,6 +7502,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 }
             });
         }
+
+        // Cloned before `.with_state(state)` below consumes `state` — the
+        // auth middleware needs its own `State` extraction (to record
+        // failed-auth attempts to the audit log) via `from_fn_with_state`.
+        let auth_mw_state = Arc::clone(&state);
 
         let app = Router::new()
             .route("/v1/chat/completions", post(handle_chat_completions))
@@ -7152,12 +7614,21 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 "/api/mcp/servers/:name/toggle",
                 post(handle_toggle_mcp_server),
             )
+            .route("/api/workspace/tree", get(handle_workspace_tree))
+            .route(
+                "/api/workspace/file",
+                get(handle_workspace_file_read).put(handle_workspace_file_write),
+            )
+            .route("/api/workspace/index", post(handle_workspace_index))
             .with_state(state)
             // Auth runs inside CORS (added first here = innermost = runs
             // *after* CORS on the way in), so a browser's CORS preflight
             // OPTIONS request is still handled without needing a bearer
             // token — matches how CORS preflight is expected to work.
-            .layer(middleware::from_fn(auth_middleware))
+            .layer(middleware::from_fn_with_state(
+                auth_mw_state,
+                auth_middleware,
+            ))
             .layer(CorsLayer::permissive())
             .layer(tower_governor::GovernorLayer {
                 config: governor_conf,
@@ -9261,6 +9732,41 @@ mod tests {
         std::env::set_var("GHOSTLINK_NODE_ID", "test-node-explicit");
         assert_eq!(detect_node_id(), "test-node-explicit");
         std::env::remove_var("GHOSTLINK_NODE_ID");
+    }
+
+    fn audit_entry(event: &str) -> AuditLogEntry {
+        AuditLogEntry {
+            event: event.to_string(),
+            status: "SUCCESS".to_string(),
+            ip: "127.0.0.1".to_string(),
+            time: chrono::Utc::now().to_rfc3339(),
+            detail: None,
+        }
+    }
+
+    #[test]
+    fn push_audit_entry_appends_in_order() {
+        let mut log = std::collections::VecDeque::new();
+        push_audit_entry(&mut log, audit_entry("first"));
+        push_audit_entry(&mut log, audit_entry("second"));
+        assert_eq!(log.len(), 2);
+        assert_eq!(log[0].event, "first");
+        assert_eq!(log[1].event, "second");
+    }
+
+    #[test]
+    fn push_audit_entry_trims_oldest_once_over_cap() {
+        let mut log = std::collections::VecDeque::new();
+        for i in 0..(AUDIT_LOG_CAP + 10) {
+            push_audit_entry(&mut log, audit_entry(&format!("event-{i}")));
+        }
+        assert_eq!(log.len(), AUDIT_LOG_CAP, "must never grow past the cap");
+        // The oldest 10 were pushed out; the front is now event-10.
+        assert_eq!(log.front().unwrap().event, "event-10");
+        assert_eq!(
+            log.back().unwrap().event,
+            format!("event-{}", AUDIT_LOG_CAP + 9)
+        );
     }
 
     #[test]

--- a/crates/ghost-link/src/mcp/registry.rs
+++ b/crates/ghost-link/src/mcp/registry.rs
@@ -144,6 +144,23 @@ impl McpRegistry {
         Ok(())
     }
 
+    /// Reads a configured env var for one server from `mcp_servers.toml`
+    /// (e.g. `rag`'s `OLLAMA_URL`), resolving `${VAR}` indirection the same
+    /// way `connect_enabled` does. Needed because those env vars are only
+    /// ever applied to the *spawned child process* — this (main) process
+    /// never inherits them, so out-of-band checks (e.g. "is rag's Ollama
+    /// actually reachable") can't just read `std::env::var` directly.
+    pub fn env_var_for(&self, server_name: &str, key: &str) -> Option<String> {
+        let configs = self.config_manager.load().ok()?;
+        let config = configs.into_iter().find(|c| c.name == server_name)?;
+        match config.transport {
+            super::config::McpTransport::Stdio { env, .. } => {
+                env.get(key).map(|v| super::config::resolve_env_value(v))
+            }
+            super::config::McpTransport::Http { .. } => None,
+        }
+    }
+
     pub async fn call_tool(
         &self,
         server_name: &str,

--- a/crates/mcp-rag/src/main.rs
+++ b/crates/mcp-rag/src/main.rs
@@ -69,6 +69,22 @@ impl RagIndex {
     }
 }
 
+/// Removes any existing entries for `doc_id` (chunk ids are `"{doc_id}#N"`)
+/// and appends `new_entries` in their place. Re-indexing the same document
+/// (e.g. a file re-saved, or a workspace re-index revisiting an unchanged
+/// path) must *replace* its prior chunks, not pile up duplicates alongside
+/// them — otherwise every re-index grows the index and search() starts
+/// returning multiple stale copies of the same source.
+fn replace_document_entries(
+    entries: &mut Vec<IndexEntry>,
+    doc_id: &str,
+    new_entries: Vec<IndexEntry>,
+) {
+    let prefix = format!("{doc_id}#");
+    entries.retain(|e| !e.id.starts_with(&prefix));
+    entries.extend(new_entries);
+}
+
 /// Splits `text` into paragraph-sized chunks (blank-line separated), further
 /// breaking any paragraph longer than `max_chars` at word boundaries so a
 /// single giant paragraph doesn't become one unwieldy embedding. Empty/
@@ -256,25 +272,29 @@ impl Rag {
                 .unwrap_or_else(|_| "doc".to_string())
         });
 
-        let mut indexed = 0usize;
+        // Embed every chunk into a scratch Vec first — only replace the
+        // document's prior entries once all of them succeed, so a
+        // mid-document embed failure (Ollama dropping mid-loop) leaves the
+        // previous good index untouched instead of half-deleted.
+        let mut new_entries = Vec::with_capacity(chunks.len());
         for (i, chunk) in chunks.iter().enumerate() {
             let embedding = match self.embed(chunk).await {
                 Ok(e) => e,
                 Err(err) => return err,
             };
             let norm = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
-            let mut index = self.index.lock().await;
-            index.entries.push(IndexEntry {
+            new_entries.push(IndexEntry {
                 id: format!("{doc_id}#{i}"),
                 source: source.clone(),
                 text: chunk.clone(),
                 embedding,
                 norm,
             });
-            indexed += 1;
         }
 
-        let index = self.index.lock().await;
+        let indexed = new_entries.len();
+        let mut index = self.index.lock().await;
+        replace_document_entries(&mut index.entries, &doc_id, new_entries);
         if let Err(err) = index.save(&self.index_path) {
             return format!(
                 "indexed {indexed} chunk(s) from '{doc_id}' but failed to persist index: {err}"
@@ -420,6 +440,48 @@ mod tests {
         assert_eq!(ranked[0].1.id, "exact");
         assert_eq!(ranked[1].1.id, "close");
         assert!(ranked[0].0 >= ranked[1].0);
+    }
+
+    #[test]
+    fn replace_document_entries_replaces_only_the_matching_doc_id() {
+        let mut entries = vec![
+            entry("readme.md#0", vec![0.1, 0.2]),
+            entry("readme.md#1", vec![0.3, 0.4]),
+            entry("other.md#0", vec![0.5, 0.6]),
+        ];
+        let fresh = vec![entry("readme.md#0", vec![0.9, 0.9])];
+        replace_document_entries(&mut entries, "readme.md", fresh);
+
+        assert_eq!(
+            entries.len(),
+            2,
+            "old readme.md chunks dropped, other.md untouched"
+        );
+        assert!(entries.iter().any(|e| e.id == "other.md#0"));
+        let readme_entries: Vec<_> = entries
+            .iter()
+            .filter(|e| e.id.starts_with("readme.md#"))
+            .collect();
+        assert_eq!(
+            readme_entries.len(),
+            1,
+            "re-indexing must not leave stale duplicate chunks"
+        );
+        assert_eq!(readme_entries[0].embedding, vec![0.9, 0.9]);
+    }
+
+    #[test]
+    fn replace_document_entries_does_not_match_on_prefix_alone() {
+        // "readme.md-old" must not be treated as a chunk of "readme.md" just
+        // because it shares a string prefix — only the literal "#"-delimited
+        // doc_id boundary counts.
+        let mut entries = vec![entry("readme.md-old#0", vec![0.1, 0.2])];
+        replace_document_entries(
+            &mut entries,
+            "readme.md",
+            vec![entry("readme.md#0", vec![0.5, 0.5])],
+        );
+        assert_eq!(entries.len(), 2);
     }
 
     #[test]

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -68,13 +68,73 @@ curl http://127.0.0.1:8080/api/security/pqc/state \
 
 ### Audit log
 
-`GET /api/security/audit-log` exists but always returns an empty list today
-— it is not yet wired up to record events. Documented here as-is rather than
-implied to be functional.
+`GET /api/security/audit-log` records real security-relevant events —
+failed authentication attempts, JWT refresh, PQC/TLS enable, and tool-call
+approve/deny decisions — in-memory, capped at the most recent 500, returned
+most-recent-first. Resets on restart (no persistent trail across restarts
+yet).
+
+```bash
+curl http://127.0.0.1:8080/api/security/audit-log \
+  -H "Authorization: Bearer $GHOSTLINK_API_KEY"
+```
 
 ```json
-{ "entries": [] }
+{
+  "entries": [
+    { "event": "jwt_refresh", "status": "SUCCESS", "ip": "127.0.0.1", "time": "2026-07-30T00:56:16.043249300+00:00", "detail": null },
+    { "event": "auth", "status": "FAILED", "ip": "127.0.0.1", "time": "2026-07-30T00:56:16.000337400+00:00", "detail": "GET /api/models" }
+  ]
+}
 ```
+
+## Workspace (Editor tab)
+
+Backs the GUI's Editor tab — file tree browsing, open/save, and repo-aware
+chat indexing. Confined to a canonicalized workspace root
+(`GHOSTLINK_WORKSPACE_ROOT`, defaults to the launch directory); every route
+rejects a `path` that resolves outside it.
+
+### List a directory
+
+```bash
+curl "http://127.0.0.1:8080/api/workspace/tree?path=" \
+  -H "Authorization: Bearer $GHOSTLINK_API_KEY"
+```
+
+```json
+{ "path": "", "entries": [{ "name": "README.md", "path": "README.md", "is_dir": false, "size": 23257 }] }
+```
+
+### Read / write a file
+
+```bash
+curl "http://127.0.0.1:8080/api/workspace/file?path=README.md" \
+  -H "Authorization: Bearer $GHOSTLINK_API_KEY"
+
+curl -X PUT http://127.0.0.1:8080/api/workspace/file \
+  -H "Authorization: Bearer $GHOSTLINK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"path": "README.md", "content": "..."}'
+```
+
+Files over 5MB, directories, and non-UTF-8 (binary) content are rejected
+with a JSON `{"error": "..."}` body rather than a partial read/write.
+
+### Index the workspace for repo-aware chat
+
+```bash
+curl -X POST http://127.0.0.1:8080/api/workspace/index \
+  -H "Authorization: Bearer $GHOSTLINK_API_KEY"
+```
+
+```json
+{ "status": "ok", "scanned": 2, "indexed": 2, "failed": 0, "capped": false }
+```
+
+Returns `{"status": "skipped", "reason": "..."}` instead — not an error —
+when the `rag` MCP server isn't configured or Ollama isn't reachable at the
+configured `OLLAMA_URL`.
 
 ## `POST /v1/chat/completions`
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -145,10 +145,10 @@ paths:
   /api/security/audit-log:
     get:
       summary: Security audit log entries
-      description: Exists but is not yet wired up to record events — always returns an empty list today.
+      description: Real events — failed auth, JWT refresh, PQC enable, tool-call approve/deny — capped at the most recent 500, most-recent-first. In-memory only; resets on restart.
       responses:
         "200":
-          description: Audit log entries (currently always empty)
+          description: Audit log entries
           content:
             application/json:
               schema:
@@ -156,7 +156,109 @@ paths:
                 properties:
                   entries:
                     type: array
-                    items: {}
+                    items:
+                      type: object
+                      properties:
+                        event: { type: string, example: jwt_refresh }
+                        status: { type: string, example: SUCCESS }
+                        ip: { type: string, example: 127.0.0.1 }
+                        time: { type: string, format: date-time }
+                        detail: { type: string, nullable: true }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /api/workspace/tree:
+    get:
+      summary: List a directory under the Editor tab's workspace root
+      parameters:
+        - name: path
+          in: query
+          required: false
+          schema: { type: string }
+          description: Relative path under the workspace root; empty for the root itself.
+      responses:
+        "200":
+          description: Directory entries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path: { type: string }
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        path: { type: string }
+                        is_dir: { type: boolean }
+                        size: { type: integer }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /api/workspace/file:
+    get:
+      summary: Read a workspace file
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: File content, or an error if the path escapes the workspace root, is a directory, exceeds 5MB, or isn't valid UTF-8
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path: { type: string }
+                  content: { type: string }
+                  error: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    put:
+      summary: Write a workspace file
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path, content]
+              properties:
+                path: { type: string }
+                content: { type: string }
+      responses:
+        "200":
+          description: Write result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  path: { type: string }
+                  error: { type: string }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /api/workspace/index:
+    post:
+      summary: Index the workspace into the rag MCP server for repo-aware chat context
+      description: Returns status "skipped" (not an error) when the rag MCP server isn't connected or Ollama isn't reachable at its configured OLLAMA_URL.
+      responses:
+        "200":
+          description: Indexing result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: ok }
+                  scanned: { type: integer }
+                  indexed: { type: integer }
+                  failed: { type: integer }
+                  capped: { type: boolean }
+                  reason: { type: string }
         "401":
           $ref: "#/components/responses/Unauthorized"
 components:

--- a/ghostlink_gui_modern/package-lock.json
+++ b/ghostlink_gui_modern/package-lock.json
@@ -8,10 +8,12 @@
       "name": "ghostlink-studio-gui",
       "version": "1.3.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "axios": "^1.6.0",
         "date-fns": "^2.30.0",
         "framer-motion": "^12.42.2",
         "lucide-react": "^0.292.0",
+        "monaco-editor": "^0.56.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
@@ -35,6 +37,7 @@
         "tailwindcss": "^3.4.0",
         "typescript": "^5.3.0",
         "vite": "^5.0.0",
+        "vite-plugin-monaco-editor-esm": "^2.0.2",
         "vitest": "^1.0.0"
       }
     },
@@ -939,6 +942,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1688,6 +1714,13 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2857,6 +2890,15 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4280,6 +4322,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5216,6 +5270,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.4.8",
+        "marked": "14.0.0"
+      }
     },
     "node_modules/motion-dom": {
       "version": "12.42.2",
@@ -6524,6 +6588,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -7227,6 +7297,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-monaco-editor-esm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-monaco-editor-esm/-/vite-plugin-monaco-editor-esm-2.0.2.tgz",
+      "integrity": "sha512-XVkOpL/r0rw1NpbO30vUwG4S0THkC9KB1vjjV8olGd49h4/EQsKl3DrxB6KRDwyZNC9mKiiZgk2L6njUYj3oKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.33.0"
       }
     },
     "node_modules/vitest": {

--- a/ghostlink_gui_modern/package.json
+++ b/ghostlink_gui_modern/package.json
@@ -13,10 +13,12 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "axios": "^1.6.0",
     "date-fns": "^2.30.0",
     "framer-motion": "^12.42.2",
     "lucide-react": "^0.292.0",
+    "monaco-editor": "^0.56.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
@@ -40,6 +42,7 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
     "vite": "^5.0.0",
+    "vite-plugin-monaco-editor-esm": "^2.0.2",
     "vitest": "^1.0.0"
   }
 }

--- a/ghostlink_gui_modern/src/App.tsx
+++ b/ghostlink_gui_modern/src/App.tsx
@@ -3,6 +3,7 @@ import { Plus, ChevronRight, Menu, Cpu, Zap, Wifi } from 'lucide-react';
 import { useAppStore } from './store';
 import { GhostlinkAPI } from './api';
 import { ChatTab } from './components/ChatTab';
+import { EditorTab } from './components/EditorTab';
 import { ModelsTab } from './components/ModelsTab';
 import { MetricsTab } from './components/MetricsTab';
 import { SessionsTab } from './components/SessionsTab';
@@ -220,6 +221,8 @@ function App() {
         return <SettingsTab api={api} />;
       case 7:
         return <McpTab api={api} />;
+      case 8:
+        return <EditorTab api={api} />;
       default:
         return null;
     }

--- a/ghostlink_gui_modern/src/api.ts
+++ b/ghostlink_gui_modern/src/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { Model, Metric, Session, Worker, Settings, McpServer } from './store';
+import { Model, Metric, Session, Worker, Settings, McpServer, WorkspaceEntry } from './store';
 
 type CircuitState = 'closed' | 'open' | 'half-open';
 
@@ -660,6 +660,59 @@ export class GhostlinkAPI {
       return { success: true, data: response.data };
     } catch (error: any) {
       return { success: false, error: error.response?.data?.error || error.message };
+    }
+  }
+
+  // Workspace file API (Editor tab) — distinct from the MCP file_operations
+  // tool (sandboxed to ./mcp_workspace, only invoked mid tool-call); these
+  // hit the new /api/workspace/* routes directly so the GUI can browse/open/
+  // save real project files.
+  async getWorkspaceTree(path = ''): Promise<{ path: string; entries: WorkspaceEntry[]; error?: string }> {
+    try {
+      const response = await this.http.get('/api/workspace/tree', { params: { path } });
+      if (response.data?.error) {
+        return { path, entries: [], error: response.data.error };
+      }
+      return { path: response.data.path ?? path, entries: response.data.entries || [] };
+    } catch (error: any) {
+      return { path, entries: [], error: error.response?.data?.error || error.message };
+    }
+  }
+
+  async getWorkspaceFile(path: string): Promise<{ path: string; content: string; error?: string }> {
+    try {
+      const response = await this.http.get('/api/workspace/file', { params: { path } });
+      if (response.data?.error) {
+        return { path, content: '', error: response.data.error };
+      }
+      return { path: response.data.path ?? path, content: response.data.content ?? '' };
+    } catch (error: any) {
+      return { path, content: '', error: error.response?.data?.error || error.message };
+    }
+  }
+
+  async writeWorkspaceFile(path: string, content: string): Promise<{ success: boolean; error?: string }> {
+    try {
+      const response = await this.http.put('/api/workspace/file', { path, content });
+      if (response.data?.error) {
+        return { success: false, error: response.data.error };
+      }
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: error.response?.data?.error || error.message };
+    }
+  }
+
+  /** Feeds the workspace into the `rag` MCP server's retrieval index so chat
+   *  has repo context without the user calling index_document by hand.
+   *  `status: "skipped"` (not an error) is the expected result whenever the
+   *  `rag` server isn't configured/connected — most installs won't have it. */
+  async indexWorkspace(): Promise<{ status: string; indexed?: number; failed?: number; scanned?: number; capped?: boolean; reason?: string; error?: string }> {
+    try {
+      const response = await this.http.post('/api/workspace/index');
+      return response.data;
+    } catch (error: any) {
+      return { status: 'error', error: error.response?.data?.error || error.message };
     }
   }
 

--- a/ghostlink_gui_modern/src/components/CommandPalette.tsx
+++ b/ghostlink_gui_modern/src/components/CommandPalette.tsx
@@ -10,6 +10,7 @@ import {
   Shield,
   Settings,
   Plug,
+  FileCode,
   CornerDownLeft,
   type LucideIcon,
 } from 'lucide-react';
@@ -25,6 +26,7 @@ export interface NavTab {
 // so the two never drift out of sync.
 export const NAV_TABS: NavTab[] = [
   { label: 'Chat', icon: MessageSquare, id: 0 },
+  { label: 'Editor', icon: FileCode, id: 8 },
   { label: 'Models', icon: Database, id: 1 },
   { label: 'Metrics', icon: BarChart3, id: 2 },
   { label: 'Sessions', icon: Clock, id: 3 },

--- a/ghostlink_gui_modern/src/components/EditorTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/EditorTab.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EditorTab } from './EditorTab';
+import { useAppStore } from '../store';
+import { GhostlinkAPI } from '../api';
+
+// EditorTab renders a real Monaco `Editor`/`DiffEditor`, which needs browser
+// APIs (workers, canvas text measurement) jsdom doesn't provide. Stand in
+// with plain form controls that expose the same value/onChange/onMount
+// contract EditorTab actually depends on.
+vi.mock('@monaco-editor/react', () => {
+  // EditorTab's onMount also registers an inline-completions provider via
+  // the second (monaco namespace) argument real @monaco-editor/react passes.
+  const fakeMonaco = {
+    languages: { registerInlineCompletionsProvider: () => ({ dispose: () => {} }) },
+    Range: class {},
+  };
+  const Editor = ({ value, onChange, onMount }: any) => {
+    onMount?.({ layout: () => {}, getSelection: () => null, getModel: () => null }, fakeMonaco);
+    return (
+      <textarea
+        data-testid="mock-editor"
+        value={value}
+        onChange={(e: any) => onChange?.(e.target.value)}
+      />
+    );
+  };
+  const DiffEditor = ({ original, modified, onMount }: any) => {
+    onMount?.({ layout: () => {} });
+    return (
+      <div data-testid="mock-diff-editor">
+        <pre data-testid="diff-original">{original}</pre>
+        <pre data-testid="diff-modified">{modified}</pre>
+      </div>
+    );
+  };
+  return { __esModule: true, default: Editor, DiffEditor };
+});
+
+// EditorTab's onMount wires up a ResizeObserver (see the comment in
+// EditorTab.tsx on why) — jsdom has no real implementation.
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function createMockApi(): GhostlinkAPI {
+  const api = new GhostlinkAPI('http://localhost:8003');
+  vi.spyOn(api, 'getWorkspaceTree').mockResolvedValue({
+    path: '',
+    entries: [
+      { name: 'README.md', path: 'README.md', is_dir: false, size: 123 },
+      { name: 'src', path: 'src', is_dir: true, size: 0 },
+    ],
+  });
+  vi.spyOn(api, 'getWorkspaceFile').mockResolvedValue({ path: 'README.md', content: '# Hello' });
+  vi.spyOn(api, 'writeWorkspaceFile').mockResolvedValue({ success: true });
+  vi.spyOn(api, 'sendMessage').mockResolvedValue({ success: true, data: { response: 'This file says hello.' } });
+  vi.spyOn(api, 'indexWorkspace').mockResolvedValue({ status: 'skipped', reason: 'not connected' });
+  return api;
+}
+
+describe('EditorTab', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    useAppStore.setState({
+      currentModel: 'none',
+      editorOpenPath: null,
+      editorContent: '',
+      editorOriginalContent: '',
+      editorPendingDiff: null,
+      toasts: [],
+    });
+  });
+
+  // Asserts the repo-aware-context auto-index here (rather than its own
+  // test) because `workspaceIndexAttempted` in EditorTab.tsx is a
+  // module-level guard, not component state — it only fires once for the
+  // whole test file's lifetime, on whichever test mounts EditorTab first.
+  it('loads and renders the root file tree, and silently kicks off workspace indexing', async () => {
+    const api = createMockApi();
+    render(<EditorTab api={api} />);
+    await waitFor(() => {
+      expect(api.getWorkspaceTree).toHaveBeenCalledWith('');
+      expect(screen.getByText('README.md')).toBeInTheDocument();
+      expect(screen.getByText('src')).toBeInTheDocument();
+    });
+    await waitFor(() => expect(api.indexWorkspace).toHaveBeenCalled());
+    // "skipped" (rag not connected) must not surface a toast — that's the
+    // expected outcome for most installs, not a failure worth interrupting for.
+    expect(useAppStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('opens a file on click', async () => {
+    const api = createMockApi();
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('README.md')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('README.md'));
+
+    await waitFor(() => {
+      expect(api.getWorkspaceFile).toHaveBeenCalledWith('README.md');
+      expect(screen.getByTestId('mock-editor')).toHaveValue('# Hello');
+    });
+  });
+
+  it('expands a directory node and lists its children', async () => {
+    const api = createMockApi();
+    (api.getWorkspaceTree as any).mockImplementation((path: string) => {
+      if (path === '') {
+        return Promise.resolve({ path: '', entries: [{ name: 'src', path: 'src', is_dir: true, size: 0 }] });
+      }
+      return Promise.resolve({ path, entries: [{ name: 'App.tsx', path: 'src/App.tsx', is_dir: false, size: 10 }] });
+    });
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('src')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('src'));
+
+    await waitFor(() => {
+      expect(api.getWorkspaceTree).toHaveBeenCalledWith('src');
+      expect(screen.getByText('App.tsx')).toBeInTheDocument();
+    });
+  });
+
+  it('enables Save once the buffer is edited, and writes on click', async () => {
+    const api = createMockApi();
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('README.md')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('README.md'));
+    await waitFor(() => expect(screen.getByTestId('mock-editor')).toHaveValue('# Hello'));
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId('mock-editor'), { target: { value: '# Hello, edited' } });
+    expect(saveButton).not.toBeDisabled();
+
+    fireEvent.click(saveButton);
+    await waitFor(() => {
+      expect(api.writeWorkspaceFile).toHaveBeenCalledWith('README.md', '# Hello, edited');
+    });
+  });
+
+  it('runs Explain and renders the reply', async () => {
+    const api = createMockApi();
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('README.md')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('README.md'));
+    await waitFor(() => expect(screen.getByTestId('mock-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Explain' }));
+
+    await waitFor(() => {
+      expect(api.sendMessage).toHaveBeenCalled();
+      expect(screen.getByText('This file says hello.')).toBeInTheDocument();
+    });
+    // Explain is read-only — it must never propose a diff.
+    expect(screen.queryByTestId('mock-diff-editor')).not.toBeInTheDocument();
+  });
+
+  it('shows a diff preview for Fix, and Accept writes the proposed content', async () => {
+    const api = createMockApi();
+    (api.sendMessage as any).mockResolvedValue({
+      success: true,
+      data: { response: '```\n# Hello, fixed\n```' },
+    });
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('README.md')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('README.md'));
+    await waitFor(() => expect(screen.getByTestId('mock-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fix' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-diff-editor')).toBeInTheDocument();
+      expect(screen.getByTestId('diff-modified')).toHaveTextContent('# Hello, fixed');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    await waitFor(() => {
+      expect(api.writeWorkspaceFile).toHaveBeenCalledWith('README.md', '# Hello, fixed');
+      expect(screen.queryByTestId('mock-diff-editor')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Reject discards the proposed diff without writing', async () => {
+    const api = createMockApi();
+    (api.sendMessage as any).mockResolvedValue({
+      success: true,
+      data: { response: '```\n# Hello, refactored\n```' },
+    });
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('README.md')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('README.md'));
+    await waitFor(() => expect(screen.getByTestId('mock-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refactor' }));
+    await waitFor(() => expect(screen.getByTestId('mock-diff-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-diff-editor')).not.toBeInTheDocument();
+    });
+    expect(api.writeWorkspaceFile).not.toHaveBeenCalled();
+  });
+
+  it('multi-file refactor: select a file, run, and Accept writes the proposed change', async () => {
+    const api = createMockApi();
+    (api.sendMessage as any).mockResolvedValue({
+      success: true,
+      data: { response: '### FILE: README.md\n```\n# Hello, multi-refactored\n```' },
+    });
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('README.md')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('Select README.md for multi-file refactor'));
+    const refactorButton = await screen.findByRole('button', { name: /Refactor Selected/ });
+    fireEvent.click(refactorButton);
+
+    await waitFor(() => {
+      const call = (api.sendMessage as any).mock.calls.at(-1)[0];
+      expect(call.message).toContain('### FILE: README.md');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Multi-file refactor/)).toBeInTheDocument();
+      expect(screen.getByTestId('diff-modified')).toHaveTextContent('# Hello, multi-refactored');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    await waitFor(() => {
+      expect(api.writeWorkspaceFile).toHaveBeenCalledWith('README.md', '# Hello, multi-refactored');
+      expect(screen.queryByText(/Multi-file refactor/)).not.toBeInTheDocument();
+    });
+  });
+
+  it('toggles the ghost-text autocomplete button state', async () => {
+    const api = createMockApi();
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('README.md')).toBeInTheDocument());
+
+    const toggle = screen.getByRole('button', { name: 'Ghost-text autocomplete' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows an error toast when opening a file fails', async () => {
+    const api = createMockApi();
+    (api.getWorkspaceFile as any).mockResolvedValue({ path: 'README.md', content: '', error: 'not found' });
+    render(<EditorTab api={api} />);
+    await waitFor(() => expect(screen.getByText('README.md')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('README.md'));
+
+    await waitFor(() => {
+      expect(useAppStore.getState().toasts.some((t) => t.type === 'error' && t.message === 'not found')).toBe(true);
+    });
+    expect(screen.getByText('No file open')).toBeInTheDocument();
+  });
+});

--- a/ghostlink_gui_modern/src/components/EditorTab.tsx
+++ b/ghostlink_gui_modern/src/components/EditorTab.tsx
@@ -1,0 +1,815 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import Editor, { DiffEditor, type OnMount, type Monaco } from '@monaco-editor/react';
+import type * as monacoEditor from 'monaco-editor';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+import {
+  Folder,
+  FolderOpen,
+  File as FileIcon,
+  Save,
+  Loader,
+  Sparkles,
+  Wrench,
+  Wand2,
+  Check,
+  X,
+  RefreshCw,
+  Zap,
+  SkipForward,
+} from 'lucide-react';
+import { useAppStore, WorkspaceEntry } from '../store';
+import { GhostlinkAPI } from '../api';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Pulls the first fenced code block out of a markdown reply so a "Fix" or
+// "Refactor" response can be offered as a concrete diff instead of just
+// prose — the model is asked (see buildScopedPrompt below) to always answer
+// with a single fenced block containing the full replacement file content.
+function extractFirstCodeBlock(markdown: string): string | null {
+  const match = /```[a-zA-Z0-9_-]*\r?\n([\s\S]*?)```/.exec(markdown);
+  return match ? match[1].replace(/\r?\n$/, '') : null;
+}
+
+// Parses the `### FILE: <path>` + fenced-block format the multi-file
+// refactor prompt (below) asks the model to reply in, into path -> proposed
+// content pairs. Deliberately tolerant: a file the model didn't mention
+// (because it decided no change was needed) just won't appear here.
+function parseMultiFileReply(content: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const re = /###\s*FILE:\s*(.+?)\r?\n```[a-zA-Z0-9_-]*\r?\n([\s\S]*?)```/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(content))) {
+    map.set(match[1].trim(), match[2].replace(/\r?\n$/, ''));
+  }
+  return map;
+}
+
+// DiffEditor (unlike Editor) has no `path` prop to infer language from —
+// only `Editor` does that. This covers the file types this repo actually
+// has; anything else just falls back to plaintext (still diffs correctly,
+// just without syntax colors).
+const EXT_LANGUAGE: Record<string, string> = {
+  ts: 'typescript', tsx: 'typescript', js: 'javascript', jsx: 'javascript',
+  rs: 'rust', go: 'go', py: 'python', json: 'json', toml: 'toml',
+  yaml: 'yaml', yml: 'yaml', md: 'markdown', css: 'css', html: 'html',
+  sh: 'shell', ps1: 'powershell', sql: 'sql',
+};
+function guessLanguage(path: string | null): string | undefined {
+  if (!path) return undefined;
+  const ext = path.split('.').pop()?.toLowerCase();
+  return ext ? EXT_LANGUAGE[ext] : undefined;
+}
+
+type ActionKind = 'explain' | 'fix' | 'refactor';
+
+const ACTIONS: { kind: ActionKind; label: string; icon: React.ElementType }[] = [
+  { kind: 'explain', label: 'Explain', icon: Sparkles },
+  { kind: 'fix', label: 'Fix', icon: Wrench },
+  { kind: 'refactor', label: 'Refactor', icon: Wand2 },
+];
+
+function buildScopedPrompt(kind: ActionKind, path: string, code: string, wholeFile: boolean): string {
+  const scope = wholeFile ? 'the whole file' : 'the selected excerpt below';
+  const header = `File: ${path}\nYou're looking at ${scope}.`;
+  if (kind === 'explain') {
+    return `${header}\n\nExplain what this code does, in plain terms.\n\n\`\`\`\n${code}\n\`\`\``;
+  }
+  const verb = kind === 'fix' ? 'Fix any bugs in' : 'Refactor';
+  return (
+    `${header}\n\n${verb} this code. Reply with ONLY a single fenced code block ` +
+    `containing the complete replacement for ${wholeFile ? 'the file' : 'the excerpt'} — no prose before or after.\n\n` +
+    `\`\`\`\n${code}\n\`\`\``
+  );
+}
+
+// A minimal per-selection assistant reply — deliberately separate from the
+// main Chat tab's history (ChatTab.tsx) so asking about a file doesn't
+// clutter the user's actual conversation, and so this tab keeps working
+// standalone without depending on ChatTab being mounted.
+interface ScratchReply {
+  kind: ActionKind;
+  content: string;
+  loading: boolean;
+}
+
+interface MultiDiffItem {
+  path: string;
+  original: string;
+  proposed: string;
+}
+
+// Module-level (not component state) so revisiting the Editor tab within
+// the same page load doesn't re-trigger indexing every time — EditorTab
+// unmounts on every tab switch, so a component-local guard would reset.
+let workspaceIndexAttempted = false;
+
+const TreeNode: React.FC<{
+  entry: WorkspaceEntry;
+  depth: number;
+  api: GhostlinkAPI;
+  openPath: string | null;
+  onOpenFile: (path: string) => void;
+  selectedPaths: Set<string>;
+  onToggleSelect: (path: string) => void;
+}> = ({ entry, depth, api, openPath, onOpenFile, selectedPaths, onToggleSelect }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [children, setChildren] = useState<WorkspaceEntry[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const toggle = async () => {
+    if (!entry.is_dir) {
+      onOpenFile(entry.path);
+      return;
+    }
+    if (!expanded && children === null) {
+      setLoading(true);
+      const result = await api.getWorkspaceTree(entry.path);
+      setChildren(result.entries);
+      setLoading(false);
+    }
+    setExpanded((e) => !e);
+  };
+
+  const isOpen = entry.path === openPath;
+
+  return (
+    <div>
+      <div
+        className={`flex items-center gap-1 w-full pr-2 rounded-lg transition ${
+          isOpen ? 'bg-blue-600/20' : 'hover:bg-slate-800'
+        }`}
+        style={{ paddingLeft: `${depth * 14 + 8}px` }}
+      >
+        {!entry.is_dir && (
+          <input
+            type="checkbox"
+            aria-label={`Select ${entry.name} for multi-file refactor`}
+            checked={selectedPaths.has(entry.path)}
+            onClick={(e) => e.stopPropagation()}
+            onChange={() => onToggleSelect(entry.path)}
+            className="shrink-0 accent-blue-600"
+          />
+        )}
+        <button
+          onClick={toggle}
+          title={entry.path}
+          className={`flex items-center gap-1.5 flex-1 min-w-0 py-1 text-left text-xs transition ${
+            isOpen ? 'text-blue-400' : 'text-slate-400 hover:text-slate-200'
+          }`}
+        >
+          {entry.is_dir ? (
+            loading ? (
+              <Loader size={13} className="animate-spin shrink-0" aria-hidden="true" />
+            ) : expanded ? (
+              <FolderOpen size={13} className="shrink-0 text-amber-400" aria-hidden="true" />
+            ) : (
+              <Folder size={13} className="shrink-0 text-amber-400" aria-hidden="true" />
+            )
+          ) : (
+            <FileIcon size={13} className="shrink-0" aria-hidden="true" />
+          )}
+          <span className="truncate">{entry.name}</span>
+        </button>
+      </div>
+      {entry.is_dir && expanded && children && (
+        <div>
+          {children.map((child) => (
+            <TreeNode
+              key={child.path}
+              entry={child}
+              depth={depth + 1}
+              api={api}
+              openPath={openPath}
+              onOpenFile={onOpenFile}
+              selectedPaths={selectedPaths}
+              onToggleSelect={onToggleSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const EditorTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
+  const {
+    currentModel,
+    editorOpenPath, editorContent, editorOriginalContent, editorPendingDiff,
+    setEditorOpenFile, setEditorContent, setEditorSaved, setEditorPendingDiff,
+    addToast,
+  } = useAppStore();
+
+  const [rootEntries, setRootEntries] = useState<WorkspaceEntry[]>([]);
+  const [treeError, setTreeError] = useState<string | null>(null);
+  const [treeLoading, setTreeLoading] = useState(false);
+  const [opening, setOpening] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [running, setRunning] = useState<ActionKind | null>(null);
+  const [reply, setReply] = useState<ScratchReply | null>(null);
+  const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
+  const editorContainerRef = useRef<HTMLDivElement>(null);
+  const editorResizeObserverRef = useRef<ResizeObserver | null>(null);
+  const diffContainerRef = useRef<HTMLDivElement>(null);
+  const multiDiffContainerRef = useRef<HTMLDivElement>(null);
+
+  // Ghost-text inline autocomplete (opt-in — see the toggle in the tree
+  // header). MVP: not true fill-in-the-middle (no suffix awareness, no
+  // model-specific FIM tokens) — just "continue what's before the cursor"
+  // through the same chat-completion endpoint everything else here uses, so
+  // latency is a real network+inference round trip, not per-keystroke-fast.
+  const [autocompleteEnabled, setAutocompleteEnabled] = useState(false);
+  const autocompleteEnabledRef = useRef(false);
+  const editorOpenPathRef = useRef(editorOpenPath);
+  const currentModelRef = useRef(currentModel);
+  const inlineProviderRef = useRef<{ dispose: () => void } | null>(null);
+
+  // Multi-file refactor (MVP): select several files in the tree, send them
+  // all in one prompt, then review each proposed change one at a time
+  // (Accept/Reject/Skip) — the same diff-preview idea as the single-file
+  // flow above, just queued across files instead of scoped to the open one.
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set());
+  const [multiRunning, setMultiRunning] = useState(false);
+  const [multiQueue, setMultiQueue] = useState<MultiDiffItem[] | null>(null);
+  const [multiIndex, setMultiIndex] = useState(0);
+
+  const dirty = editorOpenPath !== null && editorContent !== editorOriginalContent;
+
+  useEffect(() => {
+    autocompleteEnabledRef.current = autocompleteEnabled;
+  }, [autocompleteEnabled]);
+  useEffect(() => {
+    editorOpenPathRef.current = editorOpenPath;
+  }, [editorOpenPath]);
+  useEffect(() => {
+    currentModelRef.current = currentModel;
+  }, [currentModel]);
+
+  useEffect(() => {
+    return () => {
+      editorResizeObserverRef.current?.disconnect();
+      inlineProviderRef.current?.dispose();
+    };
+  }, []);
+
+  const loadRoot = useCallback(async () => {
+    setTreeLoading(true);
+    const result = await api.getWorkspaceTree('');
+    if (result.error) {
+      setTreeError(result.error);
+    } else {
+      setTreeError(null);
+      setRootEntries(result.entries);
+    }
+    setTreeLoading(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api]);
+
+  useEffect(() => {
+    loadRoot();
+  }, [loadRoot]);
+
+  // Repo-aware chat context: best-effort, silent unless it actually indexed
+  // something — most installs won't have the `rag` MCP server configured
+  // (disabled by default, needs a pulled embedding model), and that's an
+  // expected "skipped" outcome, not a failure worth surfacing.
+  useEffect(() => {
+    if (workspaceIndexAttempted) return;
+    workspaceIndexAttempted = true;
+    api.indexWorkspace().then((result) => {
+      if (result.status === 'ok' && (result.indexed ?? 0) > 0) {
+        addToast({
+          type: 'success',
+          message: `Indexed ${result.indexed} file(s) for repo-aware chat context${result.capped ? ' (capped)' : ''}`,
+        });
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api]);
+
+  const openFile = async (path: string) => {
+    setOpening(true);
+    const result = await api.getWorkspaceFile(path);
+    setOpening(false);
+    if (result.error) {
+      addToast({ type: 'error', message: result.error });
+      return;
+    }
+    setEditorOpenFile(path, result.content);
+    setReply(null);
+  };
+
+  const toggleSelectPath = (path: string) => {
+    setSelectedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const handleSave = async () => {
+    if (!editorOpenPath) return;
+    setSaving(true);
+    const result = await api.writeWorkspaceFile(editorOpenPath, editorContent);
+    setSaving(false);
+    if (result.success) {
+      setEditorSaved();
+      addToast({ type: 'success', message: `Saved ${editorOpenPath}` });
+    } else {
+      addToast({ type: 'error', message: result.error || 'Failed to save file' });
+    }
+  };
+
+  const runAction = async (kind: ActionKind) => {
+    if (!editorOpenPath) return;
+    const editor = editorRef.current;
+    const selection = editor?.getSelection();
+    const model = editor?.getModel();
+    const hasSelection = !!selection && !!model && !selection.isEmpty();
+    const scopedCode = hasSelection ? model!.getValueInRange(selection!) : editorContent;
+
+    setRunning(kind);
+    setReply({ kind, content: '', loading: true });
+    setEditorPendingDiff(null);
+
+    const result = await api.sendMessage({
+      message: buildScopedPrompt(kind, editorOpenPath, scopedCode, !hasSelection),
+      messages: [{ role: 'user', content: buildScopedPrompt(kind, editorOpenPath, scopedCode, !hasSelection) }],
+      temperature: 0.2,
+      top_p: 0.9,
+      top_k: 40,
+      penalty: 1.1,
+      max_tokens: 2048,
+      system_prompt: 'You are a precise coding assistant embedded in a code editor.',
+      mcp: { tools: [] },
+      stream: false,
+      model: currentModel === 'none' ? undefined : currentModel,
+    });
+
+    setRunning(null);
+
+    if (!result.success) {
+      setReply({ kind, content: `Error: ${result.error || 'request failed'}`, loading: false });
+      return;
+    }
+
+    const content = result.data?.response ?? '';
+    setReply({ kind, content, loading: false });
+
+    if (kind !== 'explain') {
+      const codeBlock = extractFirstCodeBlock(content);
+      if (codeBlock) {
+        // A selection-scoped edit only replaces that range in the full
+        // document — splicing by offset (not just swapping in the whole
+        // reply) is what lets the diff view below show the real, complete
+        // before/after of the file rather than just the changed excerpt.
+        const proposedFull =
+          hasSelection && selection && model
+            ? editorContent.slice(0, model.getOffsetAt(selection.getStartPosition())) +
+              codeBlock +
+              editorContent.slice(model.getOffsetAt(selection.getEndPosition()))
+            : codeBlock;
+        if (proposedFull !== editorContent) {
+          setEditorPendingDiff({ proposed: proposedFull });
+        }
+      }
+    }
+  };
+
+  const acceptDiff = async () => {
+    if (!editorOpenPath || !editorPendingDiff) return;
+    setEditorContent(editorPendingDiff.proposed);
+    const result = await api.writeWorkspaceFile(editorOpenPath, editorPendingDiff.proposed);
+    if (result.success) {
+      setEditorSaved();
+      addToast({ type: 'success', message: `Applied edit to ${editorOpenPath}` });
+    } else {
+      addToast({ type: 'error', message: result.error || 'Failed to write file' });
+    }
+    setEditorPendingDiff(null);
+  };
+
+  const rejectDiff = () => setEditorPendingDiff(null);
+
+  const runMultiFileRefactor = async () => {
+    const paths = Array.from(selectedPaths);
+    if (paths.length === 0) return;
+    setMultiRunning(true);
+
+    const files = await Promise.all(
+      paths.map(async (p) => {
+        const result = await api.getWorkspaceFile(p);
+        return { path: p, content: result.error ? null : result.content };
+      })
+    );
+    const usable = files.filter((f): f is { path: string; content: string } => f.content !== null);
+    if (usable.length === 0) {
+      setMultiRunning(false);
+      addToast({ type: 'error', message: 'Could not read any of the selected files' });
+      return;
+    }
+
+    const prompt =
+      `Refactor the following files. For EACH file, reply with a section formatted exactly as:\n` +
+      `### FILE: <path>\n\`\`\`\n<complete replacement content for that file>\n\`\`\`\n\n` +
+      `Only include a section for a file if it actually needs a change. No prose outside those sections.\n\n` +
+      usable.map((f) => `### FILE: ${f.path}\n\`\`\`\n${f.content}\n\`\`\``).join('\n\n');
+
+    const result = await api.sendMessage({
+      message: prompt,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.2,
+      top_p: 0.9,
+      top_k: 40,
+      penalty: 1.1,
+      max_tokens: 4096,
+      system_prompt: 'You are a precise coding assistant refactoring multiple files at once.',
+      mcp: { tools: [] },
+      stream: false,
+      model: currentModel === 'none' ? undefined : currentModel,
+    });
+
+    setMultiRunning(false);
+
+    if (!result.success) {
+      addToast({ type: 'error', message: result.error || 'Multi-file refactor request failed' });
+      return;
+    }
+
+    const proposals = parseMultiFileReply(result.data?.response ?? '');
+    const queue: MultiDiffItem[] = usable
+      .filter((f) => proposals.has(f.path) && proposals.get(f.path) !== f.content)
+      .map((f) => ({ path: f.path, original: f.content, proposed: proposals.get(f.path)! }));
+
+    if (queue.length === 0) {
+      addToast({ type: 'info', message: 'No changes proposed for the selected files' });
+      return;
+    }
+
+    setMultiQueue(queue);
+    setMultiIndex(0);
+  };
+
+  const advanceMultiQueue = () => {
+    if (!multiQueue) return;
+    if (multiIndex + 1 >= multiQueue.length) {
+      setMultiQueue(null);
+      setMultiIndex(0);
+      setSelectedPaths(new Set());
+    } else {
+      setMultiIndex((i) => i + 1);
+    }
+  };
+
+  const acceptMultiCurrent = async () => {
+    if (!multiQueue) return;
+    const item = multiQueue[multiIndex];
+    const result = await api.writeWorkspaceFile(item.path, item.proposed);
+    if (result.success) {
+      addToast({ type: 'success', message: `Applied edit to ${item.path}` });
+      // Keep the open buffer in sync if this queued file is also open.
+      if (editorOpenPath === item.path) {
+        setEditorContent(item.proposed);
+        setEditorSaved();
+      }
+    } else {
+      addToast({ type: 'error', message: result.error || `Failed to write ${item.path}` });
+    }
+    advanceMultiQueue();
+  };
+
+  const rejectMultiCurrent = () => advanceMultiQueue();
+
+  const registerInlineCompletions = (monacoInstance: Monaco) => {
+    inlineProviderRef.current?.dispose();
+    inlineProviderRef.current = monacoInstance.languages.registerInlineCompletionsProvider('*', {
+      async provideInlineCompletions(
+        model: monacoEditor.editor.ITextModel,
+        position: monacoEditor.Position,
+        _context: monacoEditor.languages.InlineCompletionContext,
+        token: monacoEditor.CancellationToken
+      ): Promise<monacoEditor.languages.InlineCompletions> {
+        if (!autocompleteEnabledRef.current) return { items: [] };
+
+        // Monaco cancels and re-invokes this on every keystroke — sleeping
+        // then checking cancellation is the standard debounce pattern for
+        // inline completion providers (there's no separate "quiet period"
+        // hook to wait on instead).
+        await sleep(450);
+        if (token.isCancellationRequested) return { items: [] };
+
+        const path = editorOpenPathRef.current;
+        if (!path) return { items: [] };
+
+        const prefix = model.getValueInRange({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: position.lineNumber,
+          endColumn: position.column,
+        });
+        if (!prefix.trim()) return { items: [] };
+
+        const prompt =
+          `File: ${path}\nContinue the code exactly where it leaves off. Reply with ONLY the raw ` +
+          `continuation text to insert at the cursor — no explanation, no markdown fences, don't repeat ` +
+          `any of the code already shown, no leading or trailing blank lines.\n\n\`\`\`\n${prefix}\n\`\`\``;
+
+        const modelName = currentModelRef.current;
+        const result = await api.sendMessage({
+          message: prompt,
+          messages: [{ role: 'user', content: prompt }],
+          temperature: 0.1,
+          top_p: 0.9,
+          top_k: 40,
+          penalty: 1.1,
+          max_tokens: 60,
+          system_prompt: 'You are a code-completion engine. Reply with raw code only, nothing else.',
+          mcp: { tools: [] },
+          stream: false,
+          model: modelName === 'none' ? undefined : modelName,
+        });
+
+        if (token.isCancellationRequested || !result.success) return { items: [] };
+
+        let suggestion = (result.data?.response ?? '')
+          .replace(/^```[a-zA-Z0-9_-]*\r?\n?/, '')
+          .replace(/```\s*$/, '')
+          .replace(/^\r?\n+/, '')
+          .replace(/\r?\n+$/, '');
+        if (!suggestion) return { items: [] };
+
+        return {
+          items: [
+            {
+              insertText: suggestion,
+              range: new monacoInstance.Range(position.lineNumber, position.column, position.lineNumber, position.column),
+            },
+          ],
+        };
+      },
+      freeInlineCompletions() {},
+    });
+  };
+
+  const currentMultiItem = multiQueue ? multiQueue[multiIndex] : null;
+
+  return (
+    <div className="flex h-full bg-slate-950">
+      {/* File tree */}
+      <div className="w-64 shrink-0 border-r border-slate-900 flex flex-col">
+        <div className="flex items-center justify-between px-3 py-3 border-b border-slate-900">
+          <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider">Workspace</h3>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setAutocompleteEnabled((v) => !v)}
+              aria-pressed={autocompleteEnabled}
+              aria-label="Ghost-text autocomplete"
+              title="Ghost-text autocomplete (experimental — fires a real completion request as you pause typing)"
+              className={`p-1 rounded-lg transition ${
+                autocompleteEnabled ? 'bg-blue-600/20 text-blue-400' : 'text-slate-500 hover:text-white hover:bg-slate-900'
+              }`}
+            >
+              <Zap size={13} aria-hidden="true" />
+            </button>
+            <button
+              onClick={loadRoot}
+              aria-label="Refresh file tree"
+              className="p-1 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-white transition"
+            >
+              <RefreshCw size={13} className={treeLoading ? 'animate-spin' : ''} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+        {selectedPaths.size > 0 && (
+          <div className="px-3 py-2 border-b border-slate-900 flex items-center justify-between gap-2 bg-slate-900/40">
+            <span className="text-[11px] text-slate-400">{selectedPaths.size} selected</span>
+            <button
+              onClick={runMultiFileRefactor}
+              disabled={multiRunning}
+              className="flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-bold bg-purple-600 hover:bg-purple-500 text-white disabled:opacity-40 transition"
+            >
+              {multiRunning ? <Loader size={11} className="animate-spin" aria-hidden="true" /> : <Wand2 size={11} aria-hidden="true" />}
+              Refactor Selected
+            </button>
+          </div>
+        )}
+        <div className="flex-1 overflow-y-auto py-2">
+          {treeError && <div className="px-3 py-2 text-xs text-red-400">{treeError}</div>}
+          {!treeError && rootEntries.length === 0 && !treeLoading && (
+            <div className="px-3 py-2 text-xs text-slate-600">Empty workspace</div>
+          )}
+          {rootEntries.map((entry) => (
+            <TreeNode
+              key={entry.path}
+              entry={entry}
+              depth={0}
+              api={api}
+              openPath={editorOpenPath}
+              onOpenFile={openFile}
+              selectedPaths={selectedPaths}
+              onToggleSelect={toggleSelectPath}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Editor + assistant panel */}
+      <div className="flex-1 flex flex-col min-w-0">
+        <div className="flex items-center justify-between px-4 py-2 border-b border-slate-900">
+          <div className="flex items-center gap-2 min-w-0">
+            {editorOpenPath ? (
+              <>
+                <FileIcon size={14} className="text-slate-500 shrink-0" aria-hidden="true" />
+                <span className="text-sm font-medium text-slate-200 truncate">{editorOpenPath}</span>
+                {dirty && <span className="w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" title="Unsaved changes" />}
+              </>
+            ) : (
+              <span className="text-sm text-slate-600">Select a file to open</span>
+            )}
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            {ACTIONS.map(({ kind, label, icon: Icon }) => (
+              <button
+                key={kind}
+                onClick={() => runAction(kind)}
+                disabled={!editorOpenPath || running !== null}
+                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-slate-400 hover:text-white hover:bg-slate-800 disabled:opacity-40 transition"
+              >
+                {running === kind ? <Loader size={13} className="animate-spin" aria-hidden="true" /> : <Icon size={13} aria-hidden="true" />}
+                {label}
+              </button>
+            ))}
+            <button
+              onClick={handleSave}
+              disabled={!editorOpenPath || !dirty || saving}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition"
+            >
+              {saving ? <Loader size={13} className="animate-spin" aria-hidden="true" /> : <Save size={13} aria-hidden="true" />}
+              Save
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 min-h-0 flex flex-col">
+          {currentMultiItem ? (
+            <div className="flex-1 min-h-0 flex flex-col">
+              <div className="flex items-center justify-between px-4 py-2 bg-purple-500/10 border-b border-purple-500/30">
+                <span className="text-xs font-bold text-purple-300">
+                  Multi-file refactor — {multiIndex + 1} of {multiQueue!.length}: {currentMultiItem.path}
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={acceptMultiCurrent}
+                    className="flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-bold bg-green-600 hover:bg-green-500 text-white transition"
+                  >
+                    <Check size={13} aria-hidden="true" /> Accept
+                  </button>
+                  <button
+                    onClick={rejectMultiCurrent}
+                    className="flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-bold bg-slate-800 hover:bg-slate-700 text-slate-300 transition"
+                  >
+                    <X size={13} aria-hidden="true" /> Reject
+                  </button>
+                  <button
+                    onClick={advanceMultiQueue}
+                    title="Skip without applying or discarding — you can revisit it another time"
+                    className="flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-bold bg-slate-800 hover:bg-slate-700 text-slate-300 transition"
+                  >
+                    <SkipForward size={13} aria-hidden="true" /> Skip
+                  </button>
+                </div>
+              </div>
+              <div ref={multiDiffContainerRef} className="flex-1 min-h-0 relative">
+                <DiffEditor
+                  original={currentMultiItem.original}
+                  modified={currentMultiItem.proposed}
+                  language={guessLanguage(currentMultiItem.path)}
+                  theme="vs-dark"
+                  options={{ readOnly: true, renderSideBySide: true, minimap: { enabled: false }, automaticLayout: false }}
+                  onMount={(diffEditor) => {
+                    if (multiDiffContainerRef.current) {
+                      const rect = multiDiffContainerRef.current.getBoundingClientRect();
+                      diffEditor.layout({ width: rect.width, height: rect.height });
+                    }
+                    const ro = new ResizeObserver((entries) => {
+                      const entry = entries[0];
+                      if (!entry) return;
+                      const { width, height } = entry.contentRect;
+                      if (width > 0 && height > 0) diffEditor.layout({ width, height });
+                    });
+                    if (multiDiffContainerRef.current) ro.observe(multiDiffContainerRef.current);
+                  }}
+                />
+              </div>
+            </div>
+          ) : editorPendingDiff ? (
+            <div className="flex-1 min-h-0 flex flex-col">
+              <div className="flex items-center justify-between px-4 py-2 bg-amber-500/10 border-b border-amber-500/30">
+                <span className="text-xs font-bold text-amber-400">Review proposed change (original vs. suggested)</span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={acceptDiff}
+                    className="flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-bold bg-green-600 hover:bg-green-500 text-white transition"
+                  >
+                    <Check size={13} aria-hidden="true" /> Accept
+                  </button>
+                  <button
+                    onClick={rejectDiff}
+                    className="flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-bold bg-slate-800 hover:bg-slate-700 text-slate-300 transition"
+                  >
+                    <X size={13} aria-hidden="true" /> Reject
+                  </button>
+                </div>
+              </div>
+              <div ref={diffContainerRef} className="flex-1 min-h-0 relative">
+                <DiffEditor
+                  original={editorContent}
+                  modified={editorPendingDiff.proposed}
+                  language={guessLanguage(editorOpenPath)}
+                  theme="vs-dark"
+                  options={{ readOnly: true, renderSideBySide: true, minimap: { enabled: false }, automaticLayout: false }}
+                  onMount={(diffEditor) => {
+                    // Same ResizeObserver-driven layout as the main Editor
+                    // below — see its onMount comment for why. The immediate
+                    // explicit call covers the initial paint; the observer
+                    // covers the pane being resized afterward.
+                    if (diffContainerRef.current) {
+                      const rect = diffContainerRef.current.getBoundingClientRect();
+                      diffEditor.layout({ width: rect.width, height: rect.height });
+                    }
+                    const ro = new ResizeObserver((entries) => {
+                      const entry = entries[0];
+                      if (!entry) return;
+                      const { width, height } = entry.contentRect;
+                      if (width > 0 && height > 0) diffEditor.layout({ width, height });
+                    });
+                    if (diffContainerRef.current) ro.observe(diffContainerRef.current);
+                  }}
+                />
+              </div>
+            </div>
+          ) : editorOpenPath ? (
+            <div ref={editorContainerRef} className="flex-1 min-h-0 relative">
+              <Editor
+                value={editorContent}
+                path={editorOpenPath}
+                theme="vs-dark"
+                onChange={(value) => setEditorContent(value ?? '')}
+                onMount={(editorInstance, monacoInstance) => {
+                  editorRef.current = editorInstance;
+                  registerInlineCompletions(monacoInstance);
+                  // Monaco's own `automaticLayout` measures its container via
+                  // a ResizeObserver *it* attaches — inside this nested flex
+                  // layout (mounted right after an async file fetch, in a
+                  // conditionally-rendered pane) that first measurement can
+                  // land on a bogus near-zero size, and since the container
+                  // never actually changes size afterward, Monaco's own
+                  // observer never fires again to correct it. Driving
+                  // `layout()` from our own ResizeObserver on the wrapper div
+                  // (which we've confirmed reports the real size) sidesteps
+                  // that entirely.
+                  editorResizeObserverRef.current?.disconnect();
+                  if (editorContainerRef.current) {
+                    const rect = editorContainerRef.current.getBoundingClientRect();
+                    editorInstance.layout({ width: rect.width, height: rect.height });
+                  }
+                  const ro = new ResizeObserver((entries) => {
+                    const entry = entries[0];
+                    if (!entry) return;
+                    const { width, height } = entry.contentRect;
+                    if (width > 0 && height > 0) editorInstance.layout({ width, height });
+                  });
+                  if (editorContainerRef.current) ro.observe(editorContainerRef.current);
+                  editorResizeObserverRef.current = ro;
+                }}
+                options={{ minimap: { enabled: false }, fontSize: 13, automaticLayout: false }}
+              />
+            </div>
+          ) : (
+            <div className="flex-1 flex items-center justify-center text-slate-600 text-sm">
+              {opening ? <Loader size={20} className="animate-spin" aria-hidden="true" /> : 'No file open'}
+            </div>
+          )}
+
+          {reply && (
+            <div className="max-h-64 overflow-y-auto border-t border-slate-900 px-4 py-3 bg-slate-900/40">
+              <div className="flex items-center gap-2 mb-1.5">
+                <Sparkles size={13} className="text-blue-400" aria-hidden="true" />
+                <span className="text-xs font-bold text-slate-300 capitalize">{reply.kind} result</span>
+                {reply.loading && <Loader size={12} className="animate-spin text-blue-500" aria-hidden="true" />}
+              </div>
+              <div className="prose prose-invert prose-sm max-w-none break-words text-sm">
+                <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+                  {reply.content || (reply.loading ? 'Thinking…' : '')}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ghostlink_gui_modern/src/main.tsx
+++ b/ghostlink_gui_modern/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import './monacoSetup';
 import { useAppStore } from './store';
 import { resolveApiBase } from './config';
 

--- a/ghostlink_gui_modern/src/monacoSetup.ts
+++ b/ghostlink_gui_modern/src/monacoSetup.ts
@@ -1,0 +1,10 @@
+import * as monaco from 'monaco-editor';
+import { loader } from '@monaco-editor/react';
+
+// Ghostlink is a local-first app (see the speech-to-text tradeoff note in
+// ChatTab.tsx) — @monaco-editor/react's default loader pulls Monaco from a
+// jsdelivr CDN at runtime, which would silently fail offline. Pointing the
+// loader at the `monaco-editor` package already in node_modules keeps the
+// editor itself fully local; `vite-plugin-monaco-editor-esm` (see
+// vite.config.ts) handles bundling its language workers the same way.
+loader.config({ monaco });

--- a/ghostlink_gui_modern/src/store.ts
+++ b/ghostlink_gui_modern/src/store.ts
@@ -94,6 +94,13 @@ export interface BackendStatus {
   temperature: number | null;
 }
 
+export interface WorkspaceEntry {
+  name: string;
+  path: string;
+  is_dir: boolean;
+  size: number;
+}
+
 export interface McpServer {
   name: string;
   slot: string;
@@ -183,6 +190,20 @@ interface AppState {
   pendingModelActions: Record<string, string>;
   downloadProgress: Record<string, DownloadProgressEntry>;
 
+  // Editor tab state — lifted here for the same reason as chatMessages
+  // above: switching tabs unmounts EditorTab, and an in-progress unsaved
+  // edit (or a diff the user hasn't accepted/rejected yet) would otherwise
+  // be silently lost instead of just picking back up on remount.
+  editorOpenPath: string | null;
+  editorContent: string;
+  editorOriginalContent: string;
+  editorPendingDiff: { proposed: string } | null;
+  setEditorOpenFile: (path: string, content: string) => void;
+  setEditorContent: (content: string) => void;
+  setEditorSaved: () => void;
+  setEditorPendingDiff: (diff: { proposed: string } | null) => void;
+  closeEditorFile: () => void;
+
   // App-wide transient notifications (rendered by <Toaster/> in App.tsx).
   // Distinct from the persistent inline error/empty-state banners each tab
   // already has for context-tied validation/connection errors — this is for
@@ -247,6 +268,10 @@ export const useAppStore = create<AppState>((set) => ({
   pendingModelActions: {},
   downloadProgress: {},
   toasts: [],
+  editorOpenPath: null,
+  editorContent: '',
+  editorOriginalContent: '',
+  editorPendingDiff: null,
 
   setApiBase: (base) => set({ apiBase: base }),
   setBackendOnline: (online) => set({ backendOnline: online }),
@@ -285,6 +310,13 @@ export const useAppStore = create<AppState>((set) => ({
     set((state) => ({ pendingModelActions: resolveUpdater(updater, state.pendingModelActions) })),
   setDownloadProgress: (updater) =>
     set((state) => ({ downloadProgress: resolveUpdater(updater, state.downloadProgress) })),
+  setEditorOpenFile: (path, content) =>
+    set({ editorOpenPath: path, editorContent: content, editorOriginalContent: content, editorPendingDiff: null }),
+  setEditorContent: (content) => set({ editorContent: content }),
+  setEditorSaved: () => set((state) => ({ editorOriginalContent: state.editorContent })),
+  setEditorPendingDiff: (diff) => set({ editorPendingDiff: diff }),
+  closeEditorFile: () =>
+    set({ editorOpenPath: null, editorContent: '', editorOriginalContent: '', editorPendingDiff: null }),
   addToast: (toast) => {
     const id = typeof crypto !== 'undefined' && crypto.randomUUID
       ? crypto.randomUUID()

--- a/ghostlink_gui_modern/vite.config.ts
+++ b/ghostlink_gui_modern/vite.config.ts
@@ -1,12 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import monacoEditorEsmPlugin from 'vite-plugin-monaco-editor-esm'
 
 // The control-plane gateway (Go), not ghost-link directly — see config.ts's
 // resolveApiBase for the matching default on the axios-client side.
 const proxyTarget = process.env.VITE_PROXY_TARGET || 'http://127.0.0.1:8000'
 
 export default defineConfig({
-  plugins: [react()],
+  // Bundles Monaco's language workers locally (esbuild, served from
+  // node_modules/.monaco) instead of the CDN @monaco-editor/react defaults
+  // to — Ghostlink is local-first everywhere else, so the Editor tab's code
+  // editor shouldn't be the one piece that silently needs internet access.
+  plugins: [react(), monacoEditorEsmPlugin()],
   server: {
     port: 5173,
     proxy: {

--- a/mcp_servers.example.toml
+++ b/mcp_servers.example.toml
@@ -151,8 +151,10 @@ slot = ""
 # Local retrieval-augmented generation: chunks + embeds documents via a local
 # Ollama embedding model into a brute-force cosine-similarity index (JSON
 # file, no external vector DB) so chat can look them up later with search().
-# Disabled by default: enable once you've `ollama pull`ed an embedding model.
-enabled = false
+# Enabled by default — the Editor tab's auto-index (POST /api/workspace/index)
+# needs it connected to do anything; requires `ollama pull nomic-embed-text`
+# (or override OLLAMA_EMBED_MODEL below) or it just fails to connect quietly.
+enabled = true
 transport = "stdio"
 command = "target/release/mcp-rag.exe"
 args = []


### PR DESCRIPTION
## Summary

Ghostlink Studio was chat-only — code rendered as read-only Markdown, no way to browse/open/edit a real project file from the GUI, and no diff-preview step before an AI-proposed change touched disk. This adds a Monaco-based **Editor tab** wired directly into the existing chat/MCP infrastructure.

- **Workspace file API** (`GET /api/workspace/tree`, `GET`/`PUT /api/workspace/file`) — confined to a canonicalized `GHOSTLINK_WORKSPACE_ROOT`, with a path-traversal guard.
- **Explain / Fix / Refactor** — scoped to selection or whole file; Fix/Refactor propose changes via a side-by-side `DiffEditor` with explicit Accept/Reject.
- **Multi-file refactor** — select several files, one batched prompt, sequential per-file diff review (Accept/Reject/Skip).
- **Ghost-text autocomplete** (opt-in) — Monaco's native inline-completions provider, debounced against the existing chat endpoint. Explicit MVP: no fill-in-the-middle model support, no suffix awareness.
- **Repo-aware chat context** — `POST /api/workspace/index` feeds the workspace into the `rag` MCP server directly (not via an LLM tool-calling loop). `rag` is now enabled by default; a direct `OllamaClient::health()` probe keeps the "not usable" case a clean `"skipped"` rather than a wall of per-file failures.
- **Real security audit log** (`/api/security/audit-log` was a hardcoded empty stub) — now records failed auth, JWT refresh, PQC enable, and tool-call approve/deny.

### Fixed
- `mcp-rag`'s `index_document` only ever appended chunks, never removed a document's prior ones — every re-index (which happens every Editor-tab page load) grew `rag_index.json` with duplicates forever. Now replaces by doc-id prefix before inserting.

### Bug found and fixed during verification
Monaco's own `automaticLayout` locked onto a bogus 5×5px size in this nested-flex pane and never self-corrected (its ResizeObserver's first measurement landed wrong, and the container never changed size afterward to trigger a second one). Fixed with an explicit `.layout()` call on mount plus our own `ResizeObserver` on a container we control.

## Validation commands run

```bash
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```
All clean, 0 failures (150 tests in `ghost-link`, 12 in `mcp-rag`, plus `ghostlink-core` integration suites).

```bash
cd ghostlink_gui_modern
npx tsc --noEmit
npx vitest run
```
Clean; 128/128 passed (10 new in `EditorTab.test.tsx`).

**Manual verification** (not just curl): built the release binary, ran the actual GUI against it, confirmed the Editor tab renders real repo files, opened/edited/saved a file, ran Explain against a live model, triggered the diff-preview Accept/Reject flow, and confirmed a real audit-log entry appears in the Security tab after a JWT refresh. Confirmed the RAG dedup fix live — indexed a directory (10 chunks), re-indexed, still exactly 10.

## Release checklist (per CONTRIBUTING.md's Release Rubric)

**Hard gates**
- [x] `cargo fmt --all --check` — OK
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — OK
- [x] `cargo test --workspace` — all pass
- [ ] CI: ubuntu/windows/macos — pending this PR's run
- [x] Performance baseline — no runtime/transport/pipeline code touched; not applicable

**Scoring factors**
- [x] Documentation: `README.md` (new "Editor Tab & Copilot Features" section, updated endpoint table, MCP tools table), `docs/API_REFERENCE.md`, `docs/openapi.yaml`
- [x] Changelog updated (`CHANGELOG.md` `[1.16.0]`)
- [x] Version bumped: `1.15.1` → `1.16.0` (README badge + CHANGELOG)
- [x] Operational caveats documented: ghost-text autocomplete and multi-file refactor are explicitly MVP-scoped in the CHANGELOG; audit log is in-memory only (resets on restart)

**Final recommendation:** Conditional GO — pending this PR's CI run across all three platforms.

## Known limitations (intentional, documented in CHANGELOG)
- Ghost-text autocomplete and multi-file refactor weren't exercised against a live completion-capable model this session (none was loaded in the test environment) — type-checked, unit-tested, and confirmed to render/wire up correctly in the browser instead.
- Audit log is in-memory only, capped at 500 entries — no persistent trail across restarts yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)