### PR TITLE
⚡ Bolt: Lock-free total system memory query optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2026-07-24 - [Lock-Free Total System Memory Query Optimization]
+**Learning:** Frequently querying cluster-wide hardware capacities (such as total system memory or total VRAM) by locking thread-safe maps and summing their values on every call introduces unnecessary mutex acquisition overhead, thread contention, and linear traversal cost. Caching cumulative system metrics in atomic integers (e.g., `AtomicU64`) and maintaining them with delta updates during registration enables lock-free, O(1) status queries.
+**Action:** Always maintain cumulative metrics with atomic delta updates on registration/deregistration instead of computing them via map traversal on the query path.
+
 ## 2026-07-23 - [Zero-Copy Binary Protocol Slice Decoding Optimization]
 **Learning:** Constructing multi-byte arrays by manually indexing elements (such as `[payload[cursor], payload[cursor+1], ...]`) prevents the compiler from emitting optimal unaligned single-instruction loads. Transitioning to slice `.try_into()` conversion allows `rustc`/LLVM to generate optimal unaligned load instructions, which reduces CPU instructions and speeds up binary frame parsing.
 **Action:** Always parse multi-byte primitives (like `u16`, `u32`, `f32`) from byte streams by converting slice windows to fixed-size arrays via `.try_into()` instead of manual byte array construction.

--- a/crates/ghostlink-core/src/cluster.rs
+++ b/crates/ghostlink-core/src/cluster.rs
@@ -211,6 +211,8 @@ pub struct ClusterState {
     last_update: Arc<AtomicU64>,
     /// Cached total VRAM across all registered nodes
     total_vram_cache: Arc<AtomicU64>,
+    /// Cached total system memory across all registered nodes
+    total_system_memory_cache: Arc<AtomicU64>,
 }
 
 impl Clone for ClusterState {
@@ -222,6 +224,7 @@ impl Clone for ClusterState {
             metrics: Arc::clone(&self.metrics),
             last_update: Arc::clone(&self.last_update),
             total_vram_cache: Arc::clone(&self.total_vram_cache),
+            total_system_memory_cache: Arc::clone(&self.total_system_memory_cache),
         }
     }
 }
@@ -242,6 +245,7 @@ impl ClusterState {
             metrics: Arc::new(Mutex::new(HashMap::new())),
             last_update: Arc::new(AtomicU64::new(0)),
             total_vram_cache: Arc::new(AtomicU64::new(0.0_f64.to_bits())),
+            total_system_memory_cache: Arc::new(AtomicU64::new(0.0_f64.to_bits())),
         }
     }
 
@@ -268,9 +272,11 @@ impl ClusterState {
         let compute_capability = node.compute_capability.clone();
         let rpc_port = node.rpc_port;
         let mut vram_delta = vram_gb;
+        let mut system_memory_delta = system_memory_gb;
 
         if let Some(existing) = nodes.get_mut(&id) {
             vram_delta = vram_gb - existing.vram_gb;
+            system_memory_delta = system_memory_gb - existing.system_memory_gb;
             existing.vram_gb = vram_gb;
             existing.system_memory_gb = system_memory_gb;
             existing.compute_capability = compute_capability.clone();
@@ -314,6 +320,12 @@ impl ClusterState {
         let current_total_vram = f64::from_bits(self.total_vram_cache.load(Ordering::Acquire));
         self.total_vram_cache.store(
             (current_total_vram + vram_delta as f64).to_bits(),
+            Ordering::Release,
+        );
+
+        let current_total_system_mem = f64::from_bits(self.total_system_memory_cache.load(Ordering::Acquire));
+        self.total_system_memory_cache.store(
+            (current_total_system_mem + system_memory_delta as f64).to_bits(),
             Ordering::Release,
         );
 
@@ -437,11 +449,7 @@ impl ClusterState {
 
     /// Get total system memory
     pub fn total_system_memory_gb(&self) -> f32 {
-        let nodes = self
-            .nodes
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        nodes.values().map(|n| n.system_memory_gb).sum()
+        f64::from_bits(self.total_system_memory_cache.load(Ordering::Acquire)) as f32
     }
 }
 

--- a/crates/ghostlink-core/src/cluster.rs
+++ b/crates/ghostlink-core/src/cluster.rs
@@ -323,7 +323,8 @@ impl ClusterState {
             Ordering::Release,
         );
 
-        let current_total_system_mem = f64::from_bits(self.total_system_memory_cache.load(Ordering::Acquire));
+        let current_total_system_mem =
+            f64::from_bits(self.total_system_memory_cache.load(Ordering::Acquire));
         self.total_system_memory_cache.store(
             (current_total_system_mem + system_memory_delta as f64).to_bits(),
             Ordering::Release,


### PR DESCRIPTION
Optimize `ClusterState::total_system_memory_gb` to load lock-free and in O(1) time complexity by caching the value in `total_system_memory_cache` (`AtomicU64`) similar to `total_vram_gb`. This replaces an $O(N)$ lock-heavy map traversal with a lock-free atomic load.

---
*PR created automatically by Jules for task [4314291633354852872](https://jules.google.com/task/4314291633354852872) started by @rwilliamspbg-ops*