### PR TITLE
🎨 Palette: MCP Servers Tab Keyboard Accessibility Focus Rings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,7 @@
 ## 2026-07-23 - [Keyboard Navigation Focus Rings]
 **Learning:** Custom interactive elements (such as onboarding suggestion buttons, icon-only header utility buttons, and custom model dropdown triggers) that rely on default focus outlines often have their outlines swallowed by absolute wrappers, overflow constraints, or dark-theme backgrounds. This makes keyboard-only and screen-reader navigation completely blind and confusing. Using specific Tailwind focus-visible styling ensures clear, localized, high-contrast focus rings without cluttering the visual layout for mouse/touch-first users.
 **Action:** Always apply tailored focus-visible indicators (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) to all custom-styled buttons, chips, and dropdown triggers to preserve keyboard accessibility.
+
+## 2026-07-31 - [MCP Tab Keyboard Accessibility]
+**Learning:** Custom toggle buttons and control headers in utility panels (like the MCP Servers tab) must have high-contrast focus-visible styles configured. Without them, keyboard users can navigate to the page but are left unable to clearly discern which server toggle or action button currently holds visual focus.
+**Action:** Ensure all button elements inside toggle lists and header actions use `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none` for excellent keyboard navigation visibility.

--- a/ghostlink_gui_modern/src/components/McpTab.tsx
+++ b/ghostlink_gui_modern/src/components/McpTab.tsx
@@ -53,7 +53,7 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
         <button
           onClick={refresh}
           aria-label="Refresh MCP servers"
-          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition"
+          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
         >
           <RefreshCw size={18} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
         </button>
@@ -140,7 +140,7 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                   aria-label={`${server.enabled ? 'Disable' : 'Enable'} ${server.name}`}
                   className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ${
                     server.enabled ? 'bg-blue-600' : 'bg-slate-700'
-                  } ${toggling === server.name ? 'opacity-50' : ''}`}
+                  } ${toggling === server.name ? 'opacity-50' : ''} focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
                   title={server.enabled ? 'Disable server' : 'Enable server'}
                 >
                   <div


### PR DESCRIPTION
This PR adds tailored high-contrast keyboard-accessible focus-visible styles to the interactive refresh button and the server enable/disable switches on the MCP Servers panel (`McpTab.tsx`). This ensures clear focus state indicators for keyboard-only and screen-reader users navigating the MCP servers list.

---
*PR created automatically by Jules for task [4944173308063220838](https://jules.google.com/task/4944173308063220838) started by @rwilliamspbg-ops*