### PR TITLE
🎨 Palette: Enhance Active Sessions Tab UX & Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal
 
+## 2026-08-02 - [Sessions Active Protection & Tooltips]
+**Learning:** Cancelling a running LLM inference session is a highly disruptive action. Sighted users need immediate visual hover tooltips (`title`) to confirm the destructive function of icon-only action triggers, and all users benefit from a non-blocking confirmation dialog (`window.confirm`) to prevent accidental session evictions. Additionally, ensuring these interactive controls have tailored keyboard focus rings guarantees an accessible experience during keyboard navigation.
+**Action:** Always protect cluster session teardowns with clear modal confirmations, intuitive tooltips, and tailored `focus-visible:` focus rings.
+
 ## 2026-07-20 - [Clear Chat Confirmation & Tooltip]
 **Learning:** Destructive actions placed immediately adjacent to common utility actions (like Save and Load) without tooltips or confirmation dialogs lead to high rates of accidental data loss and user frustration. Sighted users need hover tooltips (`title`) to understand icon-only buttons, and all users benefit from a non-blocking confirmation dialog before clearing an active session.
 **Action:** Always add a clear confirmation dialog and descriptive tooltips to header actions that discard user-generated state.

--- a/ghostlink_gui_modern/src/components/SessionsTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/SessionsTab.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SessionsTab } from './SessionsTab';
+import { useAppStore } from '../store';
+
+function createMockApi() {
+  return {
+    getSessions: vi.fn().mockResolvedValue({
+      sessions: [
+        { id: 'session-1', model: 'llama-3-8b', status: 'Running', throughput: 24.5, latency: 120, tokens: 412 },
+        { id: 'session-2', model: 'mistral-7b', status: 'Idle', throughput: 0, latency: 0, tokens: 88 },
+      ],
+    }),
+    cancelSession: vi.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+describe('SessionsTab', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      sessions: [
+        { id: 'session-1', model: 'llama-3-8b', status: 'Running', throughput: 24.5, latency: 120, tokens: 412 },
+        { id: 'session-2', model: 'mistral-7b', status: 'Idle', throughput: 0, latency: 0, tokens: 88 },
+      ],
+      setSessions: vi.fn((sessions) => {
+        useAppStore.setState({ sessions });
+      }),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('renders sessions with custom tooltips and details', async () => {
+    const api = createMockApi();
+    render(<SessionsTab api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Sessions')).toBeInTheDocument();
+      expect(screen.getByText('session-1')).toBeInTheDocument();
+      expect(screen.getByText('session-2')).toBeInTheDocument();
+      expect(screen.getByText('llama-3-8b')).toBeInTheDocument();
+      expect(screen.getByText('mistral-7b')).toBeInTheDocument();
+    });
+
+    // Check tooltip/title on Refresh button
+    const refreshBtn = screen.getByRole('button', { name: /refresh sessions/i });
+    expect(refreshBtn).toHaveAttribute('title', 'Refresh sessions');
+
+    // Check tooltip/title on Cancel session buttons
+    const cancelBtn1 = screen.getByRole('button', { name: /cancel session session-1/i });
+    expect(cancelBtn1).toHaveAttribute('title', 'Cancel session session-1');
+  });
+
+  it('prompts confirm and calls cancelSession when confirmed', async () => {
+    const api = createMockApi();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<SessionsTab api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('session-1')).toBeInTheDocument();
+    });
+
+    const cancelBtn = screen.getByRole('button', { name: /cancel session session-1/i });
+    fireEvent.click(cancelBtn);
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Are you sure you want to cancel session session-1? This will immediately terminate the running inference.'
+    );
+    expect(api.cancelSession).toHaveBeenCalledWith('session-1');
+  });
+
+  it('does not call cancelSession when cancel is rejected in confirm dialog', async () => {
+    const api = createMockApi();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(<SessionsTab api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('session-1')).toBeInTheDocument();
+    });
+
+    const cancelBtn = screen.getByRole('button', { name: /cancel session session-1/i });
+    fireEvent.click(cancelBtn);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(api.cancelSession).not.toHaveBeenCalled();
+  });
+});

--- a/ghostlink_gui_modern/src/components/SessionsTab.tsx
+++ b/ghostlink_gui_modern/src/components/SessionsTab.tsx
@@ -36,7 +36,8 @@ export const SessionsTab: React.FC<{ api: any }> = ({ api }) => {
         <button
           onClick={refreshSessions}
           aria-label="Refresh sessions"
-          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition"
+          title="Refresh sessions"
+          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
         >
           <RefreshCw size={18} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
         </button>
@@ -75,9 +76,14 @@ export const SessionsTab: React.FC<{ api: any }> = ({ api }) => {
                             {session.status}
                         </div>
                         <button
-                            onClick={() => handleCancel(session.id)}
-                            className="p-2 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition"
+                            onClick={() => {
+                              if (window.confirm(`Are you sure you want to cancel session ${session.id}? This will immediately terminate the running inference.`)) {
+                                handleCancel(session.id);
+                              }
+                            }}
+                            className="p-2 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                             aria-label={`Cancel session ${session.id}`}
+                            title={`Cancel session ${session.id}`}
                         >
                             <XCircle size={18} aria-hidden="true" />
                         </button>


### PR DESCRIPTION
I have implemented a gorgeous, highly useful micro-UX and accessibility improvement on the Active Sessions tab:

- Added hover tooltips (`title` attribute) matching `aria-label`s on both the Refresh and Cancel buttons so mouse/touch users get immediate feedback.
- Added high-contrast, tailored keyboard focus-visible states (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) to both buttons, ensuring screen reader and keyboard-only users can navigate safely.
- Added a non-blocking confirmation dialog (`window.confirm`) to protect against accidental session cancelation/eviction.
- Added a complete Vitest suite in `SessionsTab.test.tsx` to assert on all of these features and confirm correctness.
- Visually verified the UI with a Playwright headless script and generated a correct screenshot.

---
*PR created automatically by Jules for task [7895472841618490436](https://jules.google.com/task/7895472841618490436) started by @rwilliamspbg-ops*