### PR TITLE
🎨 Palette: Keyboard Accessibility Focus Rings in ChatTab

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2026-07-22 - [Empty Chat Onboarding Suggestion Chips]
 **Learning:** Empty conversational states create a high cognitive load for users who may not know how to start. Providing pre-configured prompt suggestion buttons under the welcome message reduces onboarding friction. Ensuring these buttons are semantic elements (`<button>`), fully accessible with descriptive ARIA labels, and focus-linked to the main chat composer creates a smooth, intuitive keyboard and mouse experience.
 **Action:** Always include interactive, accessible suggestion cards/chips in blank conversational views to guide users and focus the text composer when selected.
+
+## 2026-07-23 - [Keyboard Navigation Focus Rings]
+**Learning:** Custom interactive elements (such as onboarding suggestion buttons, icon-only header utility buttons, and custom model dropdown triggers) that rely on default focus outlines often have their outlines swallowed by absolute wrappers, overflow constraints, or dark-theme backgrounds. This makes keyboard-only and screen-reader navigation completely blind and confusing. Using specific Tailwind focus-visible styling ensures clear, localized, high-contrast focus rings without cluttering the visual layout for mouse/touch-first users.
+**Action:** Always apply tailored focus-visible indicators (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) to all custom-styled buttons, chips, and dropdown triggers to preserve keyboard accessibility.

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -744,7 +744,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                     onClick={() => setShowModelSelector(!showModelSelector)}
                     aria-haspopup="listbox"
                     aria-expanded={showModelSelector}
-                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg hover:bg-slate-900 transition text-sm font-semibold group"
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg hover:bg-slate-900 transition text-sm font-semibold group focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                 >
                     <span className="text-slate-200 group-hover:text-white max-w-[200px] truncate">
                         {currentModel === 'none' ? 'Select Model' : currentModel.split('/').pop()}
@@ -809,7 +809,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                         aria-haspopup="listbox"
                         aria-expanded={showCompareSelector}
                         title="Compare against a second model"
-                        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition text-xs font-semibold"
+                        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition text-xs font-semibold focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                     >
                         <GitCompare size={14} aria-hidden="true" />
                         Compare
@@ -862,7 +862,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
               <div className="flex items-center gap-1">
                 <button
                   onClick={() => { if (!loading) { setSessionName(`Session ${new Date().toLocaleDateString()}`); setShowSessions(true); }}}
-                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-white transition"
+                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   title="Save Session"
                   aria-label="Save session"
                   aria-haspopup="dialog"
@@ -872,7 +872,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                 </button>
                 <button
                   onClick={() => { loadSessions(); setShowSessions(true); }}
-                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-white transition"
+                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   title="Load Session"
                   aria-label="Load session"
                   aria-haspopup="dialog"
@@ -887,7 +887,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                       setMessages([]);
                     }
                   }}
-                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-white transition"
+                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   title="Clear chat"
                   aria-label="Clear chat"
                 >
@@ -1005,7 +1005,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                                     textareaRef.current?.focus();
                                 }}
                                 aria-label={s.label}
-                                className="p-3.5 text-left bg-slate-900/50 hover:bg-slate-800/80 border border-slate-800 hover:border-slate-700 text-xs text-slate-300 hover:text-white rounded-xl transition duration-200 active:scale-[0.98]"
+                                className="p-3.5 text-left bg-slate-900/50 hover:bg-slate-800/80 border border-slate-800 hover:border-slate-700 text-xs text-slate-300 hover:text-white rounded-xl transition duration-200 active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                             >
                                 {s.text}
                             </button>
@@ -1143,21 +1143,21 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
 
                         {msg.role === 'assistant' && (
                             <div className="flex items-center gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity focus-within:opacity-100">
-                                <button onClick={() => handleCopy(msg.content, msg.id)} className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition" title="Copy" aria-label="Copy response">
+                                <button onClick={() => handleCopy(msg.content, msg.id)} className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" title="Copy" aria-label="Copy response">
                                   {copiedId === msg.id ? <Check size={14} className="text-green-400" aria-hidden="true" /> : <Copy size={14} aria-hidden="true" />}
                                 </button>
-                                <button className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition" title="Good response" aria-label="Good response">
+                                <button className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" title="Good response" aria-label="Good response">
                                     <ThumbsUp size={14} aria-hidden="true" />
                                 </button>
-                                <button className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition" title="Bad response" aria-label="Bad response">
+                                <button className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" title="Bad response" aria-label="Bad response">
                                     <ThumbsDown size={14} aria-hidden="true" />
                                 </button>
-                                <button onClick={handleRegenerate} className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition" title="Regenerate" aria-label="Regenerate response">
+                                <button onClick={handleRegenerate} className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" title="Regenerate" aria-label="Regenerate response">
                                     <RotateCcw size={14} aria-hidden="true" />
                                 </button>
                                 <button
                                   onClick={() => { try { speechSynthesis.speak(new SpeechSynthesisUtterance(msg.content)); } catch {} }}
-                                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition"
+                                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                                   title="Read aloud"
                                   aria-label="Read response aloud"
                                 >
@@ -1166,7 +1166,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                                 <button
                                   onClick={() => handleDeleteMessage(msg.id)}
                                   disabled={loading}
-                                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-red-400 transition disabled:opacity-40"
+                                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-red-400 transition disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                                   title="Delete"
                                   aria-label="Delete response"
                                 >
@@ -1180,7 +1180,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                                 <button
                                   onClick={() => handleEditMessage(msg)}
                                   disabled={loading}
-                                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition disabled:opacity-40"
+                                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-slate-300 transition disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                                   title="Edit and resend"
                                   aria-label="Edit and resend message"
                                 >
@@ -1189,7 +1189,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                                 <button
                                   onClick={() => handleDeleteMessage(msg.id)}
                                   disabled={loading}
-                                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-red-400 transition disabled:opacity-40"
+                                  className="p-1.5 rounded-lg hover:bg-slate-900 text-slate-500 hover:text-red-400 transition disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                                   title="Delete"
                                   aria-label="Delete message"
                                 >
@@ -1276,7 +1276,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                     aria-haspopup="menu"
                     aria-expanded={showTools}
                     aria-label="Capabilities"
-                    className={`p-2 rounded-xl transition ${showTools ? 'bg-slate-800 text-blue-400' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'}`}
+                    className={`p-2 rounded-xl transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${showTools ? 'bg-slate-800 text-blue-400' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'}`}
                 >
                     <Plus size={20} aria-hidden="true" />
                 </button>
@@ -1289,7 +1289,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                         aria-label={isRecording ? 'Stop voice input' : 'Start voice input'}
                         aria-pressed={isRecording}
                         title={isRecording ? 'Stop voice input' : 'Voice input (requires internet — browser speech recognition)'}
-                        className={`relative p-2 rounded-full transition ${
+                        className={`relative p-2 rounded-full transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                             isRecording
                                 ? 'bg-red-500/20 text-red-400'
                                 : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'
@@ -1305,7 +1305,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                     onClick={handleSend}
                     disabled={!input.trim() || loading}
                     aria-label="Send message"
-                    className={`p-2 rounded-full transition shadow-lg ${
+                    className={`p-2 rounded-full transition shadow-lg focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
                         !input.trim() || loading
                             ? 'bg-slate-800 text-slate-600'
                             : 'bg-white text-black hover:bg-slate-200'


### PR DESCRIPTION
Introduced high-contrast focus indicators using Tailwind's `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none` classes on all primary interactive elements inside the main Chat interface (`ChatTab.tsx`). This includes suggestion chips, model controls, session management controls, assistant response copy/rating tools, and chat composition triggers. Fully verified through type-checking, automated unit tests, and Playwright-driven screenshot/video recordings.

---
*PR created automatically by Jules for task [14984863611736794574](https://jules.google.com/task/14984863611736794574) started by @rwilliamspbg-ops*