### PR TITLE
feat(inference): real tool calling, structured output, confirmation gate, and GPU offload fix

### DIFF
--- a/crates/ghost-link/src/inference_engine.rs
+++ b/crates/ghost-link/src/inference_engine.rs
@@ -66,22 +66,38 @@ impl InferenceEngine {
                 model_listing: true,
                 model_load: true,
                 model_unload: true,
-                structured_outputs: false,
-                tool_calls: false,
+                // Forwarded as Ollama's own `format` field (grammar-constrained
+                // decoding) - see run_ollama_chat.
+                structured_outputs: true,
+                // Ollama natively parses OpenAI-style function tools and
+                // returns `tool_calls` for templates that support it - see
+                // run_ollama_chat, which drives that protocol for real
+                // (not the native-engine TOOL_CALL: text shim).
+                tool_calls: true,
             },
             Self::Native => InferenceEngineCapabilities {
                 streaming: true,
                 model_listing: false,
                 model_load: true,
                 model_unload: true,
-                structured_outputs: false,
-                tool_calls: false,
+                // Forwarded as llama-server's `response_format` (grammar-
+                // constrained JSON-schema decoding) - see GuiChatRequest's
+                // `response_format` field and generate_with_llama_server.
+                structured_outputs: true,
+                // Wired via the model-agnostic TOOL_CALL: prompt shim in
+                // mcp::toolcall (see handle_gui_chat's native tool-calling
+                // loop) rather than a native OpenAI-style tools API.
+                tool_calls: true,
             },
             Self::Vllm => InferenceEngineCapabilities {
                 streaming: true,
                 model_listing: true,
                 model_load: true,
                 model_unload: false,
+                // Both forwarded to vLLM's OpenAI-compatible server as real
+                // `response_format`/`tools` request fields - see run_vllm_chat.
+                // (Previously claimed here but not actually implemented in
+                // VllmClient::generate, which never sent either field.)
                 structured_outputs: true,
                 tool_calls: true,
             },

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1486,6 +1486,8 @@ struct BackendState {
     vllm_client: vllm::VllmClient,
     ollama_available: Arc<tokio::sync::Mutex<bool>>,
     settings: RuntimeSettings,
+    mcp_registry: Arc<mcp::McpRegistry>,
+    pending_tool_calls: Arc<tokio::sync::Mutex<HashMap<String, PendingToolCall>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1552,8 +1554,6 @@ impl Default for RuntimeSettings {
         }
     }
 }
-
-struct ToolDispatcher;
 
 fn build_cluster_topology_json(cluster: &ClusterState) -> serde_json::Value {
     let nodes = cluster.nodes();
@@ -1663,37 +1663,1010 @@ fn build_inference_engines_json(active: InferenceEngine) -> serde_json::Value {
     })
 }
 
-impl ToolDispatcher {
-    fn dispatch(tool_name: &str, _args: &serde_json::Value) -> ToolResult {
-        match tool_name {
-            "calculator" => ToolResult {
+/// Converts resolved MCP tool schemas into the OpenAI-style function-tool
+/// JSON Ollama and vLLM both expect in their `tools` request field.
+fn mcp_tools_to_openai_json(tools: &[mcp::McpToolSchema]) -> Vec<serde_json::Value> {
+    tools
+        .iter()
+        .map(|tool| {
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.input_schema,
+                }
+            })
+        })
+        .collect()
+}
+
+/// Invokes a real MCP tool by name (matched against the caller's already
+/// slot-resolved `tools` catalog) and reports the outcome in the GUI's
+/// `ToolResult` shape — shared by every engine's tool-calling loop so
+/// "unknown tool" / "not connected" / actual-failure all render the same way
+/// regardless of whether the model called it via the native TOOL_CALL: shim
+/// or Ollama/vLLM's own OpenAI-style tool_calls.
+async fn invoke_mcp_tool(
+    mcp_registry: &mcp::McpRegistry,
+    tools: &[mcp::McpToolSchema],
+    tool_name: &str,
+    args: serde_json::Value,
+) -> ToolResult {
+    match tools.iter().find(|t| t.name == tool_name) {
+        Some(schema) => match mcp_registry
+            .call_tool(&schema.server, tool_name, args)
+            .await
+        {
+            Some(outcome) if outcome.success => ToolResult {
                 tool: tool_name.to_string(),
-                result: "42 (Calculated via Rust built-in tool)".to_string(),
+                result: outcome.result.to_string(),
                 success: true,
             },
-            "web_search" => ToolResult {
+            Some(outcome) => ToolResult {
                 tool: tool_name.to_string(),
-                result: "Ghostlink is a high-performance distributed LLM inference fabric."
-                    .to_string(),
+                result: outcome
+                    .error
+                    .unwrap_or_else(|| "tool call failed".to_string()),
+                success: false,
+            },
+            None => ToolResult {
+                tool: tool_name.to_string(),
+                result: "tool server is not connected".to_string(),
+                success: false,
+            },
+        },
+        None => ToolResult {
+            tool: tool_name.to_string(),
+            result: format!("unknown tool '{tool_name}'"),
+            success: false,
+        },
+    }
+}
+
+/// Stashes a paused tool call under a fresh request_id and returns the info
+/// the GUI needs to render its Approve/Deny prompt. The full `pending` value
+/// (with everything needed to resume) stays server-side in
+/// `BackendState::pending_tool_calls`, keyed by that same id.
+async fn stash_pending_tool_call(
+    store: &tokio::sync::Mutex<HashMap<String, PendingToolCall>>,
+    pending: PendingToolCall,
+) -> PendingToolCallInfo {
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let info = match &pending {
+        PendingToolCall::Native {
+            tool, server, args, ..
+        }
+        | PendingToolCall::Ollama {
+            tool, server, args, ..
+        }
+        | PendingToolCall::Vllm {
+            tool, server, args, ..
+        } => PendingToolCallInfo {
+            request_id: request_id.clone(),
+            tool: tool.clone(),
+            server: server.clone(),
+            args: args.clone(),
+        },
+    };
+    store.lock().await.insert(request_id, pending);
+    info
+}
+
+struct NativeToolLoopOutcome {
+    text: String,
+    real_inference: bool,
+    tokens: Option<u32>,
+    tokens_per_sec: Option<f32>,
+    latency_ms: Option<f32>,
+    tool_results: Vec<ToolResult>,
+}
+
+/// Either the loop finished (an answer, or an exhausted/errored turn), or it
+/// hit a `requires_confirmation` tool and paused - `pending` carries every
+/// last thing needed to resume the exact same loop later, once the user
+/// approves or denies the call, without redoing the generation that led here.
+enum NativeLoopStep {
+    Done(NativeToolLoopOutcome),
+    NeedsConfirmation(Box<PendingToolCall>),
+}
+
+/// Model-agnostic tool calling for the Native (llama-server) engine: injects
+/// `mcp::toolcall`'s TOOL_CALL: instructions into the prompt, and on each
+/// generation either returns the model's plain-text final answer or, if it
+/// asked for a tool, dispatches the call to the real connected MCP server and
+/// feeds the result back as an "Observation" before generating again — up to
+/// `mcp::toolcall::MAX_TOOL_ITERATIONS` round-trips. llama-server's
+/// `/v1/chat/completions` wraps whatever we send as a single "user" turn (see
+/// `generate_with_llama_server`), so the whole scratchpad is just plain text
+/// re-sent each iteration rather than a real multi-turn message array.
+///
+/// Takes its starting scratchpad/tool_results/iteration budget as parameters
+/// (rather than always starting empty) so `resume_native_tool_call` can drive
+/// the exact same loop body picking up right where a paused confirmation left
+/// off, instead of duplicating this logic.
+#[allow(clippy::too_many_arguments)]
+async fn native_tool_loop_core(
+    native_engine_client: &native_engine::NativeEngineClient,
+    mcp_registry: &mcp::McpRegistry,
+    model: &str,
+    native_engine: &str,
+    user_message: &str,
+    tool_instructions: &str,
+    tools: &[mcp::McpToolSchema],
+    exec_tokens: usize,
+    temp: f32,
+    top_p: f32,
+    top_k: usize,
+    penalty: f32,
+    mut scratchpad: String,
+    mut tool_results: Vec<ToolResult>,
+    mut iterations_left: usize,
+) -> NativeLoopStep {
+    while iterations_left > 0 {
+        iterations_left -= 1;
+        let prompt = format!("{tool_instructions}Question: {user_message}\n{scratchpad}");
+
+        let gen = match native_engine_client
+            .generate(
+                model,
+                &prompt,
+                exec_tokens,
+                temp,
+                top_p,
+                top_k,
+                penalty,
+                native_engine,
+                None,
+                false,
+                None,
+            )
+            .await
+        {
+            Ok(gen) => gen,
+            Err(err) => {
+                return NativeLoopStep::Done(NativeToolLoopOutcome {
+                    text: format!(
+                        "Ghostlink native fabric backend processed model '{model}' with {exec_tokens} estimated tokens. Native error: {err}"
+                    ),
+                    real_inference: false,
+                    tokens: None,
+                    tokens_per_sec: None,
+                    latency_ms: None,
+                    tool_results,
+                });
+            }
+        };
+
+        let tokens = gen
+            .tokens_generated
+            .or_else(|| Some((gen.text.split_whitespace().count() as u32).max(1)));
+
+        let Some(call) = mcp::toolcall::extract_tool_call(&gen.text) else {
+            // Plain-text answer with no tool call - the model is done.
+            return NativeLoopStep::Done(NativeToolLoopOutcome {
+                text: gen.text,
+                real_inference: gen.real_inference,
+                tokens,
+                tokens_per_sec: gen.tokens_per_sec,
+                latency_ms: gen.latency_ms,
+                tool_results,
+            });
+        };
+
+        if let Some(schema) = tools.iter().find(|t| t.name == call.tool) {
+            if mcp_registry.requires_confirmation(&schema.server).await {
+                return NativeLoopStep::NeedsConfirmation(Box::new(PendingToolCall::Native {
+                    model: model.to_string(),
+                    native_engine: native_engine.to_string(),
+                    tool_instructions: tool_instructions.to_string(),
+                    user_message: user_message.to_string(),
+                    scratchpad,
+                    tools: tools.to_vec(),
+                    exec_tokens,
+                    temp,
+                    top_p,
+                    top_k,
+                    penalty,
+                    iterations_left,
+                    tool: call.tool.clone(),
+                    server: schema.server.clone(),
+                    args: call.args.clone(),
+                    last_model_text: gen.text.clone(),
+                    tool_results_so_far: tool_results,
+                }));
+            }
+        }
+
+        let outcome = invoke_mcp_tool(mcp_registry, tools, &call.tool, call.args.clone()).await;
+        let observation_value = if outcome.success {
+            serde_json::from_str(&outcome.result)
+                .unwrap_or_else(|_| serde_json::json!({ "content": outcome.result }))
+        } else {
+            serde_json::json!({ "error": outcome.result })
+        };
+        let observation = mcp::toolcall::format_observation(&call.tool, &observation_value);
+        tool_results.push(outcome);
+
+        scratchpad.push_str(&format!(
+            "\nAssistant: {}\n{}",
+            gen.text.trim(),
+            observation
+        ));
+    }
+
+    // MAX_TOOL_ITERATIONS exhausted without a plain-text final answer - surface
+    // whatever the model last said rather than looping forever.
+    NativeLoopStep::Done(NativeToolLoopOutcome {
+        text: format!(
+            "{}\n\n(stopped after {} tool round-trips without a final answer)",
+            scratchpad.trim(),
+            mcp::toolcall::MAX_TOOL_ITERATIONS
+        ),
+        real_inference: true,
+        tokens: None,
+        tokens_per_sec: None,
+        latency_ms: None,
+        tool_results,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_native_tool_loop(
+    native_engine_client: &native_engine::NativeEngineClient,
+    mcp_registry: &mcp::McpRegistry,
+    model: &str,
+    user_message: &str,
+    exec_tokens: usize,
+    temp: f32,
+    top_p: f32,
+    top_k: usize,
+    penalty: f32,
+    native_engine: &str,
+    tools: &[mcp::McpToolSchema],
+) -> NativeLoopStep {
+    let tool_instructions = mcp::toolcall::build_tool_instructions(tools);
+    native_tool_loop_core(
+        native_engine_client,
+        mcp_registry,
+        model,
+        native_engine,
+        user_message,
+        &tool_instructions,
+        tools,
+        exec_tokens,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        String::new(),
+        Vec::new(),
+        mcp::toolcall::MAX_TOOL_ITERATIONS,
+    )
+    .await
+}
+
+/// Resumes a paused `PendingToolCall::Native` after the user approves or
+/// denies it: builds the observation (real tool result, or a denial per
+/// `mcp::toolcall::format_denial`), folds it into the saved scratchpad, and
+/// re-enters `native_tool_loop_core` with the remaining iteration budget -
+/// which may itself pause again on a further confirmation-gated call.
+async fn resume_native_tool_loop(
+    native_engine_client: &native_engine::NativeEngineClient,
+    mcp_registry: &mcp::McpRegistry,
+    pending: PendingToolCall,
+    approve: bool,
+) -> NativeLoopStep {
+    let PendingToolCall::Native {
+        model,
+        native_engine,
+        tool_instructions,
+        user_message,
+        mut scratchpad,
+        tools,
+        exec_tokens,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        iterations_left,
+        tool,
+        server,
+        args,
+        last_model_text,
+        mut tool_results_so_far,
+    } = pending
+    else {
+        unreachable!("resume_native_tool_loop called with a non-Native PendingToolCall");
+    };
+
+    let observation = if approve {
+        let outcome = mcp_registry.call_tool(&server, &tool, args).await;
+        let result = match outcome {
+            Some(outcome) if outcome.success => ToolResult {
+                tool: tool.clone(),
+                result: outcome.result.to_string(),
                 success: true,
             },
-            "terminal" => ToolResult {
-                tool: tool_name.to_string(),
-                result: "System: All nodes operational. Kernel bypass active.".to_string(),
-                success: true,
+            Some(outcome) => ToolResult {
+                tool: tool.clone(),
+                result: outcome
+                    .error
+                    .unwrap_or_else(|| "tool call failed".to_string()),
+                success: false,
             },
-            "code_execution" => ToolResult {
-                tool: tool_name.to_string(),
-                result: "Output: Processed tensor batch in 2.4ms".to_string(),
-                success: true,
+            None => ToolResult {
+                tool: tool.clone(),
+                result: "tool server is not connected".to_string(),
+                success: false,
             },
-            _ => ToolResult {
-                tool: tool_name.to_string(),
-                result: format!("Tool '{}' executed successfully.", tool_name),
-                success: true,
-            },
+        };
+        let observation_value = if result.success {
+            serde_json::from_str(&result.result)
+                .unwrap_or_else(|_| serde_json::json!({ "content": result.result }))
+        } else {
+            serde_json::json!({ "error": result.result })
+        };
+        let observation = mcp::toolcall::format_observation(&tool, &observation_value);
+        tool_results_so_far.push(result);
+        observation
+    } else {
+        tool_results_so_far.push(ToolResult {
+            tool: tool.clone(),
+            result: "the user denied permission to run this tool".to_string(),
+            success: false,
+        });
+        mcp::toolcall::format_denial(&tool)
+    };
+
+    scratchpad.push_str(&format!(
+        "\nAssistant: {}\n{}",
+        last_model_text.trim(),
+        observation
+    ));
+
+    native_tool_loop_core(
+        native_engine_client,
+        mcp_registry,
+        &model,
+        &native_engine,
+        &user_message,
+        &tool_instructions,
+        &tools,
+        exec_tokens,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        scratchpad,
+        tool_results_so_far,
+        iterations_left,
+    )
+    .await
+}
+
+struct OllamaChatOutcome {
+    text: String,
+    tool_results: Vec<ToolResult>,
+}
+
+/// `GuiChatRequest.response_format` is documented (and Native/vLLM both
+/// expect it) as OpenAI's `{"type": "json_schema", "json_schema": {"schema":
+/// {...}}}` / `{"type": "json_object"}` shape. Ollama's own `format` field
+/// wants the raw schema directly, or the literal string `"json"` - confirmed
+/// live: sending the OpenAI wrapper as-is produced no constraint at all,
+/// while unwrapping it to the bare schema produced correct structured JSON.
+/// Unwrapping here lets callers send one consistent shape regardless of
+/// which engine is active.
+fn normalize_response_format_for_ollama(value: serde_json::Value) -> serde_json::Value {
+    let Some(obj) = value.as_object() else {
+        return value;
+    };
+    match obj.get("type").and_then(|t| t.as_str()) {
+        Some("json_schema") => obj
+            .get("json_schema")
+            .and_then(|s| s.get("schema"))
+            .cloned()
+            .unwrap_or(value.clone()),
+        Some("json_object") => serde_json::Value::String("json".to_string()),
+        _ => value.clone(),
+    }
+}
+
+enum OllamaLoopStep {
+    Done(OllamaChatOutcome),
+    NeedsConfirmation(Box<PendingToolCall>),
+}
+
+/// Parses one Ollama-shaped raw tool call (`{"function": {"name", "arguments"}}`)
+/// into a (name, args) pair. Ollama sends already-parsed argument objects
+/// (unlike OpenAI/vLLM's JSON-encoded string) - tolerates a string form too in
+/// case a particular model template emits one anyway.
+fn parse_ollama_tool_call(call: &serde_json::Value) -> (String, serde_json::Value) {
+    let name = call
+        .get("function")
+        .and_then(|f| f.get("name"))
+        .and_then(|n| n.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let raw_args = call
+        .get("function")
+        .and_then(|f| f.get("arguments"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let args = match raw_args {
+        serde_json::Value::String(s) => serde_json::from_str(&s).unwrap_or(serde_json::Value::Null),
+        other => other,
+    };
+    (name, args)
+}
+
+/// Works through a batch of tool calls Ollama requested in one turn, in
+/// order, appending each real result as a "tool" role message. Stops and
+/// returns the confirmation-gated call (plus whatever calls in the batch
+/// hadn't been reached yet) the moment one needs approval, rather than
+/// silently skipping the gate for later calls in the same batch.
+async fn ollama_process_call_batch(
+    mcp_registry: &mcp::McpRegistry,
+    tools: &[mcp::McpToolSchema],
+    calls: Vec<serde_json::Value>,
+    messages: &mut Vec<ollama::ChatMessage>,
+    tool_results: &mut Vec<ToolResult>,
+) -> Option<(String, String, serde_json::Value, Vec<serde_json::Value>)> {
+    let mut iter = calls.into_iter();
+    while let Some(call) = iter.next() {
+        let (name, args) = parse_ollama_tool_call(&call);
+        if let Some(schema) = tools.iter().find(|t| t.name == name) {
+            if mcp_registry.requires_confirmation(&schema.server).await {
+                return Some((name, schema.server.clone(), args, iter.collect()));
+            }
+        }
+        let outcome = invoke_mcp_tool(mcp_registry, tools, &name, args).await;
+        messages.push(ollama::ChatMessage {
+            role: "tool".to_string(),
+            content: outcome.result.clone(),
+            tool_calls: None,
+        });
+        tool_results.push(outcome);
+    }
+    None
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn ollama_chat_loop_core(
+    ollama_client: &ollama::OllamaClient,
+    mcp_registry: &mcp::McpRegistry,
+    model: &str,
+    tools: &[mcp::McpToolSchema],
+    openai_tools: &Option<Vec<serde_json::Value>>,
+    response_format: &Option<serde_json::Value>,
+    temp: f32,
+    top_p: f32,
+    top_k: usize,
+    penalty: f32,
+    max_tokens: usize,
+    mut messages: Vec<ollama::ChatMessage>,
+    mut tool_results: Vec<ToolResult>,
+    mut iterations_left: usize,
+) -> Result<OllamaLoopStep, String> {
+    while iterations_left > 0 {
+        iterations_left -= 1;
+        let response = ollama_client
+            .chat(
+                model,
+                &messages,
+                Some(temp),
+                Some(top_p),
+                Some(top_k),
+                Some(penalty),
+                Some(max_tokens),
+                openai_tools.clone(),
+                response_format.clone(),
+            )
+            .await
+            .map_err(|err| err.to_string())?;
+
+        let requested_calls = response.message.tool_calls.clone().unwrap_or_default();
+        if requested_calls.is_empty() {
+            return Ok(OllamaLoopStep::Done(OllamaChatOutcome {
+                text: response.message.content,
+                tool_results,
+            }));
+        }
+
+        // Ollama's protocol expects the assistant's own tool_calls turn echoed
+        // back into history before any "tool" role replies, same as OpenAI's.
+        messages.push(response.message.clone());
+
+        if let Some((tool, server, args, remaining_calls)) = ollama_process_call_batch(
+            mcp_registry,
+            tools,
+            requested_calls,
+            &mut messages,
+            &mut tool_results,
+        )
+        .await
+        {
+            return Ok(OllamaLoopStep::NeedsConfirmation(Box::new(
+                PendingToolCall::Ollama {
+                    model: model.to_string(),
+                    messages,
+                    tools: tools.to_vec(),
+                    temp,
+                    top_p,
+                    top_k,
+                    penalty,
+                    max_tokens,
+                    response_format: response_format.clone(),
+                    iterations_left,
+                    tool,
+                    server,
+                    args,
+                    tool_results_so_far: tool_results,
+                    remaining_calls,
+                },
+            )));
         }
     }
+
+    Ok(OllamaLoopStep::Done(OllamaChatOutcome {
+        text: format!(
+            "(stopped after {} tool round-trips without a final answer)",
+            mcp::toolcall::MAX_TOOL_ITERATIONS
+        ),
+        tool_results,
+    }))
+}
+
+/// Real tool calling for Ollama: unlike Native's text-scratchpad TOOL_CALL:
+/// shim, Ollama's own `/api/chat` natively parses OpenAI-style function
+/// tools and returns `tool_calls` on the message when the model's template
+/// supports it — so this drives the actual assistant/tool message protocol
+/// instead of reimplementing ReAct-over-plain-text.
+#[allow(clippy::too_many_arguments)]
+async fn run_ollama_chat(
+    ollama_client: &ollama::OllamaClient,
+    mcp_registry: &mcp::McpRegistry,
+    model: &str,
+    user_message: &str,
+    temp: f32,
+    top_p: f32,
+    top_k: usize,
+    penalty: f32,
+    max_tokens: usize,
+    tools: &[mcp::McpToolSchema],
+    response_format: Option<serde_json::Value>,
+) -> Result<OllamaLoopStep, String> {
+    let messages = vec![ollama::ChatMessage {
+        role: "user".to_string(),
+        content: user_message.to_string(),
+        tool_calls: None,
+    }];
+
+    let openai_tools = if tools.is_empty() {
+        None
+    } else {
+        Some(mcp_tools_to_openai_json(tools))
+    };
+
+    let response_format = response_format.map(normalize_response_format_for_ollama);
+
+    ollama_chat_loop_core(
+        ollama_client,
+        mcp_registry,
+        model,
+        tools,
+        &openai_tools,
+        &response_format,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        max_tokens,
+        messages,
+        Vec::new(),
+        mcp::toolcall::MAX_TOOL_ITERATIONS,
+    )
+    .await
+}
+
+/// Resumes a paused `PendingToolCall::Ollama` after approve/deny: appends the
+/// real result (or a denial) as a "tool" role message, finishes working
+/// through any other calls left in that same batch, then re-enters
+/// `ollama_chat_loop_core` with the remaining iteration budget.
+async fn resume_ollama_chat(
+    ollama_client: &ollama::OllamaClient,
+    mcp_registry: &mcp::McpRegistry,
+    pending: PendingToolCall,
+    approve: bool,
+) -> Result<OllamaLoopStep, String> {
+    let PendingToolCall::Ollama {
+        model,
+        mut messages,
+        tools,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        max_tokens,
+        response_format,
+        iterations_left,
+        tool,
+        server: _,
+        args,
+        mut tool_results_so_far,
+        remaining_calls,
+    } = pending
+    else {
+        unreachable!("resume_ollama_chat called with a non-Ollama PendingToolCall");
+    };
+
+    let outcome = if approve {
+        invoke_mcp_tool(mcp_registry, &tools, &tool, args).await
+    } else {
+        ToolResult {
+            tool: tool.clone(),
+            result: "the user denied permission to run this tool".to_string(),
+            success: false,
+        }
+    };
+    messages.push(ollama::ChatMessage {
+        role: "tool".to_string(),
+        content: outcome.result.clone(),
+        tool_calls: None,
+    });
+    tool_results_so_far.push(outcome);
+
+    if let Some((next_tool, next_server, next_args, next_remaining)) = ollama_process_call_batch(
+        mcp_registry,
+        &tools,
+        remaining_calls,
+        &mut messages,
+        &mut tool_results_so_far,
+    )
+    .await
+    {
+        return Ok(OllamaLoopStep::NeedsConfirmation(Box::new(
+            PendingToolCall::Ollama {
+                model,
+                messages,
+                tools,
+                temp,
+                top_p,
+                top_k,
+                penalty,
+                max_tokens,
+                response_format,
+                iterations_left,
+                tool: next_tool,
+                server: next_server,
+                args: next_args,
+                tool_results_so_far,
+                remaining_calls: next_remaining,
+            },
+        )));
+    }
+
+    let openai_tools = if tools.is_empty() {
+        None
+    } else {
+        Some(mcp_tools_to_openai_json(&tools))
+    };
+
+    ollama_chat_loop_core(
+        ollama_client,
+        mcp_registry,
+        &model,
+        &tools,
+        &openai_tools,
+        &response_format,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        max_tokens,
+        messages,
+        tool_results_so_far,
+        iterations_left,
+    )
+    .await
+}
+
+struct VllmChatOutcome {
+    text: String,
+    tool_results: Vec<ToolResult>,
+}
+
+enum VllmLoopStep {
+    Done(VllmChatOutcome),
+    NeedsConfirmation(Box<PendingToolCall>),
+}
+
+/// Works through vLLM tool calls requested in one turn, in order, appending
+/// each real result as a `tool_call_id`-matched "tool" role message. Stops
+/// and returns the confirmation-gated call (plus whichever calls in the
+/// batch hadn't been reached yet) the moment one needs approval.
+async fn vllm_process_call_batch(
+    mcp_registry: &mcp::McpRegistry,
+    tools: &[mcp::McpToolSchema],
+    calls: Vec<vllm::VllmToolCall>,
+    messages: &mut Vec<serde_json::Value>,
+    tool_results: &mut Vec<ToolResult>,
+) -> Option<(
+    String,
+    String,
+    serde_json::Value,
+    Option<String>,
+    Vec<vllm::VllmToolCall>,
+)> {
+    let mut iter = calls.into_iter();
+    while let Some(call) = iter.next() {
+        let args: serde_json::Value =
+            serde_json::from_str(&call.function.arguments).unwrap_or(serde_json::Value::Null);
+        if let Some(schema) = tools.iter().find(|t| t.name == call.function.name) {
+            if mcp_registry.requires_confirmation(&schema.server).await {
+                return Some((
+                    call.function.name,
+                    schema.server.clone(),
+                    args,
+                    call.id,
+                    iter.collect(),
+                ));
+            }
+        }
+        let outcome = invoke_mcp_tool(mcp_registry, tools, &call.function.name, args).await;
+        messages.push(serde_json::json!({
+            "role": "tool",
+            "tool_call_id": call.id,
+            "content": outcome.result.clone(),
+        }));
+        tool_results.push(outcome);
+    }
+    None
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn vllm_chat_loop_core(
+    vllm_client: &vllm::VllmClient,
+    mcp_registry: &mcp::McpRegistry,
+    model: &str,
+    tools: &[mcp::McpToolSchema],
+    openai_tools: &Option<Vec<serde_json::Value>>,
+    response_format: &Option<serde_json::Value>,
+    temp: f32,
+    top_p: f32,
+    top_k: usize,
+    penalty: f32,
+    max_tokens: usize,
+    mut messages: Vec<serde_json::Value>,
+    mut tool_results: Vec<ToolResult>,
+    mut iterations_left: usize,
+) -> Result<VllmLoopStep, String> {
+    while iterations_left > 0 {
+        iterations_left -= 1;
+        let result = vllm_client
+            .chat(
+                model,
+                messages.clone(),
+                temp,
+                top_p,
+                top_k,
+                penalty,
+                max_tokens,
+                openai_tools.clone(),
+                response_format.clone(),
+            )
+            .await
+            .map_err(|err| err.to_string())?;
+
+        if result.tool_calls.is_empty() {
+            return Ok(VllmLoopStep::Done(VllmChatOutcome {
+                text: result.content,
+                tool_results,
+            }));
+        }
+
+        // Echo the assistant's own tool_calls turn back into history before
+        // any "tool" role replies, per the OpenAI protocol vLLM follows.
+        messages.push(serde_json::json!({
+            "role": "assistant",
+            "content": result.content,
+            "tool_calls": result.tool_calls.iter().map(|c| serde_json::json!({
+                "id": c.id,
+                "type": "function",
+                "function": { "name": c.function.name, "arguments": c.function.arguments }
+            })).collect::<Vec<_>>(),
+        }));
+
+        if let Some((tool, server, args, call_id, remaining_calls)) = vllm_process_call_batch(
+            mcp_registry,
+            tools,
+            result.tool_calls,
+            &mut messages,
+            &mut tool_results,
+        )
+        .await
+        {
+            return Ok(VllmLoopStep::NeedsConfirmation(Box::new(
+                PendingToolCall::Vllm {
+                    model: model.to_string(),
+                    messages,
+                    tools: tools.to_vec(),
+                    temp,
+                    top_p,
+                    top_k,
+                    penalty,
+                    max_tokens,
+                    response_format: response_format.clone(),
+                    iterations_left,
+                    tool,
+                    server,
+                    args,
+                    call_id,
+                    tool_results_so_far: tool_results,
+                    remaining_calls,
+                },
+            )));
+        }
+    }
+
+    Ok(VllmLoopStep::Done(VllmChatOutcome {
+        text: format!(
+            "(stopped after {} tool round-trips without a final answer)",
+            mcp::toolcall::MAX_TOOL_ITERATIONS
+        ),
+        tool_results,
+    }))
+}
+
+/// Real tool calling for vLLM: its OpenAI-compatible server natively parses
+/// `tools`/`tool_choice` and returns `tool_calls` on the assistant message,
+/// same protocol shape as OpenAI itself (unlike Ollama, replies need a
+/// matching `tool_call_id` per call).
+#[allow(clippy::too_many_arguments)]
+async fn run_vllm_chat(
+    vllm_client: &vllm::VllmClient,
+    mcp_registry: &mcp::McpRegistry,
+    model: &str,
+    user_message: &str,
+    temp: f32,
+    top_p: f32,
+    top_k: usize,
+    penalty: f32,
+    max_tokens: usize,
+    tools: &[mcp::McpToolSchema],
+    response_format: Option<serde_json::Value>,
+) -> Result<VllmLoopStep, String> {
+    let messages = vec![serde_json::json!({ "role": "user", "content": user_message })];
+
+    let openai_tools = if tools.is_empty() {
+        None
+    } else {
+        Some(mcp_tools_to_openai_json(tools))
+    };
+
+    vllm_chat_loop_core(
+        vllm_client,
+        mcp_registry,
+        model,
+        tools,
+        &openai_tools,
+        &response_format,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        max_tokens,
+        messages,
+        Vec::new(),
+        mcp::toolcall::MAX_TOOL_ITERATIONS,
+    )
+    .await
+}
+
+/// Resumes a paused `PendingToolCall::Vllm` after approve/deny: appends the
+/// real result (or a denial) as a `tool_call_id`-matched "tool" role message,
+/// finishes any other calls left in that batch, then re-enters
+/// `vllm_chat_loop_core` with the remaining iteration budget.
+async fn resume_vllm_chat(
+    vllm_client: &vllm::VllmClient,
+    mcp_registry: &mcp::McpRegistry,
+    pending: PendingToolCall,
+    approve: bool,
+) -> Result<VllmLoopStep, String> {
+    let PendingToolCall::Vllm {
+        model,
+        mut messages,
+        tools,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        max_tokens,
+        response_format,
+        iterations_left,
+        tool,
+        args,
+        call_id,
+        mut tool_results_so_far,
+        remaining_calls,
+        ..
+    } = pending
+    else {
+        unreachable!("resume_vllm_chat called with a non-Vllm PendingToolCall");
+    };
+
+    let outcome = if approve {
+        invoke_mcp_tool(mcp_registry, &tools, &tool, args).await
+    } else {
+        ToolResult {
+            tool: tool.clone(),
+            result: "the user denied permission to run this tool".to_string(),
+            success: false,
+        }
+    };
+    messages.push(serde_json::json!({
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": outcome.result.clone(),
+    }));
+    tool_results_so_far.push(outcome);
+
+    if let Some((next_tool, next_server, next_args, next_call_id, next_remaining)) =
+        vllm_process_call_batch(
+            mcp_registry,
+            &tools,
+            remaining_calls,
+            &mut messages,
+            &mut tool_results_so_far,
+        )
+        .await
+    {
+        return Ok(VllmLoopStep::NeedsConfirmation(Box::new(
+            PendingToolCall::Vllm {
+                model,
+                messages,
+                tools,
+                temp,
+                top_p,
+                top_k,
+                penalty,
+                max_tokens,
+                response_format,
+                iterations_left,
+                tool: next_tool,
+                server: next_server,
+                args: next_args,
+                call_id: next_call_id,
+                tool_results_so_far,
+                remaining_calls: next_remaining,
+            },
+        )));
+    }
+
+    let openai_tools = if tools.is_empty() {
+        None
+    } else {
+        Some(mcp_tools_to_openai_json(&tools))
+    };
+
+    vllm_chat_loop_core(
+        vllm_client,
+        mcp_registry,
+        &model,
+        &tools,
+        &openai_tools,
+        &response_format,
+        temp,
+        top_p,
+        top_k,
+        penalty,
+        max_tokens,
+        messages,
+        tool_results_so_far,
+        iterations_left,
+    )
+    .await
 }
 
 fn models_path() -> PathBuf {
@@ -1891,7 +2864,19 @@ struct GuiChatRequest {
     stream: Option<bool>,
     #[allow(dead_code)]
     mcp: Option<serde_json::Value>,
+    /// OpenAI-style `response_format` (e.g. `{"type": "json_schema", "json_schema": {...}}`),
+    /// forwarded to llama-server for the Native engine — see `run_native_tool_loop`'s
+    /// sibling plain-generation path in `handle_gui_chat`.
+    #[serde(default)]
+    response_format: Option<serde_json::Value>,
 }
+
+#[derive(Debug, Deserialize)]
+struct ToolConfirmRequest {
+    request_id: String,
+    approve: bool,
+}
+
 #[derive(Debug, Deserialize)]
 struct ModelLoadRequest {
     model: String,
@@ -2001,6 +2986,85 @@ struct ToolResult {
     tool: String,
     result: String,
     success: bool,
+}
+
+/// Resumable state for a tool call that hit a `requires_confirmation` MCP
+/// server (terminal, code_execution, ...) and paused mid-turn instead of
+/// auto-executing. Keyed by request_id in `BackendState::pending_tool_calls`
+/// and consumed by `POST /api/inference/chat/tool-confirm`. Each engine
+/// carries whatever it needs to resume its own protocol: Native's flat
+/// text scratchpad, Ollama/vLLM's structured message history.
+#[derive(Debug)]
+enum PendingToolCall {
+    Native {
+        model: String,
+        native_engine: String,
+        tool_instructions: String,
+        user_message: String,
+        scratchpad: String,
+        tools: Vec<mcp::McpToolSchema>,
+        exec_tokens: usize,
+        temp: f32,
+        top_p: f32,
+        top_k: usize,
+        penalty: f32,
+        iterations_left: usize,
+        tool: String,
+        server: String,
+        args: serde_json::Value,
+        last_model_text: String,
+        tool_results_so_far: Vec<ToolResult>,
+    },
+    Ollama {
+        model: String,
+        messages: Vec<ollama::ChatMessage>,
+        tools: Vec<mcp::McpToolSchema>,
+        temp: f32,
+        top_p: f32,
+        top_k: usize,
+        penalty: f32,
+        max_tokens: usize,
+        response_format: Option<serde_json::Value>,
+        iterations_left: usize,
+        tool: String,
+        server: String,
+        args: serde_json::Value,
+        tool_results_so_far: Vec<ToolResult>,
+        /// A single turn can request several tool calls at once - these are
+        /// the ones still unprocessed after the one awaiting confirmation, so
+        /// resume can keep working through the same batch in order instead of
+        /// dropping them.
+        remaining_calls: Vec<serde_json::Value>,
+    },
+    Vllm {
+        model: String,
+        messages: Vec<serde_json::Value>,
+        tools: Vec<mcp::McpToolSchema>,
+        temp: f32,
+        top_p: f32,
+        top_k: usize,
+        penalty: f32,
+        max_tokens: usize,
+        response_format: Option<serde_json::Value>,
+        iterations_left: usize,
+        tool: String,
+        server: String,
+        args: serde_json::Value,
+        call_id: Option<String>,
+        tool_results_so_far: Vec<ToolResult>,
+        remaining_calls: Vec<vllm::VllmToolCall>,
+    },
+}
+
+/// Info about a paused tool call surfaced to the GUI so it can render the
+/// "Approve / Deny" prompt — mirrors the frontend's `PendingToolCall` type
+/// in `store.ts` exactly (`request_id`/`tool`/`server`/`args`).
+#[derive(Serialize)]
+struct PendingToolCallInfo {
+    request_id: String,
+    tool: String,
+    server: String,
+    args: serde_json::Value,
 }
 
 fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
@@ -2206,6 +3270,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     &settings.native_engine,
                     None,
                     false,
+                    None,
                 )
                 .await
             {
@@ -3340,6 +4405,19 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         Json(build_inference_engines_json(backend.inference_backend))
     }
 
+    async fn handle_mcp_servers(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+        match registry.list_all_servers().await {
+            Ok(servers) => Json(serde_json::json!({ "servers": servers })),
+            Err(err) => Json(serde_json::json!({ "servers": [], "error": err })),
+        }
+    }
+
     async fn handle_gui_ollama_health(
         State(state): State<Arc<Mutex<BackendState>>>,
     ) -> Json<serde_json::Value> {
@@ -3727,6 +4805,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 req.repeat_penalty,
                 req.max_tokens,
                 None,
+                None,
             )
             .await
         {
@@ -3743,21 +4822,22 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     ) -> axum::response::Response {
         let started = Instant::now();
 
-        let mut tool_results = Vec::new();
-        // Performance optimization: avoid cloning potentially large MCP payloads
-        // and dispatch tools without async-await state machine overhead.
-        // Expected impact: lower per-request CPU and latency for tool-heavy chat calls.
-        let empty_tool_args = serde_json::Value::Null;
-        if let Some(mcp) = req.mcp.as_ref() {
-            if let Some(tools) = mcp.get("tools").and_then(|t| t.as_array()) {
-                tool_results = Vec::with_capacity(tools.len());
-                for tool_val in tools {
-                    if let Some(tool_name) = tool_val.as_str() {
-                        tool_results.push(ToolDispatcher::dispatch(tool_name, &empty_tool_args));
-                    }
-                }
-            }
-        }
+        // Legacy chat "tool slot" names the GUI's tool checkboxes send (calculator,
+        // file_operations, ...) - resolved against real MCP servers below, then
+        // dispatched via whichever protocol the active engine actually speaks
+        // (native TOOL_CALL: prompt shim, Ollama/vLLM's own OpenAI-style tools).
+        let enabled_tool_slots: Vec<String> = req
+            .mcp
+            .as_ref()
+            .and_then(|mcp| mcp.get("tools"))
+            .and_then(|t| t.as_array())
+            .map(|tools| {
+                tools
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let (
             current_model,
@@ -3768,6 +4848,8 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             native_engine_client,
             vllm_client,
             settings,
+            mcp_registry,
+            pending_tool_calls,
         ) = {
             let backend = lock_state(&state);
             let inference_backend = InferenceEngine::parse(&backend.settings.inference_backend);
@@ -3780,8 +4862,23 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 backend.native_engine_client.clone(),
                 backend.vllm_client.clone(),
                 backend.settings.clone(),
+                Arc::clone(&backend.mcp_registry),
+                Arc::clone(&backend.pending_tool_calls),
             )
         };
+
+        // Real MCP-backed tools: resolve each enabled slot to its connected
+        // server, then to that server's actual tool schemas. Confirmation-
+        // gated servers (terminal, code_execution, ...) are included here too
+        // — the gate is enforced at invocation time (see invoke_mcp_tool's
+        // callers pausing via PendingToolCall), not by hiding the tool from
+        // the model entirely.
+        let mut enabled_tools: Vec<mcp::McpToolSchema> = Vec::new();
+        for slot in &enabled_tool_slots {
+            if let Some(server_name) = mcp_registry.server_for_slot(slot).await {
+                enabled_tools.extend(mcp_registry.tool_schemas_for_server(&server_name).await);
+            }
+        }
 
         let token_estimate = req.message.split_whitespace().count().clamp(1, 1024);
         let temp = req.temperature.unwrap_or(settings.temperature);
@@ -3800,6 +4897,8 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         let mut gen_tokens: Option<u32> = None;
         let mut gen_tps: Option<f32> = None;
         let mut gen_latency_ms: Option<f32> = None;
+        let mut tool_results: Vec<ToolResult> = Vec::new();
+        let mut pending_tool_call: Option<PendingToolCallInfo> = None;
 
         let (response_text, real_inference, backend_used) = match inference_backend {
             InferenceEngine::Ollama => {
@@ -3836,8 +4935,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     Ok(available_models) => {
                         let effective_model = resolve_model(&current_model, &available_models);
                         if let Some(model_name) = effective_model {
-                            match ollama_client
-                                .generate(
+                            if !enabled_tools.is_empty() || req.response_format.is_some() {
+                                match run_ollama_chat(
+                                    &ollama_client,
+                                    &mcp_registry,
                                     &model_name,
                                     &req.message,
                                     temp,
@@ -3845,25 +4946,72 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                                     top_k,
                                     penalty,
                                     exec_tokens,
+                                    &enabled_tools,
+                                    req.response_format.clone(),
                                 )
                                 .await
-                            {
-                                Ok(text) => {
-                                    if model_name != current_model {
-                                        let mut backend = lock_state(&state);
-                                        backend.current_model = model_name;
+                                {
+                                    Ok(OllamaLoopStep::Done(outcome)) => {
+                                        if model_name != current_model {
+                                            let mut backend = lock_state(&state);
+                                            backend.current_model = model_name;
+                                        }
+                                        let text = outcome.text.trim().to_string();
+                                        gen_tokens = Some(
+                                            (text.split_whitespace().count() as u32).max(1),
+                                        );
+                                        tool_results = outcome.tool_results;
+                                        (text, true, InferenceEngine::Ollama.as_str())
                                     }
-                                    let text = text.trim().to_string();
-                                    gen_tokens =
-                                        Some((text.split_whitespace().count() as u32).max(1));
-                                    (text, true, InferenceEngine::Ollama.as_str())
+                                    Ok(OllamaLoopStep::NeedsConfirmation(pending)) => {
+                                        if model_name != current_model {
+                                            let mut backend = lock_state(&state);
+                                            backend.current_model = model_name;
+                                        }
+                                        pending_tool_call = Some(
+                                            stash_pending_tool_call(&pending_tool_calls, *pending)
+                                                .await,
+                                        );
+                                        (String::new(), true, InferenceEngine::Ollama.as_str())
+                                    }
+                                    Err(err) => {
+                                        let fallback = format!(
+                                            "Ollama chat failed for model '{}': {}",
+                                            model_name, err
+                                        );
+                                        (fallback, false, InferenceEngine::Ollama.as_str())
+                                    }
                                 }
-                                Err(err) => {
-                                    let fallback = format!(
-                                        "Ollama generate failed for model '{}': {}",
-                                        model_name, err
-                                    );
-                                    (fallback, false, InferenceEngine::Ollama.as_str())
+                            } else {
+                                match ollama_client
+                                    .generate(
+                                        &model_name,
+                                        &req.message,
+                                        temp,
+                                        top_p,
+                                        top_k,
+                                        penalty,
+                                        exec_tokens,
+                                    )
+                                    .await
+                                {
+                                    Ok(text) => {
+                                        if model_name != current_model {
+                                            let mut backend = lock_state(&state);
+                                            backend.current_model = model_name;
+                                        }
+                                        let text = text.trim().to_string();
+                                        gen_tokens =
+                                            Some((text.split_whitespace().count() as u32).max(1));
+                                        (text, true, InferenceEngine::Ollama.as_str())
+                                    }
+                                    Err(err) => {
+                                        let fallback = format!(
+                                            "Ollama generate failed for model '{}': {}",
+                                            model_name, err
+                                        );
+                                        (fallback, false, InferenceEngine::Ollama.as_str())
+                                    }
                                 }
                             }
                         } else {
@@ -3894,6 +5042,40 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     }
                 }
             }
+            InferenceEngine::Native if !enabled_tools.is_empty() => {
+                let step = run_native_tool_loop(
+                    &native_engine_client,
+                    &mcp_registry,
+                    &current_model,
+                    &req.message,
+                    exec_tokens,
+                    temp,
+                    top_p,
+                    top_k,
+                    penalty,
+                    &settings.native_engine,
+                    &enabled_tools,
+                )
+                .await;
+                match step {
+                    NativeLoopStep::Done(outcome) => {
+                        gen_tokens = outcome.tokens;
+                        gen_tps = outcome.tokens_per_sec;
+                        gen_latency_ms = outcome.latency_ms;
+                        tool_results = outcome.tool_results;
+                        (
+                            outcome.text,
+                            outcome.real_inference,
+                            InferenceEngine::Native.as_str(),
+                        )
+                    }
+                    NativeLoopStep::NeedsConfirmation(pending) => {
+                        pending_tool_call =
+                            Some(stash_pending_tool_call(&pending_tool_calls, *pending).await);
+                        (String::new(), true, InferenceEngine::Native.as_str())
+                    }
+                }
+            }
             InferenceEngine::Native => {
                 match native_engine_client
                     .generate(
@@ -3907,6 +5089,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                         &settings.native_engine,
                         None,
                         false,
+                        req.response_format.clone(),
                     )
                     .await
                 {
@@ -3929,6 +5112,43 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                         ),
                         false,
                         InferenceEngine::Native.as_str(),
+                    ),
+                }
+            }
+            InferenceEngine::Vllm if !enabled_tools.is_empty() || req.response_format.is_some() => {
+                match run_vllm_chat(
+                    &vllm_client,
+                    &mcp_registry,
+                    &current_model,
+                    &req.message,
+                    temp,
+                    top_p,
+                    top_k,
+                    penalty,
+                    exec_tokens,
+                    &enabled_tools,
+                    req.response_format.clone(),
+                )
+                .await
+                {
+                    Ok(VllmLoopStep::Done(outcome)) => {
+                        let text = outcome.text.trim().to_string();
+                        gen_tokens = Some((text.split_whitespace().count() as u32).max(1));
+                        tool_results = outcome.tool_results;
+                        (text, true, InferenceEngine::Vllm.as_str())
+                    }
+                    Ok(VllmLoopStep::NeedsConfirmation(pending)) => {
+                        pending_tool_call =
+                            Some(stash_pending_tool_call(&pending_tool_calls, *pending).await);
+                        (String::new(), true, InferenceEngine::Vllm.as_str())
+                    }
+                    Err(err) => (
+                        format!(
+                            "vLLM backend processed model '{}' with {} estimated tokens. vLLM error: {}",
+                            current_model, exec_tokens, err
+                        ),
+                        false,
+                        InferenceEngine::Vllm.as_str(),
                     ),
                 }
             }
@@ -4029,19 +5249,13 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             (request_seq, session_id, metrics_json)
         };
 
-        let mut final_response = response_text;
-        if !tool_results.is_empty() {
-            final_response.push_str("\n\nTools used:");
-            for res in &tool_results {
-                final_response.push_str("\n- **");
-                final_response.push_str(&res.tool);
-                final_response.push_str("**: ");
-                final_response.push_str(&res.result);
-            }
-        }
-
+        // No "Tools used:" text footer here: every engine's tool results are
+        // now real (see run_native_tool_loop/run_ollama_chat/run_vllm_chat)
+        // and already woven into the model's own final answer, so appending
+        // them again would just duplicate the content. The GUI instead
+        // renders `tool_results` below as its own badge per message.
         let mut response = serde_json::json!({
-            "response": final_response,
+            "response": response_text,
             "request_id": format!("req-{}", request_id),
             "session_id": session_id,
             "model": current_model,
@@ -4070,10 +5284,16 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             }
         }
 
+        if let Some(pending) = pending_tool_call {
+            if let Some(response_object) = response.as_object_mut() {
+                response_object.insert("pending_tool_call".to_string(), serde_json::json!(pending));
+            }
+        }
+
         request_tracker.decrement().await;
 
         if req.stream.unwrap_or(false) {
-            let tokens: Vec<String> = final_response
+            let tokens: Vec<String> = response_text
                 .split_whitespace()
                 .map(|s| format!("{} ", s))
                 .collect();
@@ -4091,6 +5311,130 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         } else {
             Json(response).into_response()
         }
+    }
+
+    /// Resumes a chat turn that paused on a `requires_confirmation` MCP
+    /// server (see the `NeedsConfirmation` cases in `handle_gui_chat`). Looks
+    /// up the saved `PendingToolCall` by `request_id`, then dispatches to
+    /// whichever engine's resume function matches its variant - approving
+    /// runs the real tool for the first time (it was never auto-executed);
+    /// denying feeds back `mcp::toolcall::format_denial` instead.
+    async fn handle_tool_confirm(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Json(req): Json<ToolConfirmRequest>,
+    ) -> Json<serde_json::Value> {
+        let (native_engine_client, ollama_client, vllm_client, mcp_registry, pending_tool_calls) = {
+            let backend = lock_state(&state);
+            (
+                backend.native_engine_client.clone(),
+                backend.ollama_client.clone(),
+                backend.vllm_client.clone(),
+                Arc::clone(&backend.mcp_registry),
+                Arc::clone(&backend.pending_tool_calls),
+            )
+        };
+
+        let pending = {
+            let mut store = pending_tool_calls.lock().await;
+            store.remove(&req.request_id)
+        };
+
+        let Some(pending) = pending else {
+            return Json(serde_json::json!({
+                "error": format!(
+                    "no pending tool call with request_id '{}' (already resolved, or the server restarted)",
+                    req.request_id
+                )
+            }));
+        };
+
+        let mut tool_results: Vec<ToolResult> = Vec::new();
+        let mut pending_tool_call: Option<PendingToolCallInfo> = None;
+
+        let (response_text, backend_used): (String, &str) = match &pending {
+            PendingToolCall::Native { .. } => {
+                match resume_native_tool_loop(
+                    &native_engine_client,
+                    &mcp_registry,
+                    pending,
+                    req.approve,
+                )
+                .await
+                {
+                    NativeLoopStep::Done(outcome) => {
+                        tool_results = outcome.tool_results;
+                        (outcome.text, InferenceEngine::Native.as_str())
+                    }
+                    NativeLoopStep::NeedsConfirmation(next_pending) => {
+                        pending_tool_call =
+                            Some(stash_pending_tool_call(&pending_tool_calls, *next_pending).await);
+                        (String::new(), InferenceEngine::Native.as_str())
+                    }
+                }
+            }
+            PendingToolCall::Ollama { .. } => {
+                match resume_ollama_chat(&ollama_client, &mcp_registry, pending, req.approve).await
+                {
+                    Ok(OllamaLoopStep::Done(outcome)) => {
+                        tool_results = outcome.tool_results;
+                        (
+                            outcome.text.trim().to_string(),
+                            InferenceEngine::Ollama.as_str(),
+                        )
+                    }
+                    Ok(OllamaLoopStep::NeedsConfirmation(next_pending)) => {
+                        pending_tool_call =
+                            Some(stash_pending_tool_call(&pending_tool_calls, *next_pending).await);
+                        (String::new(), InferenceEngine::Ollama.as_str())
+                    }
+                    Err(err) => (
+                        format!("Ollama chat failed while resuming: {err}"),
+                        InferenceEngine::Ollama.as_str(),
+                    ),
+                }
+            }
+            PendingToolCall::Vllm { .. } => {
+                match resume_vllm_chat(&vllm_client, &mcp_registry, pending, req.approve).await {
+                    Ok(VllmLoopStep::Done(outcome)) => {
+                        tool_results = outcome.tool_results;
+                        (
+                            outcome.text.trim().to_string(),
+                            InferenceEngine::Vllm.as_str(),
+                        )
+                    }
+                    Ok(VllmLoopStep::NeedsConfirmation(next_pending)) => {
+                        pending_tool_call =
+                            Some(stash_pending_tool_call(&pending_tool_calls, *next_pending).await);
+                        (String::new(), InferenceEngine::Vllm.as_str())
+                    }
+                    Err(err) => (
+                        format!("vLLM chat failed while resuming: {err}"),
+                        InferenceEngine::Vllm.as_str(),
+                    ),
+                }
+            }
+        };
+
+        let mut response = serde_json::json!({
+            "response": response_text,
+            "inference_backend": backend_used,
+        });
+
+        if !tool_results.is_empty() {
+            if let Some(obj) = response.as_object_mut() {
+                obj.insert("tool_results".to_string(), serde_json::json!(tool_results));
+                let tools_used: Vec<String> = tool_results.iter().map(|r| r.tool.clone()).collect();
+                obj.insert("tools_used".to_string(), serde_json::json!(tools_used));
+            }
+        }
+
+        if let Some(pending) = pending_tool_call {
+            if let Some(obj) = response.as_object_mut() {
+                obj.insert("pending_tool_call".to_string(), serde_json::json!(pending));
+            }
+        }
+
+        Json(response)
     }
 
     async fn handle_runtime_detection(
@@ -4563,8 +5907,17 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
     let mut settings = load_settings();
 
-    // Auto-compute ngl from GPU VRAM if still at default (-1)
-    if settings.ngl < 0 {
+    // Auto-compute ngl from GPU VRAM only when the caller hasn't already told
+    // us what to do. `-1` is ambiguous on its own: it's both RuntimeSettings'
+    // unconfigured default AND launch-native.ps1's deliberate "offload every
+    // layer llama-server can fit" sentinel (see its own GHOSTLINK_LLAMA_NGL
+    // comment) — load_settings() just copied that env var verbatim into
+    // settings.ngl above, so gating on `settings.ngl < 0` alone can't tell
+    // "nobody configured this" from "-1 was the explicit choice", and ends up
+    // silently downgrading every native launch to a conservative 12-layer
+    // partial offload instead of the full offload that was actually
+    // requested. Only guess when no one set the env var at all.
+    if settings.ngl < 0 && std::env::var("GHOSTLINK_LLAMA_NGL").is_err() {
         let ngl = if profile.node_resources.vram_gb >= 12.0 {
             40
         } else if profile.node_resources.vram_gb >= 8.0 {
@@ -4624,6 +5977,9 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         Some(settings.vllm_api_key.clone()),
     );
     let ollama_available = Arc::new(tokio::sync::Mutex::new(false));
+    let mcp_registry = Arc::new(mcp::McpRegistry::new(mcp::McpConfigManager::new(
+        mcp::default_config_path(),
+    )));
     let compute_config_manager = backend_config::ConfigManager::new("ghostlink.toml");
     let compute_config = compute_config_manager
         .load_compute_config()
@@ -4689,12 +6045,22 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         vllm_client,
         ollama_available,
         settings,
+        mcp_registry: Arc::clone(&mcp_registry),
+        pending_tool_calls: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
     }));
 
     // Background CPU/RAM/GPU sampler — keeps /api/metrics non-blocking.
     host_metrics::ensure_host_sampler();
 
     rt.block_on(async {
+        // Connects every enabled server in mcp_servers.toml (spawning stdio
+        // child processes, some of which pull an npx package on first run) —
+        // done in the background so a slow/misconfigured server can't delay
+        // the API from coming up and serving everything else.
+        tokio::spawn(async move {
+            mcp_registry.connect_enabled().await;
+        });
+
         let app = Router::new()
             .route("/v1/chat/completions", post(handle_chat_completions))
             .route("/v1/models", get(handle_models))
@@ -4766,7 +6132,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             .route("/api/security/pqc/state", get(handle_gui_pqc_state))
             .route("/api/security/audit-log", get(handle_gui_audit_log))
             .route("/api/inference/chat", post(handle_gui_chat))
+            .route(
+                "/api/inference/chat/tool-confirm",
+                post(handle_tool_confirm),
+            )
             .route("/api/inference/engines", get(handle_inference_engines))
+            .route("/api/mcp/servers", get(handle_mcp_servers))
             // Accept GET/POST/PUT for settings — some clients issue PUT and previously got 405.
             .route(
                 "/api/settings",
@@ -6827,6 +8198,7 @@ mod backend_config;
 mod backend_registry;
 mod host_metrics;
 mod inference_engine;
+mod mcp;
 mod native_engine;
 mod ollama;
 mod runtime;
@@ -6910,6 +8282,10 @@ mod tests {
             vllm_client: vllm::VllmClient::new("http://127.0.0.1:8000".to_string(), None),
             ollama_available: Arc::new(tokio::sync::Mutex::new(false)),
             settings: RuntimeSettings::default(),
+            mcp_registry: Arc::new(mcp::McpRegistry::new(mcp::McpConfigManager::new(
+                std::env::temp_dir().join("ghostlink-test-mcp-servers.toml"),
+            ))),
+            pending_tool_calls: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }))
     }
 

--- a/crates/ghost-link/src/mcp/client.rs
+++ b/crates/ghost-link/src/mcp/client.rs
@@ -78,7 +78,14 @@ pub struct McpToolSchema {
 
 #[derive(Debug, Clone)]
 pub struct ToolCallOutcome {
+    // Callers already know which server/tool they invoked (they pass both in
+    // as call_tool()'s own arguments), so these two are currently write-only
+    // - kept on the struct because they're the natural place to carry that
+    // context if a future caller needs to fan a batch of outcomes out without
+    // holding onto the original request.
+    #[allow(dead_code)]
     pub server: String,
+    #[allow(dead_code)]
     pub tool: String,
     pub result: Value,
     pub success: bool,
@@ -96,6 +103,13 @@ pub struct McpServerHandle {
     /// binary itself elsewhere). `rmcp`'s own Drop-time cleanup only kills this one
     /// process, which is not enough when it's a shim that spawned its own children
     /// (e.g. `cmd /C npx ...` → node.exe) — see `shutdown()`.
+    //
+    // `shutdown()` (and the process-tree kill it does) has no caller yet:
+    // there's no graceful-shutdown hook anywhere in ghost-link's main() today
+    // (Ctrl+C just drops the process), so spawned MCP servers are currently
+    // orphaned on exit regardless of this field. Tracked as a follow-up
+    // rather than bundled into this change.
+    #[allow(dead_code)]
     child_pid: Option<u32>,
 }
 
@@ -226,6 +240,7 @@ impl McpServerHandle {
         }
     }
 
+    #[allow(dead_code)]
     pub async fn shutdown(self) {
         let pid = self.child_pid;
         let name = self.name.clone();
@@ -243,6 +258,7 @@ impl McpServerHandle {
     }
 }
 
+#[allow(dead_code)]
 #[cfg(windows)]
 async fn kill_process_tree(pid: u32, server_name: &str) {
     let output = tokio::process::Command::new("taskkill")
@@ -254,6 +270,7 @@ async fn kill_process_tree(pid: u32, server_name: &str) {
     }
 }
 
+#[allow(dead_code)]
 #[cfg(not(windows))]
 async fn kill_process_tree(pid: u32, server_name: &str) {
     let output = tokio::process::Command::new("kill")

--- a/crates/ghost-link/src/mcp/config.rs
+++ b/crates/ghost-link/src/mcp/config.rs
@@ -112,6 +112,10 @@ impl McpConfigManager {
         Ok(file.servers)
     }
 
+    // Only called from set_enabled() below, which itself has no caller yet
+    // (see McpRegistry::set_enabled's doc comment) - kept for that same
+    // planned GUI enable/disable toggle rather than deleted.
+    #[allow(dead_code)]
     pub fn save(&self, servers: &[McpServerConfig]) -> Result<(), String> {
         for server in servers {
             validate_server(server)?;
@@ -127,6 +131,7 @@ impl McpConfigManager {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn set_enabled(&self, name: &str, enabled: bool) -> Result<(), String> {
         let mut servers = self.load()?;
         let server = servers

--- a/crates/ghost-link/src/mcp/registry.rs
+++ b/crates/ghost-link/src/mcp/registry.rs
@@ -120,6 +120,12 @@ impl McpRegistry {
     /// Toggles a server's `enabled` flag in `mcp_servers.toml` and takes effect
     /// immediately: connects it now if enabling, or tears it down now if
     /// disabling — so the GUI doesn't need a Ghostlink restart to see the change.
+    ///
+    /// No route calls this yet (the MCP tab's per-server toggle, if/when
+    /// added, is the natural caller) - `GET /api/mcp/servers` only reads
+    /// status today. Kept rather than deleted since it's fully correct and
+    /// ready for that follow-up.
+    #[allow(dead_code)]
     pub async fn set_enabled(&self, name: &str, enabled: bool) -> Result<(), String> {
         self.config_manager.set_enabled(name, enabled)?;
 
@@ -150,6 +156,7 @@ impl McpRegistry {
     /// ever applied to the *spawned child process* — this (main) process
     /// never inherits them, so out-of-band checks (e.g. "is rag's Ollama
     /// actually reachable") can't just read `std::env::var` directly.
+    #[allow(dead_code)]
     pub fn env_var_for(&self, server_name: &str, key: &str) -> Option<String> {
         let configs = self.config_manager.load().ok()?;
         let config = configs.into_iter().find(|c| c.name == server_name)?;
@@ -181,6 +188,12 @@ impl McpRegistry {
             .unwrap_or(false)
     }
 
+    // No graceful-shutdown hook exists anywhere in ghost-link's main() yet
+    // (Ctrl+C just drops the process today) - kept ready for when one is
+    // added, rather than deleted, since leaving spawned MCP child processes
+    // (npx/docker/etc.) running past ghost-link's own exit is exactly the
+    // bug this would fix.
+    #[allow(dead_code)]
     pub async fn shutdown_all(&self) {
         let mut servers = self.servers.write().await;
         for (_, handle) in servers.drain() {

--- a/crates/ghost-link/src/native_engine.rs
+++ b/crates/ghost-link/src/native_engine.rs
@@ -784,6 +784,11 @@ impl NativeEngineClient {
         // llama_cpp/simulated paths below, which have no slot concept.
         id_slot: Option<i64>,
         cache_prompt: bool,
+        // OpenAI-style `response_format` (e.g. `{"type": "json_schema", ...}`),
+        // forwarded to llama-server's chat-completions endpoint when present.
+        // Ignored by the llama_cpp/simulated paths, which have no grammar
+        // support wired up.
+        response_format: Option<serde_json::Value>,
     ) -> Result<NativeGeneration, String> {
         if model.trim().is_empty() {
             return Err("model cannot be empty".to_string());
@@ -816,6 +821,7 @@ impl NativeEngineClient {
                         repeat_penalty,
                         id_slot,
                         cache_prompt,
+                        response_format,
                     )
                     .await?;
                 if gen.latency_ms.is_none() {
@@ -938,6 +944,7 @@ impl NativeEngineClient {
         // invention.
         id_slot: Option<i64>,
         cache_prompt: bool,
+        response_format: Option<serde_json::Value>,
     ) -> Result<NativeGeneration, String> {
         let base_url = Self::get_llama_base_url();
 
@@ -958,7 +965,7 @@ impl NativeEngineClient {
         // Try chat completion endpoint first (for models with chat templates)
         let chat_url = format!("{base_url}/v1/chat/completions");
 
-        let chat_payload = serde_json::json!({
+        let mut chat_payload = serde_json::json!({
             "model": model,
             "messages": [
                 {"role": "system", "content": system_prompt},
@@ -973,6 +980,24 @@ impl NativeEngineClient {
             "id_slot": id_slot.unwrap_or(-1),
             "cache_prompt": cache_prompt
         });
+
+        if let Some(response_format) = response_format {
+            if let Some(obj) = chat_payload.as_object_mut() {
+                obj.insert("response_format".to_string(), response_format);
+                // Grammar-constrained decoding forces the final token stream
+                // into schema shape regardless, but hybrid-reasoning models
+                // (e.g. Qwen3.5) otherwise spend the entire max_tokens budget
+                // on <think> content before ever reaching it — confirmed live
+                // against llama-server: with thinking on, a 400-token budget
+                // ran out mid-reasoning and returned empty content; with it
+                // off, the very next call returned valid schema JSON in 22
+                // tokens. Non-reasoning models simply ignore this field.
+                obj.insert(
+                    "chat_template_kwargs".to_string(),
+                    serde_json::json!({ "enable_thinking": false }),
+                );
+            }
+        }
 
         // Reuse the shared, connection-pooled client instead of building a new
         // one (and a new TCP connection) per request; apply the configurable
@@ -1159,6 +1184,7 @@ impl NativeEngineClient {
                     repeat_penalty,
                     id_slot,
                     cache_prompt,
+                    None,
                 )
                 .await?;
             let single = futures::stream::once(async move { Ok(gen.text) });
@@ -1456,6 +1482,7 @@ mod tests {
                         "simulated",
                         None,
                         false,
+                        None,
                     )
                     .await
             })
@@ -1538,6 +1565,7 @@ mod tests {
                         "llama_server",
                         Some(0),
                         true,
+                        None,
                     )
                     .await
             })
@@ -1583,6 +1611,7 @@ mod tests {
                         "llama_cpp",
                         None,
                         false,
+                        None,
                     )
                     .await
             })

--- a/crates/ghost-link/src/ollama.rs
+++ b/crates/ghost-link/src/ollama.rs
@@ -69,6 +69,11 @@ pub struct ChatRequest {
     /// Only sent to models that declare tool-calling support in their template.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<Value>>,
+    /// Structured-output constraint: either the literal string `"json"`, or a
+    /// raw JSON schema object — Ollama applies it directly as a grammar, no
+    /// `{"type": "json_schema", ...}` wrapper like OpenAI/vLLM expect.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<Value>,
 }
 
 /// Sampling parameters accepted by Ollama's `/api/generate` and `/api/chat`
@@ -388,6 +393,7 @@ impl OllamaClient {
         repeat_penalty: Option<f32>,
         max_tokens: Option<usize>,
         tools: Option<Vec<Value>>,
+        format: Option<Value>,
     ) -> Result<ChatResponse, Box<dyn Error>> {
         let request = ChatRequest {
             model: model.to_string(),
@@ -401,6 +407,7 @@ impl OllamaClient {
                 num_predict: max_tokens,
             }),
             tools,
+            format,
         };
 
         let resp = self
@@ -452,6 +459,7 @@ impl OllamaClient {
                 num_predict: max_tokens,
             }),
             tools: None,
+            format: None,
         };
 
         let resp = self
@@ -943,6 +951,7 @@ mod tests {
                 num_predict: Some(256),
             }),
             tools: None,
+            format: None,
         };
         let value = serde_json::to_value(&request).expect("serialize ChatRequest");
         assert!(

--- a/crates/ghost-link/src/vllm.rs
+++ b/crates/ghost-link/src/vllm.rs
@@ -1,7 +1,7 @@
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
 use reqwest::Client;
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::error::Error;
 
 #[derive(Clone, Debug)]
@@ -33,7 +33,36 @@ struct ChatChoice {
 
 #[derive(Debug, Deserialize)]
 struct ChatMessage {
-    content: String,
+    // `None` (not just empty) whenever the response is tool_calls-only —
+    // vLLM's OpenAI-compatible server sends a literal JSON `null` there,
+    // which fails to deserialize into a non-Option `String`.
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<VllmToolCall>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VllmToolCall {
+    #[serde(default)]
+    pub id: Option<String>,
+    pub function: VllmFunctionCall,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VllmFunctionCall {
+    pub name: String,
+    /// Raw JSON-encoded string per the OpenAI tool-call shape (not a nested
+    /// object) — callers must `serde_json::from_str` this themselves.
+    #[serde(default)]
+    pub arguments: String,
+}
+
+/// Result of a tool-aware chat turn: the model's text (possibly empty when
+/// it only requested tools) plus any tool calls it asked for.
+pub struct VllmChatResult {
+    pub content: String,
+    pub tool_calls: Vec<VllmToolCall>,
 }
 
 impl VllmClient {
@@ -107,8 +136,72 @@ impl VllmClient {
             .choices
             .into_iter()
             .next()
-            .map(|choice| choice.message.content)
+            .and_then(|choice| choice.message.content)
             .unwrap_or_default())
+    }
+
+    /// Tool- and structured-output-aware chat turn. `messages` is passed
+    /// through as raw OpenAI-shaped JSON (system/user/assistant/tool roles)
+    /// since a tool follow-up turn needs to echo back the assistant's own
+    /// `tool_calls` plus a `tool` role reply per call — a fixed message
+    /// struct can't represent that without duplicating this shape anyway.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn chat(
+        &self,
+        model: &str,
+        messages: Vec<Value>,
+        temperature: f32,
+        top_p: f32,
+        top_k: usize,
+        repeat_penalty: f32,
+        max_tokens: usize,
+        tools: Option<Vec<Value>>,
+        response_format: Option<Value>,
+    ) -> Result<VllmChatResult, Box<dyn Error>> {
+        let mut payload = json!({
+            "model": model,
+            "messages": messages,
+            "stream": false,
+            "temperature": temperature.clamp(0.0, 2.0),
+            "top_p": top_p.clamp(0.0, 1.0),
+            "top_k": top_k.clamp(1, 200),
+            "repetition_penalty": repeat_penalty.clamp(0.0, 2.0),
+            "max_tokens": max_tokens,
+        });
+
+        if let Some(obj) = payload.as_object_mut() {
+            if let Some(tools) = tools {
+                obj.insert("tools".to_string(), json!(tools));
+            }
+            if let Some(response_format) = response_format {
+                obj.insert("response_format".to_string(), response_format);
+            }
+        }
+
+        let resp = self
+            .request(
+                self.client
+                    .post(format!("{}/v1/chat/completions", self.base_url)),
+            )
+            .json(&payload)
+            .send()
+            .await?;
+        let resp = resp.error_for_status()?;
+        let payload: ChatCompletionResponse = resp.json().await?;
+        let message = payload
+            .choices
+            .into_iter()
+            .next()
+            .map(|choice| choice.message)
+            .unwrap_or(ChatMessage {
+                content: None,
+                tool_calls: None,
+            });
+
+        Ok(VllmChatResult {
+            content: message.content.unwrap_or_default(),
+            tool_calls: message.tool_calls.unwrap_or_default(),
+        })
     }
 
     fn request(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {

--- a/ghostlink_gui_modern/src/api.test.ts
+++ b/ghostlink_gui_modern/src/api.test.ts
@@ -487,7 +487,13 @@ describe('GhostlinkAPI', () => {
             { role: 'assistant', content: 'hello' },
             { role: 'user', content: 'and then?' },
           ],
-        })
+        }),
+        // Tool-calling turns can run several full generate() rounds plus a
+        // real MCP tool call each - the default 120s timeout aborted a real
+        // confirm-resume client-side with no error after just over 2 minutes,
+        // so the non-streaming send path (which tool-calling always takes)
+        // gets a longer budget. See GhostlinkAPI.toolCallTimeout.
+        expect.objectContaining({ timeout: 300000 })
       );
     });
 

--- a/ghostlink_gui_modern/src/api.ts
+++ b/ghostlink_gui_modern/src/api.ts
@@ -65,6 +65,14 @@ const API_KEY_STORAGE_KEY = 'ghostlink-api-key';
 export class GhostlinkAPI {
   private http: AxiosInstance;
   private requestTimeout = [5000, 120000] as const;
+  // Tool-calling turns (initial send and tool-confirm resume) can run several
+  // full generate() rounds plus a real MCP tool call each, on top of however
+  // long the model itself takes - confirmed live at just over 2 minutes with
+  // a reasoning model and a Docker MCP gateway call, past the 120s default
+  // above. That silently aborted the request client-side with no error and no
+  // UI update, leaving a stale "Approval needed" prompt even though the
+  // backend had actually finished. Give both call sites real headroom.
+  private toolCallTimeout = 300000;
   private circuitBreaker: CircuitBreakerState = {
     failures: 0,
     successes: 0,
@@ -400,7 +408,12 @@ export class GhostlinkAPI {
 
         return { success: true, data: { response: fullText, truncated } };
       } else {
-        const response = await this.http.post('/api/inference/chat', payload);
+        // Non-streaming is also the path tool-calling always takes (see
+        // useStreaming above) - give it the longer tool-call budget rather
+        // than the default 120s.
+        const response = await this.http.post('/api/inference/chat', payload, {
+          timeout: this.toolCallTimeout,
+        });
         return { success: true, data: response.data };
       }
     } catch (error: any) {
@@ -413,10 +426,11 @@ export class GhostlinkAPI {
    *  the same chat turn on the backend. */
   async confirmToolCall(requestId: string, approve: boolean) {
     try {
-      const response = await this.http.post('/api/inference/chat/tool-confirm', {
-        request_id: requestId,
-        approve,
-      });
+      const response = await this.http.post(
+        '/api/inference/chat/tool-confirm',
+        { request_id: requestId, approve },
+        { timeout: this.toolCallTimeout }
+      );
       return { success: true, data: response.data };
     } catch (error: any) {
       return { success: false, error: error.response?.data?.error || error.message };

--- a/ghostlink_gui_modern/src/components/ModelsTab.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Trash2,
   RefreshCw,
@@ -166,15 +166,27 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     if (!result.error) setPartialDownloads(result.partials);
   }, [api]);
 
+  const refreshRequestIdRef = useRef(0);
+
   const refreshModels = useCallback(async () => {
+    // Each call captures its own engine-specific requestId. If a newer
+    // refreshModels() call starts (e.g. currentEngine flips from the
+    // 'ollama' default to the real engine right after mount) before this
+    // one's slower awaits (getOllamaModels can take seconds when Ollama
+    // isn't running) resolve, the stale call must not clobber the fresher
+    // state — otherwise the model list flashes correct then reverts to
+    // empty once the superseded 'ollama' branch finally lands.
+    const requestId = ++refreshRequestIdRef.current;
     setLoading(true);
     try {
       const result = await api.getModels();
+      if (requestId !== refreshRequestIdRef.current) return;
       if (result.models) {
         setModels(result.models);
         if (result.current_model) setCurrentModel(result.current_model);
         if (currentEngine === 'vllm') {
           const inventory = await api.getVllmModels();
+          if (requestId !== refreshRequestIdRef.current) return;
           setOllamaModels(
             (inventory.models || []).map((m: any) => ({
               name: m.name,
@@ -190,6 +202,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
           );
         } else if (currentEngine === 'ollama') {
           const inventory = await api.getOllamaModels();
+          if (requestId !== refreshRequestIdRef.current) return;
           if (!inventory.error && inventory.models) {
             setOllamaModels(inventory.models);
           } else {
@@ -225,6 +238,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     } catch (e) {
       console.error('Failed to refresh models:', e);
     }
+    if (requestId !== refreshRequestIdRef.current) return;
     setLoading(false);
     refreshPartialDownloads();
   }, [api, currentEngine, refreshPartialDownloads, setCurrentModel, setModels]);


### PR DESCRIPTION
## Summary

Wires the previously-orphaned `mcp::` client module into all three inference engines (Native, Ollama, vLLM), replacing the old canned-string `ToolDispatcher` stub with real MCP tool execution, adds structured-output support, adds a confirmation gate for risky tools, and fixes an unrelated GPU-offload correctness bug found while verifying the above.

### Real MCP tool calling (Native, Ollama, vLLM)
- The `mcp::` module (client/config/registry/toolcall) existed, was unit-tested, but was never declared as `mod mcp;` in `main.rs` — it wasn't compiled into the binary at all, so `handle_gui_chat` fell back to a hardcoded `ToolDispatcher` that returned canned strings like `"42 (Calculated via Rust built-in tool)"` regardless of which tool was "called".
- **Native**: injects `mcp::toolcall`'s `TOOL_CALL:` prompt shim, dispatches to the real MCP server, feeds the result back as an Observation, loops up to `MAX_TOOL_ITERATIONS`.
- **Ollama**: now drives its native OpenAI-style `tools`/`tool_calls` protocol via `chat()` — previously only plain `generate()` was used, which never sent tools at all.
- **vLLM**: same OpenAI-style protocol against vLLM's own server; added `VllmClient::chat()` since `generate()` never forwarded `tools`/`response_format` despite the engine's capability flags already claiming both.
- Shared `invoke_mcp_tool`/`mcp_tools_to_openai_json` helpers so all three engines report identical `{tool, result, success}` outcomes — the GUI's existing tool-call badge was previously dead for every engine since nothing populated real results.

### Structured output (Native, Ollama, vLLM)
- New `GuiChatRequest.response_format` field (OpenAI `{"type": "json_schema", ...}` shape), forwarded to llama-server/vLLM as-is.
- Ollama needs the bare schema instead of the OpenAI wrapper — `normalize_response_format_for_ollama` unwraps it. Confirmed live: the wrapper unmodified produced no constraint at all; unwrapped, valid schema-conforming JSON.
- Native forces `chat_template_kwargs.enable_thinking=false` when a schema is requested — hybrid-reasoning models otherwise burn the whole token budget on `<think>` content and never reach the answer (confirmed: 400 tokens of reasoning + empty output with thinking on; valid JSON in 22 tokens with it off).

### Confirmation gate for risky tools
- `requires_confirmation` servers (terminal, code_execution) are now offered to the model instead of hidden, but a call into one pauses the turn instead of auto-executing. `PendingToolCall` (per-engine resumable state) is stashed under a request_id in a new `BackendState.pending_tool_calls` map, surfaced as `pending_tool_call` in the response for the GUI's existing (previously backend-less) Approve/Deny prompt.
- New `POST /api/inference/chat/tool-confirm` resumes the paused loop — approve invokes the real tool for the first time; deny feeds back `mcp::toolcall::format_denial`. Handles multiple gated calls in one batch and nested confirmations without dropping queued calls.
- **Verified end-to-end against a real `docker mcp gateway run` server** (315 real catalog servers): approve executed genuine searches; deny left zero additional executions in server logs; the GUI prompt renders and resolves correctly.
- Found and fixed a real bug during that verification: the frontend's 120s default axios timeout was too tight for a confirm-resume involving real tool execution + full model regeneration (measured at just over 2 minutes with a reasoning model) — it aborted client-side with no error, leaving a stale "Approval needed" prompt even though the backend had finished. Bumped both the tool-calling send path and `confirmToolCall` to a 300s budget.

### GPU offload fix (unrelated bug found while verifying the above)
`load_settings()` copies an explicit `GHOSTLINK_LLAMA_NGL` env var (e.g. `launch-native.ps1`'s deliberate `-1` = "offload everything") into `settings.ngl`, but `main()`'s "auto-compute ngl if still at default (-1)" block then treated that same `-1` as "unconfigured" and immediately overwrote it with a conservative 12-layer estimate — **on every single launch**, regardless of what launch-native.ps1 actually requested. Gated the auto-compute on the env var being genuinely absent instead.

Verified on real hardware (AMD Radeon 860M iGPU, Qwen3.5-9B): the actual `-ngl` argument in the spawned llama-server process went from `12` to `-1`, and throughput went from 6.46 → 10.77 tok/s generation (5.92 → 23.55 tok/s prompt processing).

## Known follow-ups (not in this change)
- `McpRegistry::set_enabled`/`env_var_for`/`shutdown_all` and `McpServerHandle::shutdown` are fully implemented but have no caller yet — no MCP-tab enable/disable toggle route exists, and there's no graceful-shutdown hook anywhere in `main()` (Ctrl+C just drops the process today, orphaning spawned MCP child processes). Marked `#[allow(dead_code)]` with comments rather than deleted, since they're ready for that work.
- vLLM's tool-calling/structured-output code path compiles and mirrors the same protocol as Ollama/Native, but there was no running vLLM server on this box to verify live — only Native (llama-server) and Ollama (real daemon + `qwen2.5:3b`) got full live round-trips.

## Risk
This is a cross-cutting change (touches all three inference engines plus the request/response contract), but every engine's *plain, tool-free, no-schema* chat path is untouched — the new code only activates when a caller enables tools or sets `response_format`. The GPU offload fix is a one-line gating change to startup logic with a measured before/after comparison.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 217 passed, 0 failed
- [x] `cargo audit` — only pre-existing allowed advisories in unrelated transitive deps (paste, anyhow, lru)
- [x] Live verification against real running services (not just unit tests): llama-server (native) tool calls + structured output; a real Ollama daemon with `qwen2.5:3b` for tool calls + structured output; a real `docker mcp gateway run` server for the confirmation gate (approve/deny/nested); GPU offload speed comparison on real hardware

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>