### PR TITLE
⚡ Bolt: partial sort for top-K document ranking in RAG

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2026-08-02 - [Partial Sort for Top-K Document Ranking in RAG]
+**Learning:** Performing a full sort ($O(N \log N)$) on a large list of indexed documents to retrieve only the top $K$ items is highly inefficient. Using a partial sort like `select_nth_unstable_by` partitions the list in $O(N)$ expected time, and we only need to sort the resulting $K$ elements. This reduces complexity to $O(N + K \log K)$, which is significantly faster when $N$ is large and $K$ is small. Additionally, we must handle the edge case where `top_k == 0` to prevent integer subtraction underflow.
+**Action:** Always prefer `select_nth_unstable_by` followed by a small sort over full array sorting when only the top $K$ elements are required. Ensure bounds and subtraction checks are in place to avoid underflow/overflow panics for edge cases like $K=0$.
+
 ## 2026-07-25 - [Cursor-Based Index Traversal for Tensor Distribution]
 **Learning:** Draining and shifting elements of a vector within loops (e.g. `remaining_layers.drain(...)`) to track remaining work causes high element-shifting and copying overhead, leading to $O(N^2)$ time complexity. Keeping a cursor/index into a read-only slice of the original vector avoids modifying the vector structure entirely, eliminating element moves and bringing the time complexity to $O(N)$.
 **Action:** Always prefer read-only cursor-based slice indices over mutating/draining vectors when traversing and dividing contiguous sequences.

--- a/crates/mcp-rag/src/main.rs
+++ b/crates/mcp-rag/src/main.rs
@@ -568,11 +568,11 @@ mod tests {
 
         // 1. Normal case where N > K
         let entries = vec![
-            entry("entry1", vec![1.0, 0.0]), // similarity = 1.0
-            entry("entry2", vec![0.0, 1.0]), // similarity = 0.0
+            entry("entry1", vec![1.0, 0.0]),     // similarity = 1.0
+            entry("entry2", vec![0.0, 1.0]),     // similarity = 0.0
             entry("entry3", vec![0.707, 0.707]), // similarity = 0.707
-            entry("entry4", vec![-1.0, 0.0]), // similarity = -1.0
-            entry("entry5", vec![0.5, 0.866]), // similarity = 0.5
+            entry("entry4", vec![-1.0, 0.0]),    // similarity = -1.0
+            entry("entry5", vec![0.5, 0.866]),   // similarity = 0.5
         ];
 
         let ranked = rank(&entries, &query, 3);

--- a/crates/mcp-rag/src/main.rs
+++ b/crates/mcp-rag/src/main.rs
@@ -229,8 +229,19 @@ fn rank<'a>(
             )
         })
         .collect();
+
+    // Optimize document ranking by performing a partial sort to select only the top K elements,
+    // reducing time complexity from O(N log N) to O(N + K log K). This is extremely beneficial
+    // for larger indexes with thousands of elements since top_k is typically small (e.g. 5).
+    if top_k > 0 && scored.len() > top_k {
+        scored.select_nth_unstable_by(top_k - 1, |a, b| {
+            b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        scored.truncate(top_k);
+    } else if top_k == 0 {
+        scored.clear();
+    }
     scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-    scored.truncate(top_k);
     scored
 }
 
@@ -549,5 +560,57 @@ mod tests {
         let corrupt = dir.path().join("corrupt.json");
         std::fs::write(&corrupt, "not valid json").unwrap();
         assert!(RagIndex::load(&corrupt).entries.is_empty());
+    }
+
+    #[test]
+    fn test_rank_partial_sort() {
+        let query = vec![1.0, 0.0];
+
+        // 1. Normal case where N > K
+        let entries = vec![
+            entry("entry1", vec![1.0, 0.0]), // similarity = 1.0
+            entry("entry2", vec![0.0, 1.0]), // similarity = 0.0
+            entry("entry3", vec![0.707, 0.707]), // similarity = 0.707
+            entry("entry4", vec![-1.0, 0.0]), // similarity = -1.0
+            entry("entry5", vec![0.5, 0.866]), // similarity = 0.5
+        ];
+
+        let ranked = rank(&entries, &query, 3);
+        assert_eq!(ranked.len(), 3);
+        assert_eq!(ranked[0].1.id, "entry1");
+        assert_eq!(ranked[1].1.id, "entry3");
+        assert_eq!(ranked[2].1.id, "entry5");
+
+        // 2. Case where N < K
+        let ranked_small_n = rank(&entries, &query, 10);
+        assert_eq!(ranked_small_n.len(), 5);
+        assert_eq!(ranked_small_n[0].1.id, "entry1");
+        assert_eq!(ranked_small_n[4].1.id, "entry4");
+
+        // 3. Case where N == K
+        let ranked_equal = rank(&entries, &query, 5);
+        assert_eq!(ranked_equal.len(), 5);
+        assert_eq!(ranked_equal[0].1.id, "entry1");
+        assert_eq!(ranked_equal[4].1.id, "entry4");
+
+        // 4. Empty slice
+        let empty_entries: Vec<IndexEntry> = Vec::new();
+        let ranked_empty = rank(&empty_entries, &query, 3);
+        assert!(ranked_empty.is_empty());
+
+        // 4b. top_k == 0 edge case
+        let ranked_zero_k = rank(&entries, &query, 0);
+        assert!(ranked_zero_k.is_empty());
+
+        // 5. Identical scores
+        let identical_entries = vec![
+            entry("a", vec![1.0, 0.0]),
+            entry("b", vec![1.0, 0.0]),
+            entry("c", vec![1.0, 0.0]),
+        ];
+        let ranked_identical = rank(&identical_entries, &query, 2);
+        assert_eq!(ranked_identical.len(), 2);
+        assert!((ranked_identical[0].0 - 1.0).abs() < 1e-6);
+        assert!((ranked_identical[1].0 - 1.0).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
Optimized document ranking in `rank()` in `crates/mcp-rag/src/main.rs` by replacing a full sort of all scored entries (O(N log N) complexity) with a partial sort using `select_nth_unstable_by` (O(N) complexity) and sorting only the resulting top_k elements (O(K log K)).

This dramatically improves RAG search performance on large indexes. Added comprehensive unit tests and handled K=0 subtraction underflow safety edge case.

---
*PR created automatically by Jules for task [4904769590644601145](https://jules.google.com/task/4904769590644601145) started by @rwilliamspbg-ops*