### PR TITLE
🎨 Palette: keyboard accessibility focus visible style additions to Models and Workers tabs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-07-31 - [MCP Tab Keyboard Accessibility]
 **Learning:** Custom toggle buttons and control headers in utility panels (like the MCP Servers tab) must have high-contrast focus-visible styles configured. Without them, keyboard users can navigate to the page but are left unable to clearly discern which server toggle or action button currently holds visual focus.
 **Action:** Ensure all button elements inside toggle lists and header actions use `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none` for excellent keyboard navigation visibility.
+
+## 2026-08-01 - [Interactive Controls Keyboard Visibility]
+**Learning:** Interactive controls like tab lists (e.g., in the Models Dashboard) and control action buttons/inputs (e.g., inside the Cluster Workers dashboard) must use high-contrast focus-visible rings. Relying on default focus styles leads to invisible focused items during tab traversal on dark-theme UI panels, leaving keyboard and screen-reader users completely blind.
+**Action:** Always style all dashboards' custom buttons, tab toggles, and input elements with `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`.

--- a/ghostlink_gui_modern/src/components/ModelsTab.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.tsx
@@ -425,7 +425,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             role="tab"
             aria-selected={activeTab === 'local'}
             onClick={() => setActiveTab('local')}
-            className={`px-3 py-1.5 rounded-lg text-sm font-bold transition ${
+            className={`px-3 py-1.5 rounded-lg text-sm font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
               activeTab === 'local' ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/20' : 'text-slate-400 hover:bg-slate-900'
             }`}
           >
@@ -435,7 +435,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             role="tab"
             aria-selected={activeTab === 'recommended'}
             onClick={() => setActiveTab('recommended')}
-            className={`px-3 py-1.5 rounded-lg text-sm font-bold transition ${
+            className={`px-3 py-1.5 rounded-lg text-sm font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
               activeTab === 'recommended' ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/20' : 'text-slate-400 hover:bg-slate-900'
             }`}
           >
@@ -445,7 +445,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             role="tab"
             aria-selected={activeTab === 'huggingface'}
             onClick={() => setActiveTab('huggingface')}
-            className={`px-3 py-1.5 rounded-lg text-sm font-bold transition ${
+            className={`px-3 py-1.5 rounded-lg text-sm font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
               activeTab === 'huggingface' ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/20' : 'text-slate-400 hover:bg-slate-900'
             }`}
           >
@@ -464,13 +464,13 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                 placeholder="Search models..."
                 name="hf-search"
                 id="hf-search"
-                className="pl-8 pr-4 py-2 bg-slate-800 border border-slate-700 rounded-lg text-slate-200 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="pl-8 pr-4 py-2 bg-slate-800 border border-slate-700 rounded-lg text-slate-200 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
               />
             </div>
           )}
           <button
             onClick={refreshModels}
-            className="flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-blue-600 text-white rounded-xl text-xs font-bold transition group-hover:shadow-lg group-hover:shadow-blue-500/20"
+            className="flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-blue-600 text-white rounded-xl text-xs font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none group-hover:shadow-lg group-hover:shadow-blue-500/20"
           >
             <RefreshCw size={16} aria-hidden="true" /> Refresh
           </button>
@@ -532,7 +532,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                             <button
                               onClick={() => handleUnloadModel(model.name)}
                               disabled={pendingActions[model.name] === 'unloading' || loading}
-                              className="flex items-center gap-2 px-3 py-1 bg-slate-800 hover:bg-slate-700 text-xs font-medium rounded-full transition"
+                              className="flex items-center gap-2 px-3 py-1 bg-slate-800 hover:bg-slate-700 text-xs font-medium rounded-full transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                             >
                               {pendingActions[model.name] === 'unloading' ? (
                                 <Loader size={16} className="mr-1" />
@@ -547,7 +547,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                             onClick={() => handleSetModel(model.name)}
                             disabled={pendingActions[model.name] === 'setting' || loading}
                             title={model.usable ? undefined : 'Not downloaded yet — selecting will show an error until it is'}
-                            className="flex items-center gap-2 px-3 py-1 bg-slate-800 hover:bg-blue-600 text-xs font-medium rounded-full transition"
+                            className="flex items-center gap-2 px-3 py-1 bg-slate-800 hover:bg-blue-600 text-xs font-medium rounded-full transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                           >
                             {pendingActions[model.name] === 'setting' ? (
                               <Loader size={16} className="mr-1" />
@@ -559,7 +559,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                         )}
                         <button
                           onClick={() => handleShowModelfile(model.name)}
-                          className="p-1 hover:bg-slate-700 rounded-lg transition text-slate-400 hover:text-white"
+                          className="p-1 hover:bg-slate-700 rounded-lg transition text-slate-400 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                           title="View Modelfile"
                           aria-label={`View Modelfile for ${model.name}`}
                         >
@@ -568,7 +568,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                         <button
                           onClick={() => handleDeleteModel(model.name)}
                           disabled={pendingActions[model.name] === 'deleting' || loading}
-                          className="p-1 hover:bg-slate-700 rounded-lg transition text-slate-400 hover:text-red-400"
+                          className="p-1 hover:bg-slate-700 rounded-lg transition text-slate-400 hover:text-red-400 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                           title="Delete from Ollama"
                           aria-label={`Delete ${model.name} from Ollama`}
                         >
@@ -604,7 +604,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                       <button
                         onClick={() => handleDiscardPartial(p.filename)}
                         disabled={discardingPartial === p.filename}
-                        className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-800 hover:bg-red-600 text-slate-300 hover:text-white text-xs font-bold rounded-lg transition disabled:opacity-50 shrink-0"
+                        className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-800 hover:bg-red-600 text-slate-300 hover:text-white text-xs font-bold rounded-lg transition disabled:opacity-50 shrink-0 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                         aria-label={`Discard interrupted download ${p.filename}`}
                       >
                         {discardingPartial === p.filename ? (
@@ -718,7 +718,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                       <button
                         onClick={() => handlePullModel(model.name)}
                         disabled={pendingActions[model.name] === 'downloading' || loading}
-                        className="inline-flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-blue-600 text-white rounded-xl text-xs font-bold transition group-hover:shadow-lg group-hover:shadow-blue-500/20"
+                        className="inline-flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-blue-600 text-white rounded-xl text-xs font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none group-hover:shadow-lg group-hover:shadow-blue-500/20"
                       >
                         {pendingActions[model.name] === 'downloading' ? (
                           <>
@@ -769,7 +769,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                     <button
                       onClick={() => handleDownloadHFModel(m.id)}
                       disabled={pendingActions[m.id] === 'downloading' || loading}
-                      className="inline-flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-blue-600 text-white rounded-xl text-xs font-bold transition group-hover:shadow-lg group-hover:shadow-blue-500/20"
+                      className="inline-flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-blue-600 text-white rounded-xl text-xs font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none group-hover:shadow-lg group-hover:shadow-blue-500/20"
                     >
                       {pendingActions[m.id] === 'downloading' ? (
                         <>
@@ -802,7 +802,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
           >
             <div className="flex items-center justify-between p-4 border-b border-slate-800">
               <h3 id="modelfile-modal-title" className="text-lg font-bold text-white">Modelfile</h3>
-              <button ref={modelfileCloseRef} onClick={() => setShowModelfile(null)} className="text-slate-400 hover:text-white" aria-label="Close">
+              <button ref={modelfileCloseRef} onClick={() => setShowModelfile(null)} className="text-slate-400 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none" aria-label="Close">
                 <X size={20} aria-hidden="true" />
               </button>
             </div>
@@ -812,10 +812,10 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
               </pre>
             </div>
             <div className="flex justify-end gap-2 p-4 border-t border-slate-800">
-              <button onClick={copyModelfile} className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700">
+              <button onClick={copyModelfile} className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none">
                 Copy to Clipboard
               </button>
-              <button onClick={() => setShowModelfile(null)} className="px-4 py-2 bg-slate-800 text-white rounded-lg font-medium hover:bg-slate-700">
+              <button onClick={() => setShowModelfile(null)} className="px-4 py-2 bg-slate-800 text-white rounded-lg font-medium hover:bg-slate-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none">
                 Close
               </button>
             </div>

--- a/ghostlink_gui_modern/src/components/WorkersTab.tsx
+++ b/ghostlink_gui_modern/src/components/WorkersTab.tsx
@@ -97,13 +97,13 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
                 onClick={() => { setShowAddForm(!showAddForm); setAddError(''); }}
                 aria-haspopup="true"
                 aria-expanded={showAddForm}
-                className="flex items-center gap-2 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-xs font-bold rounded-lg transition"
+                className="flex items-center gap-2 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-xs font-bold rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             >
                 <Plus size={14} aria-hidden="true" /> Add Worker
             </button>
             <button
                 onClick={async () => { const r = await api.discoverPeers(); if (r.success) refreshWorkers(); }}
-                className="flex items-center gap-2 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 text-white text-xs font-bold rounded-lg transition"
+                className="flex items-center gap-2 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 text-white text-xs font-bold rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                 title="Discover peers on network"
             >
                 <RefreshCw size={14} aria-hidden="true" /> Discover
@@ -111,7 +111,7 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
             <button
                 onClick={refreshWorkers}
                 aria-label="Refresh workers"
-                className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition"
+                className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             >
                 <RefreshCw size={18} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
             </button>
@@ -133,7 +133,7 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
                 placeholder="192.168.1.100"
                 name="host"
                 id="host"
-                className="w-full px-3 py-1.5 bg-slate-800 border border-slate-700 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500"
+                className="w-full px-3 py-1.5 bg-slate-800 border border-slate-700 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
               />
             </div>
             <div className="w-24">
@@ -145,12 +145,12 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
                 placeholder="8003"
                 name="port"
                 id="port"
-                className="w-full px-3 py-1.5 bg-slate-800 border border-slate-700 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500"
+                className="w-full px-3 py-1.5 bg-slate-800 border border-slate-700 rounded-lg text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
               />
             </div>
             <button
               onClick={handleAddWorker}
-              className="px-4 py-1.5 bg-green-600 hover:bg-green-500 text-white text-xs font-bold rounded-lg transition"
+              className="px-4 py-1.5 bg-green-600 hover:bg-green-500 text-white text-xs font-bold rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             >
               Connect
             </button>
@@ -222,7 +222,7 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
                             <div className="flex items-end justify-end">
                                 <button
                                   onClick={() => handleDisconnectWorker(worker.id, worker.host)}
-                                  className="p-2 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition"
+                                  className="p-2 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                                   title="Disconnect worker"
                                   aria-label={`Disconnect worker ${worker.host}`}
                                 >


### PR DESCRIPTION
Improve keyboard accessibility in Models and Workers tabs by introducing high-contrast focus rings for custom button and input control components. This allows keyboard-only and assistive-tech users to navigate easily on dark-theme UI dashboards.

---
*PR created automatically by Jules for task [2145211203260362911](https://jules.google.com/task/2145211203260362911) started by @rwilliamspbg-ops*