### PR TITLE
fix: restore eight features silently lost to a bad merge conflict resolution

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: rwilliamspbg-ops

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
 [![Platforms](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-lightgrey)](#quick-start)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![GitHub Stars](https://img.shields.io/github/stars/rwilliamspbg-ops/Ghostlink?style=social)](https://github.com/rwilliamspbg-ops/Ghostlink)
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-db61a2?logo=githubsponsors)](https://github.com/sponsors/rwilliamspbg-ops)
 
 [Quick Start](#quick-start) · [Demo](#demo) · [Architecture](#architecture) · [API](#api-endpoints) · [Docs](https://rwilliamspbg-ops.github.io/Ghostlink/) · [Contributing](CONTRIBUTING.md)
 
@@ -69,12 +70,24 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
 
 ## Why Ghostlink
 
-Ghostlink is designed for teams that want lower-latency planning, more control over distributed inference topologies, and a simpler path to custom LLM serving than generic orchestration stacks.
+Point Ghostlink at every machine on your LAN and it becomes one inference
+cluster — correctly sized, authenticated, and observable — with zero YAML
+and no manual `--rpc` flags. Nobody else combines *zero-config discovery of
+heterogeneous consumer/prosumer hardware* (gaming GPU + old laptop +
+NPU-equipped ultrabook + Mac) with *real distributed inference across it*:
+vLLM assumes a homogeneous co-located GPU fleet, Ollama and LM Studio don't
+distribute at all, and Kubernetes-based serving solves this but needs a
+cluster and an ops team. See [docs/COMPARISON.md](docs/COMPARISON.md) for
+the full breakdown and [docs/BENCHMARKS.md](docs/BENCHMARKS.md) for a real
+two-machine LAN run backing this up, not just prose.
 
 Use Ghostlink when you need:
-- fast model and workload scheduling across heterogeneous hardware,
-- a self-hosted inference fabric with open-source flexibility,
-- a platform that can be extended into a paid commercial offering with support and enterprise deployment services.
+- zero-config cluster formation across mixed CPU/GPU/NPU hardware already
+  sitting on your network,
+- a self-hosted inference fabric with open-source flexibility and no
+  vendor lock-in,
+- a platform that can be extended into a paid commercial offering with
+  support and enterprise deployment services.
 
 ## Quick Start
 
@@ -208,6 +221,23 @@ run on an **Intel i7-14700K (Linux/WSL2)** with `RUSTFLAGS="-C target-cpu=native
 | TCP loopback | 1024 / 128 | 340 K tok/s | 3.01 ms |
 | In-process (spin-wait) | 256 / 32 | 639 K tok/s | 0.40 ms |
 | TCP loopback | 256 / 32 | 236 K tok/s | 1.08 ms |
+
+### Reproduce these numbers / other hardware
+
+```bash
+cargo bench -p ghostlink-core --bench criterion   # microbenchmarks
+python scripts/flow_perf_snapshot.py --exec-tokens 512 --micro-batch 8 --runs 5 --modes tcp inmem --release
+```
+
+Every number above is falsifiable — run the commands yourself. Numbers vary
+meaningfully by hardware: [docs/BENCHMARKS.md](docs/BENCHMARKS.md) documents
+two more full profiles with the same rigor — an AMD Radeon 860M integrated
+GPU laptop (Windows) and a 4-core Linux mini PC with no dedicated GPU —
+including honest noisiness notes for both low-power classes. A first real
+multi-node LAN run (that same Windows laptop and Linux mini PC, over a real
+network) is also in BENCHMARKS.md's Multi-Node Performance section; more
+node counts and hardware pairs (especially discrete GPUs) are still open,
+see [docs/ROADMAP.md](docs/ROADMAP.md), Horizon 1.
 
 ### Local llama-server tuning
 
@@ -483,7 +513,7 @@ Current focus areas:
 
 **Public launch assets:**
 - Live site: https://rwilliamspbg-ops.github.io/Ghostlink/
-- Comparison sheet: [docs/archive/comparison_sheet.md](docs/archive/comparison_sheet.md)
+- Comparison sheet: [docs/COMPARISON.md](docs/COMPARISON.md)
 - Demo flow: [docs/archive/launch_demo.md](docs/archive/launch_demo.md)
 
 ## Contributing

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -45,16 +45,30 @@ use std::time::{Duration, Instant};
 
 use tokio::io::AsyncWriteExt;
 
+// `deny_unknown_fields` on this whole family turns a typo'd key in
+// ghostlink.toml (e.g. `remote_vram_gb` misspelled) into a startup error
+// instead of a silently-ignored no-op — previously any unrecognized key
+// parsed successfully and the intended setting just never applied.
+//
+// `[compute]` is a real, documented top-level table in the same file (see
+// ghostlink.example.toml) but it's owned and parsed separately by
+// `backend_config::ConfigManager` — declared here just so deny_unknown_fields
+// doesn't reject it, not because this struct does anything with it.
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct FileConfig {
     flow: Option<FlowDefaults>,
     cluster_start: Option<ClusterStartDefaults>,
     discovery: Option<DiscoveryDefaults>,
     tcp: Option<TcpDefaults>,
     gui: Option<GuiDefaults>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    compute: Option<toml::Value>,
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct FlowDefaults {
     local_id: Option<String>,
     remote_id: Option<String>,
@@ -66,12 +80,14 @@ struct FlowDefaults {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ClusterStartDefaults {
     node_count: Option<usize>,
     base_port: Option<u16>,
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DiscoveryDefaults {
     listen: Option<String>,
     broadcast: Option<String>,
@@ -82,6 +98,7 @@ struct DiscoveryDefaults {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct TcpDefaults {
     max_inflight: Option<usize>,
     reconnect_attempts: Option<usize>,
@@ -90,6 +107,7 @@ struct TcpDefaults {
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct GuiDefaults {
     python: Option<String>,
 }
@@ -1501,6 +1519,10 @@ struct BackendState {
     /// last-writer-wins race with no relation to which process actually
     /// survived the taskkill/spawn collision.
     model_lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Custom inference backends registered via `backend_plugin` — checked
+    /// by the OpenAI-compatible REST handlers before falling through to the
+    /// built-in Native/Ollama dispatch. See `backend_plugin` module docs.
+    plugin_registry: backend_plugin::BackendPluginRegistry,
     /// Whether the *currently running* listener is actually serving HTTPS
     /// with the PQC-hybrid key exchange preference — set once at server
     /// startup from the same `use_tls` decision that picked the listener
@@ -3057,6 +3079,65 @@ struct Choice {
     message: serde_json::Value,
     finish_reason: String,
 }
+
+/// OpenAI's legacy (non-chat) completions request: a plain `prompt` string
+/// rather than a `messages` array. `handle_completions` mirrors
+/// `handle_chat_completions` almost exactly, just skipping the
+/// last-message extraction step since there's nothing to extract from.
+#[derive(Debug, Deserialize)]
+struct CompletionRequest {
+    model: String,
+    prompt: String,
+    #[allow(dead_code)]
+    stream: Option<bool>,
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    top_k: Option<usize>,
+    penalty: Option<f32>,
+    max_tokens: Option<usize>,
+}
+#[derive(Debug, Serialize)]
+struct CompletionResponse {
+    id: String,
+    object: String,
+    created: u64,
+    model: String,
+    choices: Vec<CompletionChoice>,
+}
+#[derive(Debug, Serialize)]
+struct CompletionChoice {
+    text: String,
+    index: usize,
+    finish_reason: String,
+}
+
+/// `/v1/embeddings`'s `input` field is `Value` rather than
+/// `String`/`Vec<String>` because the real API accepts either a single
+/// string or an array of strings — `handle_embeddings` normalizes both
+/// into the same code path rather than needing two request types.
+#[derive(Debug, Deserialize)]
+struct EmbeddingsRequest {
+    model: String,
+    input: serde_json::Value,
+}
+#[derive(Debug, Serialize)]
+struct EmbeddingsResponse {
+    object: String,
+    data: Vec<EmbeddingData>,
+    model: String,
+    usage: EmbeddingsUsage,
+}
+#[derive(Debug, Serialize)]
+struct EmbeddingData {
+    object: String,
+    embedding: Vec<f32>,
+    index: usize,
+}
+#[derive(Debug, Serialize)]
+struct EmbeddingsUsage {
+    prompt_tokens: usize,
+    total_tokens: usize,
+}
 #[derive(Debug, Serialize, Deserialize)]
 struct ToolResult {
     tool: String,
@@ -3217,10 +3298,71 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         env_default_usize("GHOSTLINK_CHAT_EXEC_TOKENS", default_tokens).clamp(16, 4096)
     }
 
+    /// Upper bound on prompt size accepted by the OpenAI-compatible REST
+    /// endpoints. Generous enough for any realistic context window while
+    /// keeping a single request from forwarding an unbounded payload into
+    /// the wrapped inference backend.
+    const MAX_PROMPT_CHARS: usize = 200_000;
+
+    /// Rejects prompts that are empty/whitespace-only, over the size cap, or
+    /// contain non-whitespace control characters (e.g. embedded ANSI escape
+    /// sequences or NUL bytes) that have no legitimate role in a chat prompt
+    /// and could otherwise reach logs or a terminal-based backend unescaped.
+    fn validate_prompt_text(prompt: &str) -> Result<(), String> {
+        if prompt.trim().is_empty() {
+            return Err("prompt (or messages[].content) must not be empty".to_string());
+        }
+        if prompt.len() > MAX_PROMPT_CHARS {
+            return Err(format!(
+                "prompt exceeds the {MAX_PROMPT_CHARS}-character limit"
+            ));
+        }
+        if let Some(bad) = prompt
+            .chars()
+            .find(|c| c.is_control() && !matches!(c, '\n' | '\r' | '\t'))
+        {
+            return Err(format!(
+                "prompt contains disallowed control character U+{:04X}",
+                bad as u32
+            ));
+        }
+        Ok(())
+    }
+
+    /// Clamps free-form generation parameters to sane ranges — mirrors the
+    /// pre-existing `max_tokens` clamp so a client sending e.g. `top_p: 500`
+    /// or a negative `temperature` can't hang or crash the wrapped backend.
+    fn sanitize_generation_params(
+        temp: f32,
+        top_p: f32,
+        top_k: usize,
+        penalty: f32,
+    ) -> (f32, f32, usize, f32) {
+        (
+            temp.clamp(0.0, 2.0),
+            top_p.clamp(0.0, 1.0),
+            top_k.clamp(1, 500),
+            penalty.clamp(0.0, 2.0),
+        )
+    }
+
+    fn bad_request_json(message: String) -> (StatusCode, Json<serde_json::Value>) {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": { "message": message, "type": "invalid_request_error" }
+            })),
+        )
+    }
+
     async fn handle_chat_completions(
         State(state): State<Arc<Mutex<BackendState>>>,
         Json(req): Json<ChatCompletionRequest>,
-    ) -> Json<ChatCompletionResponse> {
+    ) -> Result<Json<ChatCompletionResponse>, (StatusCode, Json<serde_json::Value>)> {
+        if req.messages.is_empty() {
+            return Err(bad_request_json("messages must not be empty".to_string()));
+        }
+
         let prompt = req
             .messages
             .iter()
@@ -3232,13 +3374,17 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             })
             .unwrap_or_default();
 
+        validate_prompt_text(&prompt).map_err(bad_request_json)?;
+
         let request_tracker = active_runtime_switcher().request_tracker().clone();
         request_tracker.increment().await;
 
-        let temp = req.temperature.unwrap_or(0.7);
-        let top_p = req.top_p.unwrap_or(0.9);
-        let top_k = req.top_k.unwrap_or(40);
-        let penalty = req.penalty.unwrap_or(1.1);
+        let (temp, top_p, top_k, penalty) = sanitize_generation_params(
+            req.temperature.unwrap_or(0.7),
+            req.top_p.unwrap_or(0.9),
+            req.top_k.unwrap_or(40),
+            req.penalty.unwrap_or(1.1),
+        );
         let max_tokens = req.max_tokens.unwrap_or(1024).clamp(16, 4096);
 
         let (
@@ -3250,6 +3396,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             ollama_client,
             vllm_client,
             settings,
+            plugin_registry,
         ) = {
             let mut backend = lock_state(&state);
             backend.chat_requests = backend.chat_requests.saturating_add(1);
@@ -3267,8 +3414,78 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 backend.ollama_client.clone(),
                 backend.vllm_client.clone(),
                 backend.settings.clone(),
+                backend.plugin_registry.clone(),
             )
         };
+
+        let gen_started = Instant::now();
+
+        // Custom backend dispatch — checked before the built-in Native/Ollama
+        // match below (left completely unmodified) so registering a plugin
+        // never changes behavior for the two built-in backends. See
+        // `backend_plugin` module docs.
+        if let Some(plugin) = plugin_registry.get(&settings.inference_backend) {
+            let plugin_name = plugin.name().to_string();
+            let result = plugin
+                .generate(backend_plugin::PluginGenerationRequest {
+                    model: model.clone(),
+                    prompt: prompt.clone(),
+                    temperature: temp,
+                    top_p,
+                    top_k,
+                    penalty,
+                    max_tokens,
+                })
+                .await;
+            let gen_latency_ms = gen_started.elapsed().as_secs_f32() * 1000.0;
+
+            let (response_text, tokens_out, real_inference) = match result {
+                Ok(r) => (r.text, r.tokens, true),
+                Err(err) => (
+                    format!("Custom backend '{plugin_name}' error: {err}"),
+                    0,
+                    false,
+                ),
+            };
+            let tokens_per_sec = (gen_latency_ms > 0.0 && tokens_out > 0)
+                .then(|| tokens_out as f32 / (gen_latency_ms / 1000.0));
+
+            {
+                let mut backend = lock_state(&state);
+                backend.last_latency_ms = gen_latency_ms;
+                if let Some(tps) = tokens_per_sec {
+                    backend.last_tokens_per_sec = tps;
+                }
+                backend.inference_metrics.record(
+                    gen_latency_ms,
+                    tokens_out,
+                    tokens_per_sec,
+                    real_inference,
+                );
+            }
+
+            request_tracker.decrement().await;
+
+            return Ok(Json(ChatCompletionResponse {
+                id: format!("chatcmpl-{}", rand::random::<u32>()),
+                object: "chat.completion".to_string(),
+                created: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                model: model.clone(),
+                choices: vec![Choice {
+                    index: 0,
+                    message: serde_json::json!({
+                        "role": "assistant",
+                        "content": response_text,
+                        "backend": plugin_name,
+                        "real_inference": real_inference
+                    }),
+                    finish_reason: "stop".to_string(),
+                }],
+            }));
+        }
 
         let nodes = cluster.nodes();
         let total_vram = cluster.total_vram_gb();
@@ -3442,7 +3659,349 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         });
 
         request_tracker.decrement().await;
-        response
+        Ok(response)
+    }
+
+    /// OpenAI's legacy `/v1/completions` endpoint: same backend dispatch as
+    /// `handle_chat_completions`, just reading a plain `prompt` string
+    /// instead of extracting one from a `messages` array. No session
+    /// context here (this is the stateless REST surface, not the GUI's
+    /// conversation), so no slot/cache-prompt reuse — matches
+    /// `handle_chat_completions`'s existing behavior.
+    async fn handle_completions(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Json(req): Json<CompletionRequest>,
+    ) -> Result<Json<CompletionResponse>, (StatusCode, Json<serde_json::Value>)> {
+        validate_prompt_text(&req.prompt).map_err(bad_request_json)?;
+        let prompt = req.prompt;
+
+        let request_tracker = active_runtime_switcher().request_tracker().clone();
+        request_tracker.increment().await;
+
+        let (temp, top_p, top_k, penalty) = sanitize_generation_params(
+            req.temperature.unwrap_or(0.7),
+            req.top_p.unwrap_or(0.9),
+            req.top_k.unwrap_or(40),
+            req.penalty.unwrap_or(1.1),
+        );
+        let max_tokens = req.max_tokens.unwrap_or(1024).clamp(16, 4096);
+
+        let (
+            model,
+            cluster,
+            inference_backend,
+            native_engine_client,
+            ollama_client,
+            vllm_client,
+            settings,
+            plugin_registry,
+        ) = {
+            let mut backend = lock_state(&state);
+            backend.chat_requests = backend.chat_requests.saturating_add(1);
+            let model = if req.model.trim().is_empty() {
+                backend.current_model.clone()
+            } else {
+                req.model.clone()
+            };
+            (
+                model,
+                Arc::clone(&backend.cluster),
+                backend.inference_backend,
+                backend.native_engine_client.clone(),
+                backend.ollama_client.clone(),
+                backend.vllm_client.clone(),
+                backend.settings.clone(),
+                backend.plugin_registry.clone(),
+            )
+        };
+
+        let gen_started = Instant::now();
+
+        // Custom backend dispatch — checked before the built-in Native/Ollama
+        // match below (left completely unmodified). See `backend_plugin`
+        // module docs and `handle_chat_completions`'s matching check.
+        if let Some(plugin) = plugin_registry.get(&settings.inference_backend) {
+            let plugin_name = plugin.name().to_string();
+            let result = plugin
+                .generate(backend_plugin::PluginGenerationRequest {
+                    model: model.clone(),
+                    prompt: prompt.clone(),
+                    temperature: temp,
+                    top_p,
+                    top_k,
+                    penalty,
+                    max_tokens,
+                })
+                .await;
+            let gen_latency_ms = gen_started.elapsed().as_secs_f32() * 1000.0;
+
+            let (response_text, tokens_out, real_inference) = match result {
+                Ok(r) => (r.text, r.tokens, true),
+                Err(err) => (
+                    format!("Custom backend '{plugin_name}' error: {err}"),
+                    0,
+                    false,
+                ),
+            };
+            let tokens_per_sec = (gen_latency_ms > 0.0 && tokens_out > 0)
+                .then(|| tokens_out as f32 / (gen_latency_ms / 1000.0));
+
+            {
+                let mut backend = lock_state(&state);
+                backend.last_latency_ms = gen_latency_ms;
+                if let Some(tps) = tokens_per_sec {
+                    backend.last_tokens_per_sec = tps;
+                }
+                backend.inference_metrics.record(
+                    gen_latency_ms,
+                    tokens_out,
+                    tokens_per_sec,
+                    real_inference,
+                );
+            }
+
+            request_tracker.decrement().await;
+
+            return Ok(Json(CompletionResponse {
+                id: format!("cmpl-{}", rand::random::<u32>()),
+                object: "text_completion".to_string(),
+                created: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+                model,
+                choices: vec![CompletionChoice {
+                    text: response_text,
+                    index: 0,
+                    finish_reason: "stop".to_string(),
+                }],
+            }));
+        }
+
+        let nodes = cluster.nodes();
+        let total_vram = cluster.total_vram_gb();
+        let layer_count = (total_vram * 2.0).clamp(8.0, 60.0) as usize;
+        let layers: Vec<LayerSpec> = (0..layer_count)
+            .map(|index| LayerSpec {
+                index,
+                vram_gb: (total_vram / (layer_count as f32 + 1.0)).min(0.4),
+                num_weights: 500_000_000 / 60,
+            })
+            .collect();
+
+        let profile = detect_runtime_profile("studio-api");
+        let exec_tokens = chat_exec_token_budget(32);
+        let exec_micro_batch = chat_exec_micro_batch();
+        let mut execution_info = String::new();
+        let result = match assign_layers_with_runtime_profile(&nodes, &layers, &profile) {
+            Ok(assignments) => {
+                let device_map = build_device_map_from_cluster(&profile, &cluster);
+                let pipeline_plan = PipelinePlan::from_assignments(&assignments, &device_map);
+                let pipeline_plan_clone = pipeline_plan.clone();
+
+                let exec_result = if nodes.len() > 1 {
+                    ghostlink_core::runtime::execute_pipeline_distributed(
+                        &pipeline_plan,
+                        exec_tokens,
+                        exec_micro_batch,
+                        tcp_transport_config_from_env(),
+                        &cluster,
+                        None,
+                        None,
+                    )
+                    .ok()
+                } else {
+                    execute_pipeline_tcp_loopback(&pipeline_plan, exec_tokens, exec_micro_batch)
+                        .ok()
+                };
+
+                if let Some(ref exec) = exec_result {
+                    let mut backend = lock_state(&state);
+                    backend.last_latency_ms = exec.avg_token_latency_ms;
+                    let tokens_per_sec = exec.throughput_tokens_per_sec;
+                    backend.last_tokens_per_sec = tokens_per_sec;
+                    backend.inference_metrics.record(
+                        exec.avg_token_latency_ms,
+                        exec.token_count.min(u32::MAX as usize) as u32,
+                        Some(tokens_per_sec),
+                        true,
+                    );
+                    for stage in &exec.stage_stats {
+                        if let Some(stage_p) = pipeline_plan_clone.stages.get(stage.stage_idx) {
+                            backend.cluster.get_metrics_mut(&stage_p.node_id, |m| {
+                                m.record_latency(stage.avg_compute_ms * 1000.0);
+                                m.record_throughput(tokens_per_sec / 1000.0);
+                            });
+                        }
+                    }
+                }
+                exec_result
+            }
+            Err(_) => None,
+        };
+
+        if let Some(exec) = result {
+            execution_info = format!(
+                " (Throughput: {:.2} tok/s, Latency: {:.2} ms)",
+                exec.throughput_tokens_per_sec, exec.avg_token_latency_ms
+            );
+        }
+
+        let response_text = match inference_backend {
+            InferenceEngine::Ollama => ollama_client
+                .generate(&model, &prompt, temp, top_p, top_k, penalty, max_tokens)
+                .await
+                .unwrap_or_else(|err| {
+                    format!("Ollama generation failed for model '{}': {}", model, err)
+                }),
+            InferenceEngine::Native => native_engine_client
+                .generate(
+                    &model,
+                    &prompt,
+                    exec_tokens,
+                    0.7,
+                    0.9,
+                    40,
+                    1.1,
+                    &settings.native_engine,
+                    // Stateless endpoint, no session to pin a slot to —
+                    // matches handle_chat_completions' same behavior.
+                    None,
+                    false,
+                    None,
+                )
+                .await
+                .map(|gen| gen.text)
+                .unwrap_or_else(|err| {
+                    format!(
+                        "Ghostlink native fabric backend error on model '{}'.{} Error: {}",
+                        model, execution_info, err
+                    )
+                }),
+            InferenceEngine::Vllm => vllm_client
+                .generate(&model, &prompt, temp, top_p, top_k, penalty, max_tokens)
+                .await
+                .unwrap_or_else(|err| {
+                    format!("vLLM generation failed for model '{}': {}", model, err)
+                }),
+        };
+
+        let response = Json(CompletionResponse {
+            id: format!("cmpl-{}", rand::random::<u32>()),
+            object: "text_completion".to_string(),
+            created: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            model,
+            choices: vec![CompletionChoice {
+                text: response_text,
+                index: 0,
+                finish_reason: "stop".to_string(),
+            }],
+        });
+
+        request_tracker.decrement().await;
+        Ok(response)
+    }
+
+    /// Cheap chars/4 heuristic — no tokenizer wired in, but good enough to
+    /// report a `prompt_tokens`/`total_tokens` usage estimate on
+    /// `/v1/embeddings` responses without pulling in a model-specific vocab.
+    fn estimate_tokens(text: &str) -> usize {
+        (text.chars().count() / 4).max(if text.trim().is_empty() { 0 } else { 1 })
+    }
+
+    /// `/v1/embeddings`'s `input` field accepts either a single string or an
+    /// array of strings per the OpenAI spec — normalizes both into one list so
+    /// the handler has a single code path. Non-string array entries are
+    /// dropped rather than erroring the whole batch; an all-invalid or empty
+    /// input yields an empty `Vec`, which the caller turns into a 400.
+    fn normalize_embeddings_input(input: &serde_json::Value) -> Vec<String> {
+        match input {
+            serde_json::Value::String(s) => vec![s.clone()],
+            serde_json::Value::Array(items) => items
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// OpenAI's `/v1/embeddings` endpoint, backed by
+    /// `OllamaClient::embeddings()` (already used internally by
+    /// `/api/ollama/embeddings`). The native engine has no embedding
+    /// support today — that would need a second llama-server instance
+    /// launched with `--embedding`, out of scope here — so a native-backend
+    /// request gets a real 501 explaining that, rather than a silent
+    /// failure or a faked response.
+    async fn handle_embeddings(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Json(req): Json<EmbeddingsRequest>,
+    ) -> axum::response::Response {
+        let inputs = normalize_embeddings_input(&req.input);
+        if inputs.is_empty() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": { "message": "input must be a non-empty string or array of strings", "type": "invalid_request_error" }
+                })),
+            )
+                .into_response();
+        }
+
+        let (inference_backend, ollama_client) = {
+            let backend = lock_state(&state);
+            (backend.inference_backend, backend.ollama_client.clone())
+        };
+
+        if inference_backend != InferenceEngine::Ollama {
+            return (
+                StatusCode::NOT_IMPLEMENTED,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": "embeddings are only available with the Ollama backend today — the native llama-server engine has no embedding support wired in",
+                        "type": "not_implemented"
+                    }
+                })),
+            )
+                .into_response();
+        }
+
+        let mut data = Vec::with_capacity(inputs.len());
+        let mut prompt_tokens = 0usize;
+        for (index, text) in inputs.iter().enumerate() {
+            match ollama_client.embeddings(&req.model, text).await {
+                Ok(embedding) => {
+                    prompt_tokens += estimate_tokens(text);
+                    data.push(EmbeddingData {
+                        object: "embedding".to_string(),
+                        embedding,
+                        index,
+                    });
+                }
+                Err(err) => {
+                    return (
+                        StatusCode::BAD_GATEWAY,
+                        Json(serde_json::json!({
+                            "error": { "message": format!("embedding generation failed: {err}"), "type": "upstream_error" }
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+        }
+
+        Json(EmbeddingsResponse {
+            object: "list".to_string(),
+            data,
+            model: req.model,
+            usage: EmbeddingsUsage {
+                prompt_tokens,
+                total_tokens: prompt_tokens,
+            },
+        })
+        .into_response()
     }
 
     fn detect_quantization(filename: &str) -> String {
@@ -4259,8 +4818,86 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         Json(serde_json::json!({ "status": "ok" }))
     }
 
-    async fn handle_gui_workers_discover() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "status": "ok", "count": 2 }))
+    async fn handle_gui_workers_discover(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let (cluster, discovery_broadcast, discovery_auth_token) = {
+            let backend = lock_state(&state);
+            (
+                Arc::clone(&backend.cluster),
+                backend.settings.discovery_broadcast.clone(),
+                backend.settings.discovery_auth_token.clone(),
+            )
+        };
+
+        let broadcast_addr = discovery_broadcast
+            .parse::<SocketAddr>()
+            .unwrap_or_else(|_| SocketAddr::from(([255, 255, 255, 255], DEFAULT_DISCOVERY_PORT)));
+        let auth_token = if discovery_auth_token.is_empty() {
+            None
+        } else {
+            Some(discovery_auth_token)
+        };
+        let local_node = detect_runtime_profile("workers-discover").node_resources;
+
+        // Both discovery paths block on their own recv loop — run them off
+        // the async runtime, concurrently, so neither stalls the other or
+        // other requests. mDNS complements the UDP broadcast fallback for
+        // networks (managed VLANs, cloud VPCs) that filter broadcast but
+        // still carry multicast.
+        let udp_peers_fut = tokio::task::spawn_blocking(move || {
+            let config = UdpDiscoveryConfig {
+                broadcast_addr,
+                auth_token,
+                response_timeout: Duration::from_millis(1200),
+                allow_legacy_crc32: env_default_bool(
+                    "GHOSTLINK_DISCOVERY_ALLOW_LEGACY_CRC32",
+                    false,
+                ),
+                ..UdpDiscoveryConfig::default()
+            };
+            let frame = DiscoveryFrame {
+                kind: FrameKind::Join,
+                node: local_node,
+            };
+            broadcast_and_collect(&frame, &config)
+        });
+        let mdns_peers_fut = tokio::task::spawn_blocking(|| {
+            ghostlink_core::mdns::discover(Duration::from_millis(1200))
+        });
+
+        let (udp_result, mdns_result) = tokio::join!(udp_peers_fut, mdns_peers_fut);
+        let udp_peers = udp_result
+            .unwrap_or_else(|_| Ok(Vec::new()))
+            .unwrap_or_default();
+        let mdns_peers = mdns_result
+            .unwrap_or_else(|_| Ok(Vec::new()))
+            .unwrap_or_else(|err| {
+                tracing::warn!("mdns: discover failed, continuing with UDP results only: {err}");
+                Vec::new()
+            });
+
+        // Dedupe by node id — a peer reachable via both paths should only
+        // count once. UDP wins ties since it carries a real reply address
+        // straight from the socket rather than an mDNS-resolved one.
+        let mut by_id = std::collections::HashMap::new();
+        for (frame, addr) in udp_peers {
+            by_id.insert(frame.node.id.clone(), (frame.node, addr));
+        }
+        for (node, addr) in mdns_peers {
+            by_id.entry(node.id.clone()).or_insert((node, addr));
+        }
+
+        let discovered = by_id.len();
+        for (node, addr) in by_id.into_values() {
+            cluster.register_with_addr(node, Some(addr));
+        }
+
+        Json(serde_json::json!({
+            "status": "ok",
+            "discovered": discovered,
+            "count": cluster.node_count(),
+        }))
     }
 
     async fn handle_gui_workers_disconnect(
@@ -4345,6 +4982,133 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             node_count,
             &backend_name,
         ))
+    }
+
+    /// Prometheus text-exposition-format sibling of `/api/metrics` — same
+    /// underlying snapshot, reformatted for scraping instead of the GUI poll.
+    /// Behind the same bearer-auth middleware as the rest of the API, so a
+    /// Prometheus scrape config needs an `authorization`/`bearer_token` entry.
+    async fn handle_metrics_prometheus(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> impl IntoResponse {
+        let host = host_metrics::current_host_snapshot();
+
+        let (inf, node_count, cluster_vram, uptime_s, backend_name) = {
+            let backend = lock_state(&state);
+            let cluster = Arc::clone(&backend.cluster);
+            let node_count = cluster.node_count();
+            let cluster_vram = cluster.total_vram_gb();
+            let inf = backend.inference_metrics.snapshot();
+            let uptime_s = backend.started_at.elapsed().as_secs_f32();
+            let backend_name = backend.inference_backend.as_str().to_string();
+            (inf, node_count, cluster_vram, uptime_s, backend_name)
+        };
+
+        let total_vram = if host.total_vram_gb > 0.0 {
+            host.total_vram_gb
+        } else {
+            cluster_vram
+        };
+        let gpu = if host.gpu_available { host.gpu } else { 0.0 };
+
+        let mut body = String::new();
+        let gauge = |body: &mut String, name: &str, help: &str, value: f32| {
+            body.push_str(&format!(
+                "# HELP {name} {help}\n# TYPE {name} gauge\n{name} {value}\n"
+            ));
+        };
+
+        gauge(
+            &mut body,
+            "ghostlink_inference_throughput_tokens_per_second",
+            "Recent tokens generated per second (EMA).",
+            inf.tokens_per_sec,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_cpu_utilization_percent",
+            "Host CPU utilization percent.",
+            host.cpu,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_memory_utilization_percent",
+            "Host memory utilization percent.",
+            host.memory,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_gpu_utilization_percent",
+            "GPU utilization percent (0 when no GPU is available).",
+            gpu,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_inference_latency_p50_milliseconds",
+            "Inference latency, 50th percentile over the recent sample window.",
+            inf.latency_p50_ms,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_inference_latency_p95_milliseconds",
+            "Inference latency, 95th percentile over the recent sample window.",
+            inf.latency_p95_ms,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_cluster_active_nodes",
+            "Number of active cluster nodes.",
+            node_count as f32,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_cluster_total_vram_gb",
+            "Total VRAM available across the cluster, in GB.",
+            total_vram,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_host_total_memory_gb",
+            "Total host system memory, in GB.",
+            host.total_memory_gb,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_host_used_memory_gb",
+            "Used host system memory, in GB.",
+            host.used_memory_gb,
+        );
+        gauge(
+            &mut body,
+            "ghostlink_uptime_seconds",
+            "Seconds since the API server started.",
+            uptime_s,
+        );
+
+        body.push_str(
+            "# HELP ghostlink_inference_samples_total Total inference latency samples recorded since startup.\n\
+             # TYPE ghostlink_inference_samples_total counter\n",
+        );
+        body.push_str(&format!(
+            "ghostlink_inference_samples_total {}\n",
+            inf.samples
+        ));
+
+        body.push_str(
+            "# HELP ghostlink_build_info Static info labels; value is always 1.\n\
+             # TYPE ghostlink_build_info gauge\n",
+        );
+        body.push_str(&format!(
+            "ghostlink_build_info{{inference_backend=\"{backend_name}\"}} 1\n"
+        ));
+
+        (
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "text/plain; version=0.0.4; charset=utf-8",
+            )],
+            body,
+        )
     }
 
     async fn handle_gui_sessions(
@@ -5955,6 +6719,8 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     println!("Listening on http://{}:{}", host, port);
     println!("Routes:");
     println!("  - POST /v1/chat/completions");
+    println!("  - POST /v1/completions");
+    println!("  - POST /v1/embeddings");
     println!("  - GET  /v1/models");
     println!("  - GET  /health");
     println!("  - GET  /api/models");
@@ -6043,6 +6809,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
         let _ = serve_discovery(&node_for_listener, &config, None);
     });
+
+    // mDNS is a complement to UDP broadcast discovery above, not a
+    // replacement — some networks (managed VLANs, cloud VPCs) filter
+    // broadcast traffic but still carry multicast. Best-effort: logged and
+    // otherwise ignored on failure, same as the UDP listener thread.
+    ghostlink_core::mdns::ensure_advertised(&profile.node_resources, port);
 
     let cluster_for_broadcast = Arc::clone(&cluster);
     let node_for_broadcast = profile.node_resources.clone();
@@ -6238,6 +7010,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         pending_tool_calls: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         download_progress: HashMap::new(),
         model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
+        plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
         enable_tls_active: use_tls,
     }));
 
@@ -6256,8 +7029,31 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             }
         });
 
+        // Per-IP request rate limiting — protects the API from runaway
+        // clients/retry loops. Applied as the outermost layer so it gates
+        // requests before CORS/auth do any work.
+        let governor_conf = std::sync::Arc::new(
+            tower_governor::governor::GovernorConfigBuilder::default()
+                .per_second(2)
+                .burst_size(30)
+                .finish()
+                .expect("static governor config is always valid"),
+        );
+        {
+            let governor_conf = Arc::clone(&governor_conf);
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+                loop {
+                    interval.tick().await;
+                    governor_conf.limiter().retain_recent();
+                }
+            });
+        }
+
         let app = Router::new()
             .route("/v1/chat/completions", post(handle_chat_completions))
+            .route("/v1/completions", post(handle_completions))
+            .route("/v1/embeddings", post(handle_embeddings))
             .route("/v1/models", get(handle_models))
             .route("/health", get(handle_health))
             .route("/api/health", get(handle_health))
@@ -6310,6 +7106,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             )
             .route("/api/metrics", get(handle_gui_metrics))
             .route("/api/metrics/history", get(handle_gui_metrics_history))
+            .route("/metrics", get(handle_metrics_prometheus))
             .route("/api/sessions", get(handle_gui_sessions))
             .route("/api/sessions/save", post(handle_gui_session_save))
             .route("/api/sessions/:session_id", get(handle_gui_session_load))
@@ -6361,7 +7158,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             // OPTIONS request is still handled without needing a bearer
             // token — matches how CORS preflight is expected to work.
             .layer(middleware::from_fn(auth_middleware))
-            .layer(CorsLayer::permissive());
+            .layer(CorsLayer::permissive())
+            .layer(tower_governor::GovernorLayer {
+                config: governor_conf,
+            });
 
         // addr already parsed above; `use_tls` computed earlier alongside
         // `BackendState.enable_tls_active`.
@@ -6383,7 +7183,7 @@ API Server Online (HTTPS, PQC-hybrid key exchange preferred). Ready for connecti
             });
             axum_server::bind_rustls(addr, tls_config)
                 .handle(shutdown_handle)
-                .serve(app.into_make_service())
+                .serve(app.into_make_service_with_connect_info::<SocketAddr>())
                 .await
                 .map_err(|err| anyhow::anyhow!("HTTPS API server terminated with error: {}", err))
         } else {
@@ -6395,10 +7195,13 @@ API Server Online (HTTPS, PQC-hybrid key exchange preferred). Ready for connecti
 API Server Online. Ready for connections."
             );
 
-            axum::serve(listener, app)
-                .with_graceful_shutdown(mcp_shutdown_on_ctrl_c(mcp_registry))
-                .await
-                .map_err(|err| anyhow::anyhow!("API server terminated with error: {}", err))
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .with_graceful_shutdown(mcp_shutdown_on_ctrl_c(mcp_registry))
+            .await
+            .map_err(|err| anyhow::anyhow!("API server terminated with error: {}", err))
         }
     })?;
 
@@ -8421,6 +9224,7 @@ fn run_gui_preflight_checks() -> Result<()> {
 mod auth;
 mod backend_api;
 mod backend_config;
+mod backend_plugin;
 mod backend_registry;
 mod host_metrics;
 mod inference_engine;
@@ -8516,6 +9320,7 @@ mod tests {
             download_progress: HashMap::new(),
             model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
             enable_tls_active: false,
+            plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
         }))
     }
 

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -4359,46 +4359,72 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             return Err("No GGUF files found in this repository. Try a GGUF-quantized variant (e.g. lmstudio-community/Meta-Llama-3-8B-Instruct-GGUF).".to_string());
         }
 
-        let filename = &gguf_files[0];
-        let file_url = format!(
-            "https://huggingface.co/{}/resolve/main/{}",
-            model_id, filename
-        );
-        let dest_path = models_dir.join(filename);
+        // Pick a quantization that fits this machine's VRAM instead of
+        // blindly taking whatever file the repo listed first, and pull every
+        // shard of a split GGUF instead of just one.
+        let vram_gb = detect_runtime_profile("hf-download").node_resources.vram_gb;
+        let groups = group_gguf_shards(&gguf_files);
+        let chosen_files = select_best_gguf_group(&groups, vram_gb)
+            .ok_or_else(|| "No usable GGUF file found in this repository".to_string())?;
 
-        if dest_path.exists() {
-            return Ok(dest_path.to_string_lossy().to_string());
+        let mut first_dest_path: Option<std::path::PathBuf> = None;
+        for filename in &chosen_files {
+            let file_url = format!(
+                "https://huggingface.co/{}/resolve/main/{}",
+                model_id, filename
+            );
+            // `filename` comes straight from the remote HuggingFace API response
+            // (`rfilename`) and may contain nested-path separators or, in the
+            // worst case, an absolute path. `PathBuf::join` silently discards the
+            // base directory when given an absolute path, and any path
+            // separators could otherwise let a crafted repo write outside
+            // `models_dir`. Only the file's base name is ever meaningful here.
+            let safe_filename = std::path::Path::new(filename.as_str())
+                .file_name()
+                .map(|f| f.to_string_lossy().into_owned())
+                .filter(|f| !f.is_empty())
+                .unwrap_or_else(|| "download.gguf".to_string());
+            let dest_path = models_dir.join(&safe_filename);
+
+            if !dest_path.exists() {
+                let resp = client
+                    .get(&file_url)
+                    .send()
+                    .await
+                    .map_err(|e| format!("Download error: {}", e))?;
+
+                if !resp.status().is_success() {
+                    return Err(format!("Failed to download file (HTTP {})", resp.status()));
+                }
+
+                if let Some(parent) = dest_path.parent() {
+                    fs::create_dir_all(parent).map_err(|e| format!("Dir error: {}", e))?;
+                }
+                let mut file = tokio::fs::File::create(&dest_path)
+                    .await
+                    .map_err(|e| format!("File error: {}", e))?;
+                let mut stream = resp;
+                while let Some(chunk) = stream
+                    .chunk()
+                    .await
+                    .map_err(|e| format!("Stream error: {}", e))?
+                {
+                    file.write_all(&chunk)
+                        .await
+                        .map_err(|e| format!("Write error: {}", e))?;
+                }
+                file.flush().await.ok();
+            }
+
+            if first_dest_path.is_none() {
+                first_dest_path = Some(dest_path);
+            }
         }
 
-        let resp = client
-            .get(&file_url)
-            .send()
-            .await
-            .map_err(|e| format!("Download error: {}", e))?;
-
-        if !resp.status().is_success() {
-            return Err(format!("Failed to download file (HTTP {})", resp.status()));
-        }
-
-        if let Some(parent) = dest_path.parent() {
-            fs::create_dir_all(parent).map_err(|e| format!("Dir error: {}", e))?;
-        }
-        let mut file = tokio::fs::File::create(&dest_path)
-            .await
-            .map_err(|e| format!("File error: {}", e))?;
-        let mut stream = resp;
-        while let Some(chunk) = stream
-            .chunk()
-            .await
-            .map_err(|e| format!("Stream error: {}", e))?
-        {
-            file.write_all(&chunk)
-                .await
-                .map_err(|e| format!("Write error: {}", e))?;
-        }
-        file.flush().await.ok();
-
-        Ok(dest_path.to_string_lossy().to_string())
+        Ok(first_dest_path
+            .expect("chosen_files is non-empty")
+            .to_string_lossy()
+            .to_string())
     }
 
     async fn handle_models(
@@ -10356,6 +10382,87 @@ mod tests {
         let map = build_device_map(&profile, "amdgpu", "n2");
         assert_eq!(map.get("amdgpu"), Some(&DeviceKind::Gpu));
         assert_eq!(map.get("n2"), Some(&DeviceKind::Gpu));
+    }
+
+    #[test]
+    fn quant_rank_orders_common_tags_by_size() {
+        assert!(quant_rank("MODEL-Q2_K.GGUF") < quant_rank("MODEL-Q4_K_M.GGUF"));
+        assert!(quant_rank("MODEL-Q4_K_M.GGUF") < quant_rank("MODEL-Q8_0.GGUF"));
+        assert!(quant_rank("MODEL-Q8_0.GGUF") < quant_rank("MODEL-F16.GGUF"));
+        // Longest-match tie-break: "Q3_K_M" must not be misread via a
+        // hypothetical shorter overlapping tag.
+        assert_eq!(
+            quant_rank("MODEL-Q3_K_M.GGUF"),
+            quant_rank("model-q3_k_m.gguf".to_uppercase().as_str())
+        );
+        assert_eq!(quant_rank("MODEL-UNKNOWNQUANT.GGUF"), None);
+    }
+
+    #[test]
+    fn target_quant_rank_scales_down_for_low_vram() {
+        let high = target_quant_rank_for_vram(24.0);
+        let mid = target_quant_rank_for_vram(8.0);
+        let low = target_quant_rank_for_vram(2.0);
+        assert!(low < mid);
+        assert!(mid <= high);
+    }
+
+    #[test]
+    fn select_best_gguf_group_picks_fitting_quant_not_first_listed() {
+        // Regression: previously `download_hf_model` always took whatever
+        // file HuggingFace's API listed first, regardless of size. A repo
+        // commonly lists a large quant before smaller ones.
+        let files = vec![
+            "model-F16.gguf".to_string(),
+            "model-Q8_0.gguf".to_string(),
+            "model-Q4_K_M.gguf".to_string(),
+            "model-Q2_K.gguf".to_string(),
+        ];
+        let groups = group_gguf_shards(&files);
+        // Below 4GB VRAM should land on a small/mid quant, never blindly on
+        // F16 (index 0, and the largest/most likely to fail to load).
+        let chosen = select_best_gguf_group(&groups, 3.5).expect("a group should be chosen");
+        assert_ne!(chosen, vec!["model-F16.gguf".to_string()]);
+        let rank = quant_rank(&chosen[0].to_ascii_uppercase()).expect("known tag");
+        assert!(
+            rank <= quant_rank("Q4_K_M").unwrap(),
+            "expected a Q4_K_M-or-smaller pick for 3.5GB VRAM, got rank {rank}"
+        );
+
+        // Higher VRAM should land on a noticeably bigger quant than the
+        // low-VRAM case, confirming the target actually scales with VRAM
+        // rather than always converging on the same answer.
+        let chosen_high = select_best_gguf_group(&groups, 24.0).expect("a group should be chosen");
+        let rank_high = quant_rank(&chosen_high[0].to_ascii_uppercase()).expect("known tag");
+        assert!(rank_high > rank);
+    }
+
+    #[test]
+    fn group_gguf_shards_keeps_split_files_together_in_order() {
+        // Regression: previously only the first shard of a split GGUF was
+        // ever downloaded, leaving an unloadable partial model on disk.
+        let files = vec![
+            "model-Q8_0-00002-of-00003.gguf".to_string(),
+            "model-Q4_K_M.gguf".to_string(),
+            "model-Q8_0-00001-of-00003.gguf".to_string(),
+            "model-Q8_0-00003-of-00003.gguf".to_string(),
+        ];
+        let groups = group_gguf_shards(&files);
+        let split_group = groups
+            .iter()
+            .find(|g| g.len() > 1)
+            .expect("the Q8_0 split set should be grouped together");
+        assert_eq!(
+            split_group,
+            &vec![
+                "model-Q8_0-00001-of-00003.gguf".to_string(),
+                "model-Q8_0-00002-of-00003.gguf".to_string(),
+                "model-Q8_0-00003-of-00003.gguf".to_string(),
+            ]
+        );
+        assert!(groups
+            .iter()
+            .any(|g| g == &vec!["model-Q4_K_M.gguf".to_string()]));
     }
 
     #[test]

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1533,6 +1533,59 @@ struct BackendState {
     /// setting and only takes effect on next restart; this field is what
     /// `/api/security/pqc/state` actually reports.
     enable_tls_active: bool,
+    /// Real security-relevant events (failed auth, tool-call approvals,
+    /// PQC/JWT actions) for `/api/security/audit-log` — was previously
+    /// hardcoded to always return an empty list. In-memory only (resets on
+    /// restart) and capped at `AUDIT_LOG_CAP`; a genuinely persistent trail
+    /// would need an append-only file, which is a bigger step than this
+    /// first real version takes.
+    audit_log: std::collections::VecDeque<AuditLogEntry>,
+}
+
+/// One row for the GUI's Security tab audit log — field names/shape match
+/// what `SecurityTab.tsx` already expects (it predates a real backend for
+/// this and was rendering against a permanently-empty list).
+#[derive(Debug, Clone, Serialize)]
+struct AuditLogEntry {
+    event: String,
+    /// "SUCCESS"/"AUTHENTICATED" render green in the GUI; anything else
+    /// (e.g. "FAILED", "DENIED") renders as a yellow warning badge.
+    status: String,
+    ip: String,
+    /// RFC3339 — the GUI does `new Date(e.time)` on this directly.
+    time: String,
+    detail: Option<String>,
+}
+
+const AUDIT_LOG_CAP: usize = 500;
+
+/// Appends one entry and trims from the front once over `AUDIT_LOG_CAP` —
+/// split out from `record_audit_event` so it's unit-testable against a bare
+/// `VecDeque` without needing to construct a full `BackendState`.
+fn push_audit_entry(log: &mut std::collections::VecDeque<AuditLogEntry>, entry: AuditLogEntry) {
+    log.push_back(entry);
+    while log.len() > AUDIT_LOG_CAP {
+        log.pop_front();
+    }
+}
+
+fn record_audit_event(
+    backend: &mut BackendState,
+    event: &str,
+    status: &str,
+    ip: String,
+    detail: Option<String>,
+) {
+    push_audit_entry(
+        &mut backend.audit_log,
+        AuditLogEntry {
+            event: event.to_string(),
+            status: status.to_string(),
+            ip,
+            time: chrono::Utc::now().to_rfc3339(),
+            detail,
+        },
+    );
 }
 
 /// Real byte-level progress for an in-flight (or just-finished) model download.
@@ -3428,7 +3481,7 @@ fn detect_node_id() -> String {
 
 fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     use axum::{
-        extract::{Path, Query, Request, State},
+        extract::{ConnectInfo, Path, Query, Request, State},
         http::StatusCode,
         middleware::{self, Next},
         response::{
@@ -3453,7 +3506,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     /// Guards every route except `/health` behind a real bearer token
     /// (the persisted API key itself, or a JWT issued from it — see
     /// `auth.rs`). Replaces having no auth check anywhere on this server.
-    async fn auth_middleware(req: Request, next: Next) -> axum::response::Response {
+    async fn auth_middleware(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
+        req: Request,
+        next: Next,
+    ) -> axum::response::Response {
         if req.uri().path() == "/health" {
             return next.run(req).await;
         }
@@ -3466,16 +3524,25 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
         match token {
             Some(t) if auth::verify_bearer_token(t) => next.run(req).await,
-            _ => (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({
-                    "error": {
-                        "message": "missing or invalid Authorization: Bearer <token> — see the API key printed at server startup, or POST /api/security/jwt/refresh with it to get a short-lived token",
-                        "type": "unauthorized"
-                    }
-                })),
-            )
-                .into_response(),
+            _ => {
+                record_audit_event(
+                    &mut lock_state(&state),
+                    "auth",
+                    "FAILED",
+                    addr.ip().to_string(),
+                    Some(format!("{} {}", req.method(), req.uri().path())),
+                );
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({
+                        "error": {
+                            "message": "missing or invalid Authorization: Bearer <token> — see the API key printed at server startup, or POST /api/security/jwt/refresh with it to get a short-lived token",
+                            "type": "unauthorized"
+                        }
+                    })),
+                )
+                    .into_response()
+            }
         }
     }
 
@@ -5445,6 +5512,352 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }
     }
 
+    // --- Workspace file API (Editor tab) ---
+    //
+    // Separate from the `file_operations` MCP server (which is sandboxed to
+    // `./mcp_workspace` and only reachable by the model mid tool-call): these
+    // routes let the GUI itself browse/open/save real project files directly,
+    // confined to GHOSTLINK_WORKSPACE_ROOT (defaults to the launch directory).
+
+    /// Files/dirs over this size are refused by both read and write — plenty
+    /// for source files, guards against loading a huge binary/log into the
+    /// in-browser editor.
+    const MAX_WORKSPACE_FILE_BYTES: u64 = 5 * 1024 * 1024;
+
+    fn workspace_root() -> std::path::PathBuf {
+        std::env::var("GHOSTLINK_WORKSPACE_ROOT")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+            })
+    }
+
+    /// Resolves a client-supplied relative path against the workspace root
+    /// and rejects anything that escapes it. Canonicalizing both sides and
+    /// checking the prefix is what actually catches `..` traversal and
+    /// symlink escapes — a naive string check on the raw path does not.
+    fn resolve_workspace_path(
+        root: &std::path::Path,
+        rel: &str,
+    ) -> Result<std::path::PathBuf, String> {
+        let rel = rel.trim_start_matches(['/', '\\']);
+        let canon_root = root
+            .canonicalize()
+            .map_err(|e| format!("workspace root: {e}"))?;
+        if rel.is_empty() {
+            return Ok(canon_root);
+        }
+        let candidate = canon_root.join(rel);
+        let resolved = if candidate.exists() {
+            candidate.canonicalize().map_err(|e| e.to_string())?
+        } else {
+            // A not-yet-existing file (e.g. the target of a fresh write) can't
+            // be canonicalized itself — canonicalize its parent instead and
+            // reattach the file name, which still catches `..` in `rel`.
+            let parent = candidate.parent().ok_or("invalid path")?;
+            let canon_parent = parent
+                .canonicalize()
+                .map_err(|_| "parent directory does not exist".to_string())?;
+            canon_parent.join(candidate.file_name().ok_or("invalid path")?)
+        };
+        if !resolved.starts_with(&canon_root) {
+            return Err("path escapes workspace root".to_string());
+        }
+        Ok(resolved)
+    }
+
+    #[derive(serde::Serialize)]
+    struct WorkspaceEntry {
+        name: String,
+        path: String,
+        is_dir: bool,
+        size: u64,
+    }
+
+    async fn handle_workspace_tree(
+        Query(params): Query<HashMap<String, String>>,
+    ) -> Json<serde_json::Value> {
+        let root = workspace_root();
+        let rel = params.get("path").map(|s| s.as_str()).unwrap_or("");
+        let dir = match resolve_workspace_path(&root, rel) {
+            Ok(p) => p,
+            Err(e) => return Json(serde_json::json!({ "error": e })),
+        };
+        if !dir.is_dir() {
+            return Json(serde_json::json!({ "error": "not a directory" }));
+        }
+        let canon_root = match root.canonicalize() {
+            Ok(p) => p,
+            Err(e) => return Json(serde_json::json!({ "error": format!("workspace root: {e}") })),
+        };
+        let read_dir = match std::fs::read_dir(&dir) {
+            Ok(rd) => rd,
+            Err(e) => return Json(serde_json::json!({ "error": e.to_string() })),
+        };
+        let mut entries: Vec<WorkspaceEntry> = Vec::new();
+        for entry in read_dir.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            // Keeps the tree readable — skip VCS/build/dependency noise the
+            // user is never going to open in a code editor pane.
+            if name.starts_with('.') || matches!(name.as_str(), "node_modules" | "target" | "dist")
+            {
+                continue;
+            }
+            let metadata = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let entry_path = entry.path();
+            let rel_path = entry_path
+                .strip_prefix(&canon_root)
+                .unwrap_or(&entry_path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            entries.push(WorkspaceEntry {
+                name,
+                path: rel_path,
+                is_dir: metadata.is_dir(),
+                size: metadata.len(),
+            });
+        }
+        entries.sort_by(|a, b| {
+            b.is_dir
+                .cmp(&a.is_dir)
+                .then(a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+        });
+        Json(serde_json::json!({ "path": rel, "entries": entries }))
+    }
+
+    async fn handle_workspace_file_read(
+        Query(params): Query<HashMap<String, String>>,
+    ) -> Json<serde_json::Value> {
+        let rel = match params.get("path") {
+            Some(p) if !p.trim().is_empty() => p.clone(),
+            _ => return Json(serde_json::json!({ "error": "path query parameter is required" })),
+        };
+        let root = workspace_root();
+        let file_path = match resolve_workspace_path(&root, &rel) {
+            Ok(p) => p,
+            Err(e) => return Json(serde_json::json!({ "error": e })),
+        };
+        let metadata = match std::fs::metadata(&file_path) {
+            Ok(m) => m,
+            Err(e) => return Json(serde_json::json!({ "error": e.to_string() })),
+        };
+        if metadata.is_dir() {
+            return Json(serde_json::json!({ "error": "path is a directory" }));
+        }
+        if metadata.len() > MAX_WORKSPACE_FILE_BYTES {
+            return Json(serde_json::json!({
+                "error": format!("file exceeds {}MB limit", MAX_WORKSPACE_FILE_BYTES / (1024 * 1024))
+            }));
+        }
+        let bytes = match std::fs::read(&file_path) {
+            Ok(b) => b,
+            Err(e) => return Json(serde_json::json!({ "error": e.to_string() })),
+        };
+        match String::from_utf8(bytes) {
+            Ok(content) => Json(serde_json::json!({ "path": rel, "content": content })),
+            Err(_) => {
+                Json(serde_json::json!({ "error": "file is not valid UTF-8 text (binary?)" }))
+            }
+        }
+    }
+
+    #[derive(serde::Deserialize)]
+    struct WorkspaceFileWriteRequest {
+        path: String,
+        content: String,
+    }
+
+    async fn handle_workspace_file_write(
+        Json(req): Json<WorkspaceFileWriteRequest>,
+    ) -> Json<serde_json::Value> {
+        if req.path.trim().is_empty() {
+            return Json(serde_json::json!({ "error": "path is required" }));
+        }
+        if req.content.len() as u64 > MAX_WORKSPACE_FILE_BYTES {
+            return Json(serde_json::json!({
+                "error": format!("content exceeds {}MB limit", MAX_WORKSPACE_FILE_BYTES / (1024 * 1024))
+            }));
+        }
+        let root = workspace_root();
+        let file_path = match resolve_workspace_path(&root, &req.path) {
+            Ok(p) => p,
+            Err(e) => return Json(serde_json::json!({ "error": e })),
+        };
+        if file_path.is_dir() {
+            return Json(serde_json::json!({ "error": "path is a directory" }));
+        }
+        match std::fs::write(&file_path, req.content.as_bytes()) {
+            Ok(_) => Json(serde_json::json!({ "status": "ok", "path": req.path })),
+            Err(e) => Json(serde_json::json!({ "error": e.to_string() })),
+        }
+    }
+
+    // --- Repo-aware chat context (RAG auto-index) ---
+    //
+    // Walks the workspace root and feeds each eligible text file into the
+    // `rag` MCP server's index_document tool directly (not via a chat
+    // completion — asking a model to call index_document once per file over
+    // a ReAct loop would be slow and unreliable), so chat gets repo context
+    // without the user calling index_document by hand. A soft "skipped"
+    // status, not an error, when `rag` isn't connected — most installs won't
+    // have it configured (disabled by default, needs a pulled embedding model).
+
+    /// Bounds a single indexing pass so it can't turn into a multi-minute
+    /// crawl (or feed gigabytes into the embedding model) on a large repo —
+    /// generous enough for typical project sizes once noise dirs are excluded.
+    const INDEX_MAX_FILES: usize = 400;
+    /// Tighter than MAX_WORKSPACE_FILE_BYTES (the editor's read/write cap) —
+    /// indexing many large files is slow and not useful for MVP repo context.
+    const INDEX_MAX_FILE_BYTES: u64 = 200 * 1024;
+    const INDEX_MAX_TOTAL_BYTES: u64 = 4 * 1024 * 1024;
+
+    fn is_index_noise_dir(name: &str) -> bool {
+        name.starts_with('.')
+            || matches!(
+                name,
+                "node_modules"
+                    | "target"
+                    | "dist"
+                    | "build"
+                    | "third_party"
+                    | "logs"
+                    | "artifacts"
+                    | "benchmarks"
+                    | "models"
+                    | "mcp_workspace"
+                    | "tmp"
+                    | "_archived"
+            )
+    }
+
+    fn collect_index_candidates(
+        dir: &std::path::Path,
+        out: &mut Vec<std::path::PathBuf>,
+        total_bytes: &mut u64,
+    ) {
+        if out.len() >= INDEX_MAX_FILES || *total_bytes >= INDEX_MAX_TOTAL_BYTES {
+            return;
+        }
+        let Ok(read_dir) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in read_dir.flatten() {
+            if out.len() >= INDEX_MAX_FILES || *total_bytes >= INDEX_MAX_TOTAL_BYTES {
+                return;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            if metadata.is_dir() {
+                if is_index_noise_dir(&name) {
+                    continue;
+                }
+                collect_index_candidates(&entry.path(), out, total_bytes);
+            } else {
+                if name.starts_with('.') {
+                    continue;
+                }
+                if metadata.len() == 0 || metadata.len() > INDEX_MAX_FILE_BYTES {
+                    continue;
+                }
+                *total_bytes += metadata.len();
+                out.push(entry.path());
+            }
+        }
+    }
+
+    async fn handle_workspace_index(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let mcp_registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+
+        let servers = match mcp_registry.list_all_servers().await {
+            Ok(s) => s,
+            Err(err) => return Json(serde_json::json!({ "status": "error", "error": err })),
+        };
+        let rag_connected = servers.iter().any(|s| s.name == "rag" && s.connected);
+        if !rag_connected {
+            return Json(serde_json::json!({
+                "status": "skipped",
+                "reason": "rag MCP server is not connected (disabled) — see mcp_servers.toml"
+            }));
+        }
+
+        // `rag`'s own MCP handshake never actually touches Ollama (its tools
+        // are registered eagerly, connectivity is only checked lazily on the
+        // first embed call) — so `rag_connected` above is true even on a
+        // native-llama.cpp-only machine with no Ollama running at all. Probe
+        // Ollama directly here so that case still gets the same graceful
+        // "skipped" response instead of a wall of per-file failures.
+        let ollama_url = mcp_registry
+            .env_var_for("rag", "OLLAMA_URL")
+            .filter(|u| !u.is_empty())
+            .unwrap_or_else(|| "http://127.0.0.1:11434".to_string());
+        let ollama_reachable = ollama::OllamaClient::new(ollama_url.clone())
+            .health()
+            .await
+            .unwrap_or(false);
+        if !ollama_reachable {
+            return Json(serde_json::json!({
+                "status": "skipped",
+                "reason": format!("Ollama isn't reachable at {ollama_url} — is `ollama serve` running?")
+            }));
+        }
+
+        let root = match workspace_root().canonicalize() {
+            Ok(p) => p,
+            Err(e) => {
+                return Json(
+                    serde_json::json!({ "status": "error", "error": format!("workspace root: {e}") }),
+                )
+            }
+        };
+
+        let mut candidates = Vec::new();
+        let mut total_bytes = 0u64;
+        collect_index_candidates(&root, &mut candidates, &mut total_bytes);
+        let capped = candidates.len() >= INDEX_MAX_FILES || total_bytes >= INDEX_MAX_TOTAL_BYTES;
+
+        let mut indexed = 0usize;
+        let mut failed = 0usize;
+        for path in &candidates {
+            let Ok(bytes) = std::fs::read(path) else {
+                failed += 1;
+                continue;
+            };
+            // Binary files fail UTF-8 decoding — silently skip them rather
+            // than counting as a failure, same as the file-read route.
+            let Ok(text) = String::from_utf8(bytes) else {
+                continue;
+            };
+            let rel = path
+                .strip_prefix(&root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let args = serde_json::json!({ "text": text, "id": rel, "source": rel });
+            match mcp_registry.call_tool("rag", "index_document", args).await {
+                Some(outcome) if outcome.success => indexed += 1,
+                _ => failed += 1,
+            }
+        }
+
+        Json(serde_json::json!({
+            "status": "ok",
+            "scanned": candidates.len(),
+            "indexed": indexed,
+            "failed": failed,
+            "capped": capped,
+        }))
+    }
+
     async fn handle_gui_queue() -> Json<serde_json::Value> {
         Json(serde_json::json!({ "status": "ok", "depth": 0 }))
     }
@@ -5454,10 +5867,31 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     /// token (`auth_middleware` gates every route but `/health`) — no
     /// separate credential to check here, just mint a fresh short-lived
     /// token signed with the same API key that got them past the gate.
-    async fn handle_gui_jwt_refresh() -> Json<serde_json::Value> {
+    async fn handle_gui_jwt_refresh(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    ) -> Json<serde_json::Value> {
         match auth::issue_jwt("ghostlink-client") {
-            Ok(token) => Json(serde_json::json!({ "status": "ok", "token": token })),
-            Err(err) => Json(serde_json::json!({ "status": "error", "error": err })),
+            Ok(token) => {
+                record_audit_event(
+                    &mut lock_state(&state),
+                    "jwt_refresh",
+                    "SUCCESS",
+                    addr.ip().to_string(),
+                    None,
+                );
+                Json(serde_json::json!({ "status": "ok", "token": token }))
+            }
+            Err(err) => {
+                record_audit_event(
+                    &mut lock_state(&state),
+                    "jwt_refresh",
+                    "FAILED",
+                    addr.ip().to_string(),
+                    Some(err.clone()),
+                );
+                Json(serde_json::json!({ "status": "error", "error": err }))
+            }
         }
     }
 
@@ -5467,12 +5901,20 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     /// response rather than implying it's already live.
     async fn handle_gui_pqc_enable(
         State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
     ) -> Json<serde_json::Value> {
         let backend = &mut *lock_state(&state);
         let mut current = backend.settings.clone();
         current.enable_tls = true;
         backend.settings = current.clone();
         save_settings(&current);
+        record_audit_event(
+            backend,
+            "pqc_enable",
+            "SUCCESS",
+            addr.ip().to_string(),
+            Some("enable_tls persisted; takes effect on restart".to_string()),
+        );
         Json(serde_json::json!({
             "status": "ok",
             "enabled": true,
@@ -5506,8 +5948,13 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }))
     }
 
-    async fn handle_gui_audit_log() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "entries": [] }))
+    async fn handle_gui_audit_log(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let backend = lock_state(&state);
+        // Most-recent-first — a log feed reads top-to-bottom as newest-first.
+        let entries: Vec<&AuditLogEntry> = backend.audit_log.iter().rev().collect();
+        Json(serde_json::json!({ "entries": entries }))
     }
 
     async fn handle_gui_runtime_select(
@@ -6491,6 +6938,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     /// denying feeds back `mcp::toolcall::format_denial` instead.
     async fn handle_tool_confirm(
         State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
         Json(req): Json<ToolConfirmRequest>,
     ) -> Json<serde_json::Value> {
         let (native_engine_client, ollama_client, vllm_client, mcp_registry, pending_tool_calls) = {
@@ -6517,6 +6965,19 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 )
             }));
         };
+
+        let (tool_name, server_name) = match &pending {
+            PendingToolCall::Native { tool, server, .. } => (tool.clone(), server.clone()),
+            PendingToolCall::Ollama { tool, server, .. } => (tool.clone(), server.clone()),
+            PendingToolCall::Vllm { tool, server, .. } => (tool.clone(), server.clone()),
+        };
+        record_audit_event(
+            &mut lock_state(&state),
+            "tool_confirm",
+            if req.approve { "APPROVED" } else { "DENIED" },
+            addr.ip().to_string(),
+            Some(format!("{tool_name} @ {server_name}")),
+        );
 
         let mut tool_results: Vec<ToolResult> = Vec::new();
         let mut pending_tool_call: Option<PendingToolCallInfo> = None;
@@ -7297,6 +7758,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
         plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
         enable_tls_active: use_tls,
+        audit_log: std::collections::VecDeque::new(),
     }));
 
     // Background CPU/RAM/GPU sampler — keeps /api/metrics non-blocking.
@@ -7334,6 +7796,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 }
             });
         }
+
+        // Cloned before `.with_state(state)` below consumes `state` — the
+        // auth middleware needs its own `State` extraction (to record
+        // failed-auth attempts to the audit log) via `from_fn_with_state`.
+        let auth_mw_state = Arc::clone(&state);
 
         let app = Router::new()
             .route("/v1/chat/completions", post(handle_chat_completions))
@@ -7437,12 +7904,21 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 "/api/backends/:name/status",
                 get(backend_api::handle_backend_status),
             )
+            .route("/api/workspace/tree", get(handle_workspace_tree))
+            .route(
+                "/api/workspace/file",
+                get(handle_workspace_file_read).put(handle_workspace_file_write),
+            )
+            .route("/api/workspace/index", post(handle_workspace_index))
             .with_state(state)
             // Auth runs inside CORS (added first here = innermost = runs
             // *after* CORS on the way in), so a browser's CORS preflight
             // OPTIONS request is still handled without needing a bearer
             // token — matches how CORS preflight is expected to work.
-            .layer(middleware::from_fn(auth_middleware))
+            .layer(middleware::from_fn_with_state(
+                auth_mw_state,
+                auth_middleware,
+            ))
             .layer(CorsLayer::permissive())
             .layer(tower_governor::GovernorLayer {
                 config: governor_conf,
@@ -9608,6 +10084,7 @@ mod tests {
             model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
             enable_tls_active: false,
             plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
+            audit_log: std::collections::VecDeque::new(),
         }))
     }
 
@@ -9620,6 +10097,41 @@ mod tests {
         std::env::set_var("GHOSTLINK_NODE_ID", "test-node-explicit");
         assert_eq!(detect_node_id(), "test-node-explicit");
         std::env::remove_var("GHOSTLINK_NODE_ID");
+    }
+
+    fn audit_entry(event: &str) -> AuditLogEntry {
+        AuditLogEntry {
+            event: event.to_string(),
+            status: "SUCCESS".to_string(),
+            ip: "127.0.0.1".to_string(),
+            time: chrono::Utc::now().to_rfc3339(),
+            detail: None,
+        }
+    }
+
+    #[test]
+    fn push_audit_entry_appends_in_order() {
+        let mut log = std::collections::VecDeque::new();
+        push_audit_entry(&mut log, audit_entry("first"));
+        push_audit_entry(&mut log, audit_entry("second"));
+        assert_eq!(log.len(), 2);
+        assert_eq!(log[0].event, "first");
+        assert_eq!(log[1].event, "second");
+    }
+
+    #[test]
+    fn push_audit_entry_trims_oldest_once_over_cap() {
+        let mut log = std::collections::VecDeque::new();
+        for i in 0..(AUDIT_LOG_CAP + 10) {
+            push_audit_entry(&mut log, audit_entry(&format!("event-{i}")));
+        }
+        assert_eq!(log.len(), AUDIT_LOG_CAP, "must never grow past the cap");
+        // The oldest 10 were pushed out; the front is now event-10.
+        assert_eq!(log.front().unwrap().event, "event-10");
+        assert_eq!(
+            log.back().unwrap().event,
+            format!("event-{}", AUDIT_LOG_CAP + 9)
+        );
     }
 
     #[test]

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -8132,10 +8132,27 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         // Per-IP request rate limiting — protects the API from runaway
         // clients/retry loops. Applied as the outermost layer so it gates
         // requests before CORS/auth do any work.
+        //
+        // This sits behind control-plane's own proxy (the GUI never talks
+        // to this port directly), which means every request — from every
+        // browser tab, every user — arrives here already collapsed onto
+        // control-plane's own source address. The old per_second(2) /
+        // burst_size(30) config was sized as if this were a genuine per-
+        // client limit; in practice it was a global ceiling on the whole
+        // gateway. A single page mount alone fires ~8 concurrent requests
+        // (settings, models, sessions, metrics, workers, backends, mcp
+        // servers), and steady-state polling (metrics+sessions every 3s,
+        // workers every 15s) adds ~0.7 req/s per open tab on top of that —
+        // two tabs, or a couple of reloads in quick succession, was enough
+        // to permanently exhaust the 30-token bucket (15s to refill at
+        // 2/s) and made ordinary GUI usage indistinguishable from a
+        // runaway client. Sized here to comfortably absorb a few tabs'
+        // worth of simultaneous mount bursts plus their steady polling,
+        // while still catching an actually-pathological tight retry loop.
         let governor_conf = std::sync::Arc::new(
             tower_governor::governor::GovernorConfigBuilder::default()
-                .per_second(2)
-                .burst_size(30)
+                .per_second(20)
+                .burst_size(60)
                 .finish()
                 .expect("static governor config is always valid"),
         );

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -2929,6 +2929,30 @@ fn save_persistent_models(models: &[ModelRecord]) {
     }
 }
 
+fn sessions_path() -> PathBuf {
+    std::env::var("GHOSTLINK_SESSIONS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("sessions.json"))
+}
+
+fn load_persistent_sessions() -> Vec<SessionRecord> {
+    let path = sessions_path();
+    if path.exists() {
+        if let Ok(data) = fs::read_to_string(path) {
+            if let Ok(sessions) = serde_json::from_str::<Vec<SessionRecord>>(&data) {
+                return sessions;
+            }
+        }
+    }
+    vec![]
+}
+
+fn save_persistent_sessions(sessions: &[SessionRecord]) {
+    if let Ok(data) = serde_json::to_string_pretty(sessions) {
+        let _ = fs::write(sessions_path(), data);
+    }
+}
+
 fn load_settings() -> RuntimeSettings {
     let path = settings_path();
     let mut settings = if path.exists() {
@@ -3100,6 +3124,10 @@ struct ModelDeleteRequest {
     model: String,
 }
 #[derive(Debug, Deserialize)]
+struct DiscardPartialRequest {
+    filename: String,
+}
+#[derive(Debug, Deserialize)]
 struct OllamaModelRequest {
     model: String,
 }
@@ -3164,14 +3192,23 @@ struct WorkerRecord {
     threads: usize,
     load: u8,
 }
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct SessionRecord {
     id: String,
+    #[serde(default)]
+    name: String,
     model: String,
     status: String,
     throughput: usize,
     latency: u32,
     tokens: usize,
+    // Only returned by the single-session load endpoint — the list endpoint
+    // (`/api/sessions`, shared with SessionsTab's active-session view)
+    // builds its own trimmed JSON rather than serializing this field, so
+    // listing saved chats doesn't ship every message body over the wire
+    // just to render a summary card.
+    #[serde(default)]
+    messages: Vec<serde_json::Value>,
 }
 #[derive(Debug, Serialize)]
 struct ChatCompletionResponse {
@@ -5155,6 +5192,69 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }))
     }
 
+    // Surfaces `.gguf.part` files left behind by an interrupted download
+    // (see download_hf_model's atomic-rename fix) — previously invisible
+    // dead weight sitting in the models directory with no way to see or
+    // reclaim it from the GUI.
+    async fn handle_gui_models_partial(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let models_dir = {
+            let backend = lock_state(&state);
+            backend.settings.models_dir.clone()
+        };
+        let dir = std::path::Path::new(&models_dir);
+        let mut partials = Vec::new();
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let filename = path.file_name().map(|f| f.to_string_lossy().to_string());
+                let Some(filename) = filename else { continue };
+                if !filename.ends_with(".gguf.part") {
+                    continue;
+                }
+                let metadata = fs::metadata(&path).ok();
+                let size_bytes = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+                let age_secs = metadata
+                    .and_then(|m| m.modified().ok())
+                    .and_then(|m| m.elapsed().ok())
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                partials.push(serde_json::json!({
+                    "filename": filename,
+                    "size_bytes": size_bytes,
+                    "age_secs": age_secs,
+                }));
+            }
+        }
+        Json(serde_json::json!({ "partial_downloads": partials }))
+    }
+
+    async fn handle_gui_models_partial_discard(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Json(req): Json<DiscardPartialRequest>,
+    ) -> Json<serde_json::Value> {
+        let models_dir = {
+            let backend = lock_state(&state);
+            backend.settings.models_dir.clone()
+        };
+        // Same defensive stance as the downloader's own filename handling —
+        // only a bare, well-formed `.gguf.part` basename is ever accepted,
+        // never a path that could escape models_dir.
+        let safe_name = std::path::Path::new(&req.filename)
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if safe_name.is_empty() || !safe_name.ends_with(".gguf.part") {
+            return Json(serde_json::json!({ "status": "error", "error": "invalid filename" }));
+        }
+        let path = std::path::Path::new(&models_dir).join(&safe_name);
+        match fs::remove_file(&path) {
+            Ok(()) => Json(serde_json::json!({ "status": "ok" })),
+            Err(e) => Json(serde_json::json!({ "status": "error", "error": e.to_string() })),
+        }
+    }
+
     async fn handle_gui_model_unload(
         State(state): State<Arc<Mutex<BackendState>>>,
         Path(model_name): Path<String>,
@@ -5618,7 +5718,24 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         State(state): State<Arc<Mutex<BackendState>>>,
     ) -> Json<serde_json::Value> {
         let backend = lock_state(&state);
-        Json(serde_json::json!({ "sessions": backend.sessions }))
+        // Summary only — omits `messages` so listing saved chats doesn't ship
+        // every message body over the wire just to render a summary card.
+        let sessions: Vec<serde_json::Value> = backend
+            .sessions
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "id": s.id,
+                    "name": s.name,
+                    "model": s.model,
+                    "status": s.status,
+                    "throughput": s.throughput,
+                    "latency": s.latency,
+                    "tokens": s.tokens,
+                })
+            })
+            .collect();
+        Json(serde_json::json!({ "sessions": sessions }))
     }
 
     async fn handle_gui_session_cancel(Path(session_id): Path<String>) -> Json<serde_json::Value> {
@@ -5630,7 +5747,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         Json(req): Json<serde_json::Value>,
     ) -> Json<serde_json::Value> {
         let session_id = req.get("id").and_then(|v| v.as_str()).unwrap_or("");
-        let _name = req
+        let name = req
             .get("name")
             .and_then(|v| v.as_str())
             .unwrap_or("Unnamed Session");
@@ -5653,16 +5770,19 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         let mut backend = lock_state(&state);
         let session = SessionRecord {
             id: session_id.to_string(),
+            name: name.to_string(),
             model: model.to_string(),
             status: "saved".to_string(),
             throughput: 0,
             latency: 0,
             tokens: messages.len(),
+            messages,
         };
 
         // Remove existing session with same id
         backend.sessions.retain(|s| s.id != session_id);
         backend.sessions.push(session);
+        save_persistent_sessions(&backend.sessions);
 
         Json(serde_json::json!({ "status": "ok", "session_id": session_id }))
     }
@@ -5677,11 +5797,13 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 "status": "ok",
                 "session": {
                     "id": session.id,
+                    "name": session.name,
                     "model": session.model,
                     "status": session.status,
                     "throughput": session.throughput,
                     "latency": session.latency,
                     "tokens": session.tokens,
+                    "messages": session.messages,
                 }
             }))
         } else {
@@ -5697,6 +5819,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         let len_before = backend.sessions.len();
         backend.sessions.retain(|s| s.id != session_id);
         if backend.sessions.len() < len_before {
+            save_persistent_sessions(&backend.sessions);
             Json(serde_json::json!({ "status": "ok", "deleted": true }))
         } else {
             Json(serde_json::json!({ "status": "error", "error": "session not found" }))
@@ -7022,7 +7145,20 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             let latency_u = latency_ms.round() as u32;
             let throughput_u = tokens_per_sec.unwrap_or(0.0).round().max(0.0) as usize;
 
-            let maybe_session = backend.sessions.first_mut();
+            // Matched by its own well-known id, not just "whichever session is
+            // first" — that used to mean any saved chat session that happened
+            // to land at index 0 got its tokens/model/status silently
+            // overwritten by unrelated live-inference bookkeeping the next
+            // time any chat request completed.
+            let live_session_id = "sess_local_001";
+            let new_messages = [
+                serde_json::json!({ "role": "user", "content": req.message }),
+                serde_json::json!({ "role": "assistant", "content": response_text }),
+            ];
+            let maybe_session = backend
+                .sessions
+                .iter_mut()
+                .find(|s| s.id == live_session_id);
             let session_id = if let Some(session) = maybe_session {
                 session.tokens = session.tokens.saturating_add(tokens_out as usize);
                 session.throughput = throughput_u;
@@ -7033,11 +7169,13 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 } else {
                     "Degraded".to_string()
                 };
+                session.messages.extend(new_messages);
                 session.id.clone()
             } else {
-                let session_id = "sess_local_001".to_string();
+                let session_id = live_session_id.to_string();
                 backend.sessions.push(SessionRecord {
                     id: session_id.clone(),
+                    name: String::new(),
                     model: current_model.clone(),
                     status: if real_inference {
                         "Running".to_string()
@@ -7047,9 +7185,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     throughput: throughput_u,
                     latency: latency_u,
                     tokens: tokens_out as usize,
+                    messages: new_messages.to_vec(),
                 });
                 session_id
             };
+            save_persistent_sessions(&backend.sessions);
 
             let metrics_json = serde_json::json!({
                 "throughput": snap.tokens_per_sec,
@@ -7950,7 +8090,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             threads: profile.recommended_workers.max(1),
             load: 35,
         }],
-        sessions: vec![],
+        sessions: load_persistent_sessions(),
         chat_requests: 0,
         last_latency_ms: 0.0,
         last_tokens_per_sec: 0.0,
@@ -8031,6 +8171,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             .route("/api/models/load", post(handle_gui_model_load))
             .route("/api/models/download", post(handle_gui_model_download))
             .route("/api/models/delete", post(handle_gui_model_delete))
+            .route("/api/models/partial", get(handle_gui_models_partial))
+            .route(
+                "/api/models/partial/discard",
+                post(handle_gui_models_partial_discard),
+            )
             .route(
                 "/api/models/search/huggingface",
                 get(handle_gui_models_search_hf),

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1488,6 +1488,36 @@ struct BackendState {
     settings: RuntimeSettings,
     mcp_registry: Arc<mcp::McpRegistry>,
     pending_tool_calls: Arc<tokio::sync::Mutex<HashMap<String, PendingToolCall>>>,
+    download_progress: HashMap<String, DownloadProgressInfo>,
+    /// Serializes the full model load/unload sequence end to end — the
+    /// llama-server stage/kill/spawn dance in `NativeEngineClient::load_model_into_slot`
+    /// plus the `BackendState` updates (`current_model`, model status, settings)
+    /// that follow it. Without this, two overlapping `/api/models/load` (or
+    /// load+unload) requests each independently ran `free_llama_port`'s
+    /// system-wide `taskkill /F /IM llama-server.exe` and raced to bind the
+    /// same port — confirmed by firing concurrent load requests and seeing
+    /// each response report a *different* `current_model`, since the final
+    /// `backend.current_model = selected_model` write was a plain
+    /// last-writer-wins race with no relation to which process actually
+    /// survived the taskkill/spawn collision.
+    model_lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Whether the *currently running* listener is actually serving HTTPS
+    /// with the PQC-hybrid key exchange preference — set once at server
+    /// startup from the same `use_tls` decision that picked the listener
+    /// branch. Distinct from `settings.enable_tls`, which is the persisted
+    /// setting and only takes effect on next restart; this field is what
+    /// `/api/security/pqc/state` actually reports.
+    enable_tls_active: bool,
+}
+
+/// Real byte-level progress for an in-flight (or just-finished) model download.
+/// Updated from the background download task, read by the GUI's polling loop.
+#[derive(Debug, Clone, Serialize, Default)]
+struct DownloadProgressInfo {
+    bytes_downloaded: u64,
+    total_bytes: u64,
+    status: String,
+    error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1519,6 +1549,50 @@ struct RuntimeSettings {
     discovery_auth_token: String,
     tcp_auth_token: String,
     xdp_interface: String,
+    /// Token budget for conversation history sent to the model, distinct from
+    /// `max_tokens` (per-response length). `#[serde(default)]` so settings.json
+    /// files saved before this field existed still deserialize instead of
+    /// falling back to `RuntimeSettings::default()` in its entirety.
+    #[serde(default = "default_conversation_token_limit")]
+    conversation_token_limit: usize,
+    /// Serve over HTTPS with a self-signed cert and a real PQC-hybrid
+    /// (X25519MLKEM768) key exchange preference (see `tls.rs`), instead of
+    /// plain HTTP. Off by default so today's plain-localhost dev flow sees
+    /// zero disruption; forced on regardless of this setting when the
+    /// server binds a non-loopback address (`tls::is_loopback_host`),
+    /// since that's the LAN/remote scenario PQC-hybrid TLS protects.
+    /// `#[serde(default)]` (false) so settings.json files saved before
+    /// this field existed still deserialize.
+    #[serde(default)]
+    enable_tls: bool,
+}
+
+// Kept as named constants (rather than inlined in both `RuntimeSettings::default()`
+// and `default_conversation_token_limit()`) so the two defaults can't drift out
+// of sync — see the derivation below.
+const DEFAULT_CTX_SIZE: usize = 4096;
+const DEFAULT_MAX_TOKENS: usize = 2048;
+const DEFAULT_PARALLEL_SLOTS: usize = 1;
+
+fn default_parallel_slots() -> usize {
+    DEFAULT_PARALLEL_SLOTS
+}
+/// Slack reserved on top of `max_tokens` for role/formatting overhead —
+/// mirrors the per-message `+ 4` in `build_conversation_prompt`, just applied
+/// once at the whole-budget level here.
+const CONVERSATION_TOKEN_MARGIN: usize = 128;
+
+/// Derived from the *default* `ctx_size`/`max_tokens`, not a flat guess — a
+/// flat number here previously left the stock settings.json tripping the
+/// Settings tab's own "history + max_tokens > ctx_size" warning out of the
+/// box. Still just the *default*: `handle_gui_chat` separately clamps
+/// whatever value ends up in `conversation_token_limit` (default or
+/// user-edited) to `ctx_size` before using it, so a manually misconfigured
+/// value can't overflow the context window either.
+fn default_conversation_token_limit() -> usize {
+    DEFAULT_CTX_SIZE
+        .saturating_sub(DEFAULT_MAX_TOKENS)
+        .saturating_sub(CONVERSATION_TOKEN_MARGIN)
 }
 
 impl Default for RuntimeSettings {
@@ -1551,6 +1625,8 @@ impl Default for RuntimeSettings {
             discovery_auth_token: String::new(),
             tcp_auth_token: String::new(),
             xdp_interface: "eth0".to_string(),
+            conversation_token_limit: default_conversation_token_limit(),
+            enable_tls: false,
         }
     }
 }
@@ -3069,7 +3145,9 @@ struct PendingToolCallInfo {
 
 fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     use axum::{
-        extract::{Path, Query, State},
+        extract::{Path, Query, Request, State},
+        http::StatusCode,
+        middleware::{self, Next},
         response::{
             sse::{Event, Sse},
             IntoResponse,
@@ -3087,6 +3165,44 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
     fn lock_state(state: &Arc<Mutex<BackendState>>) -> std::sync::MutexGuard<'_, BackendState> {
         state.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    /// Guards every route except `/health` behind a real bearer token
+    /// (the persisted API key itself, or a JWT issued from it — see
+    /// `auth.rs`). Replaces having no auth check anywhere on this server.
+    async fn auth_middleware(req: Request, next: Next) -> axum::response::Response {
+        if req.uri().path() == "/health" {
+            return next.run(req).await;
+        }
+
+        let header = req
+            .headers()
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok());
+        let token = auth::extract_bearer_token(header);
+
+        match token {
+            Some(t) if auth::verify_bearer_token(t) => next.run(req).await,
+            _ => (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": "missing or invalid Authorization: Bearer <token> — see the API key printed at server startup, or POST /api/security/jwt/refresh with it to get a short-lived token",
+                        "type": "unauthorized"
+                    }
+                })),
+            )
+                .into_response(),
+        }
+    }
+
+    /// Waits for Ctrl+C, then force-tears-down every connected MCP server before
+    /// `axum::serve`'s graceful shutdown lets the process exit. Without this, a
+    /// `cmd /C npx ...`-spawned server's child processes (see mcp::client) would
+    /// otherwise be orphaned when Ghostlink exits.
+    async fn mcp_shutdown_on_ctrl_c(mcp_registry: Arc<mcp::McpRegistry>) {
+        let _ = tokio::signal::ctrl_c().await;
+        mcp_registry.shutdown_all().await;
     }
 
     fn chat_exec_micro_batch() -> usize {
@@ -4324,16 +4440,61 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         Json(serde_json::json!({ "status": "ok", "depth": 0 }))
     }
 
+    /// Real JWT issuance (was a hardcoded `"new-token-123"`). Reaching this
+    /// handler at all already proves the caller presented a valid bearer
+    /// token (`auth_middleware` gates every route but `/health`) — no
+    /// separate credential to check here, just mint a fresh short-lived
+    /// token signed with the same API key that got them past the gate.
     async fn handle_gui_jwt_refresh() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "status": "ok", "token": "new-token-123" }))
+        match auth::issue_jwt("ghostlink-client") {
+            Ok(token) => Json(serde_json::json!({ "status": "ok", "token": token })),
+            Err(err) => Json(serde_json::json!({ "status": "error", "error": err })),
+        }
     }
 
-    async fn handle_gui_pqc_enable() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "status": "ok", "enabled": true }))
+    /// Turns on `enable_tls` in persisted settings (was a no-op that always
+    /// reported `enabled: true`). The listener is bound once at server
+    /// startup, so this takes effect on next restart — said plainly in the
+    /// response rather than implying it's already live.
+    async fn handle_gui_pqc_enable(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let backend = &mut *lock_state(&state);
+        let mut current = backend.settings.clone();
+        current.enable_tls = true;
+        backend.settings = current.clone();
+        save_settings(&current);
+        Json(serde_json::json!({
+            "status": "ok",
+            "enabled": true,
+            "restart_required": true,
+            "message": "enable_tls saved — restart the server for the HTTPS/PQC-hybrid listener to take effect"
+        }))
     }
 
-    async fn handle_gui_pqc_state() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "enabled": true, "algorithm": "ml-kem-768" }))
+    /// Reports the real, current server configuration (was hardcoded
+    /// `enabled: true`): whether `enable_tls` is on for THIS running
+    /// process (not just persisted — a setting saved via
+    /// `handle_gui_pqc_enable` doesn't apply until restart, so this
+    /// reflects what's actually serving right now) and the hybrid group
+    /// rustls is configured to prefer whenever TLS is active. This is
+    /// server-level config state, not a genuine per-connection
+    /// introspection of whether a given client actually negotiated the
+    /// hybrid group — independently verifiable via `openssl s_client
+    /// -groups X25519MLKEM768` against a TLS-enabled instance.
+    async fn handle_gui_pqc_state(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let active = lock_state(&state).enable_tls_active;
+        Json(serde_json::json!({
+            "enabled": active,
+            "algorithm": "X25519MLKEM768",
+            "note": if active {
+                "TLS is active on this server; rustls is configured to prefer the X25519MLKEM768 post-quantum hybrid key-exchange group (via the prefer-post-quantum feature)."
+            } else {
+                "TLS is not active on this server (plain HTTP) — no key exchange is happening. Enable via POST /api/security/pqc/enable and restart."
+            }
+        }))
     }
 
     async fn handle_gui_audit_log() -> Json<serde_json::Value> {
@@ -5665,6 +5826,20 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                             current.ctx_size = v as usize;
                         }
                     }
+                    "enable_tls" => {
+                        if let Some(v) = value.as_bool() {
+                            // Takes effect on next server restart — the
+                            // listener is bound once at startup (main.rs's
+                            // `start_openai_api_server`), not re-bound on a
+                            // settings change.
+                            current.enable_tls = v;
+                        }
+                    }
+                    "conversation_token_limit" => {
+                        if let Some(v) = value.as_u64() {
+                            current.conversation_token_limit = v as usize;
+                        }
+                    }
                     "temperature" => {
                         if let Some(v) = value.as_f64() {
                             current.temperature = v as f32;
@@ -5969,6 +6144,20 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
     // Load settings to get initial inference backend
     let settings = load_settings();
+    // Captured before `settings` moves into `BackendState` below — used
+    // once at the very end of this function to pick the TLS vs. plain
+    // listener.
+    // Computed once here (rather than at the final serve call, after
+    // `settings` has moved into `BackendState`) so both the listener
+    // choice below and `BackendState.enable_tls_active` (read by
+    // `/api/security/pqc/state`) share one source of truth.
+    let use_tls = settings.enable_tls || !tls::is_loopback_host(host);
+    // Eagerly generate/load (and, on first run, print) the API key here —
+    // `active_api_key()` is otherwise lazy-initialized on first use, which
+    // would mean the one-time "here's your key" banner never prints at
+    // all unless some request happens to trigger it first, leaving a
+    // fresh install with no way to discover the key it needs.
+    auth::active_api_key();
     let inference_backend = InferenceEngine::parse(&settings.inference_backend);
     let native_engine_client = native_engine::NativeEngineClient::new();
     let ollama_client = ollama::OllamaClient::new(ollama_url);
@@ -6047,6 +6236,9 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         settings,
         mcp_registry: Arc::clone(&mcp_registry),
         pending_tool_calls: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        download_progress: HashMap::new(),
+        model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
+        enable_tls_active: use_tls,
     }));
 
     // Background CPU/RAM/GPU sampler — keeps /api/metrics non-blocking.
@@ -6057,8 +6249,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         // child processes, some of which pull an npx package on first run) —
         // done in the background so a slow/misconfigured server can't delay
         // the API from coming up and serving everything else.
-        tokio::spawn(async move {
-            mcp_registry.connect_enabled().await;
+        tokio::spawn({
+            let mcp_registry = Arc::clone(&mcp_registry);
+            async move {
+                mcp_registry.connect_enabled().await;
+            }
         });
 
         let app = Router::new()
@@ -6161,20 +6356,50 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 get(backend_api::handle_backend_status),
             )
             .with_state(state)
+            // Auth runs inside CORS (added first here = innermost = runs
+            // *after* CORS on the way in), so a browser's CORS preflight
+            // OPTIONS request is still handled without needing a bearer
+            // token — matches how CORS preflight is expected to work.
+            .layer(middleware::from_fn(auth_middleware))
             .layer(CorsLayer::permissive());
 
-        // addr already parsed above
-        let listener = tokio::net::TcpListener::bind(addr)
-            .await
-            .map_err(|err| anyhow::anyhow!("failed to bind API server on {}: {}", addr, err))?;
-        println!(
-            "
+        // addr already parsed above; `use_tls` computed earlier alongside
+        // `BackendState.enable_tls_active`.
+        if use_tls {
+            let tls_config = tls::build_rustls_config(host)
+                .await
+                .map_err(|err| anyhow::anyhow!("failed to prepare TLS: {}", err))?;
+            println!(
+                "
+API Server Online (HTTPS, PQC-hybrid key exchange preferred). Ready for connections."
+            );
+            let shutdown_handle = axum_server::Handle::new();
+            tokio::spawn({
+                let shutdown_handle = shutdown_handle.clone();
+                async move {
+                    mcp_shutdown_on_ctrl_c(mcp_registry).await;
+                    shutdown_handle.graceful_shutdown(None);
+                }
+            });
+            axum_server::bind_rustls(addr, tls_config)
+                .handle(shutdown_handle)
+                .serve(app.into_make_service())
+                .await
+                .map_err(|err| anyhow::anyhow!("HTTPS API server terminated with error: {}", err))
+        } else {
+            let listener = tokio::net::TcpListener::bind(addr)
+                .await
+                .map_err(|err| anyhow::anyhow!("failed to bind API server on {}: {}", addr, err))?;
+            println!(
+                "
 API Server Online. Ready for connections."
-        );
+            );
 
-        axum::serve(listener, app)
-            .await
-            .map_err(|err| anyhow::anyhow!("API server terminated with error: {}", err))
+            axum::serve(listener, app)
+                .with_graceful_shutdown(mcp_shutdown_on_ctrl_c(mcp_registry))
+                .await
+                .map_err(|err| anyhow::anyhow!("API server terminated with error: {}", err))
+        }
     })?;
 
     Ok(())
@@ -8193,6 +8418,7 @@ fn run_gui_preflight_checks() -> Result<()> {
     Ok(())
 }
 
+mod auth;
 mod backend_api;
 mod backend_config;
 mod backend_registry;
@@ -8203,6 +8429,7 @@ mod native_engine;
 mod ollama;
 mod runtime;
 mod runtime_switcher;
+mod tls;
 mod vllm;
 
 static ACTIVE_BACKEND_REGISTRY: OnceLock<Arc<backend_registry::BackendRegistry>> = OnceLock::new();
@@ -8286,6 +8513,9 @@ mod tests {
                 std::env::temp_dir().join("ghostlink-test-mcp-servers.toml"),
             ))),
             pending_tool_calls: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            download_progress: HashMap::new(),
+            model_lifecycle_lock: Arc::new(tokio::sync::Mutex::new(())),
+            enable_tls_active: false,
         }))
     }
 

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1498,6 +1498,9 @@ struct BackendState {
     started_at: Instant,
     backend_url: String,
     cluster: Arc<ClusterState>,
+    /// This node's own id in `cluster` — needed to exclude ourselves when
+    /// selecting `distributed_inference` RPC peers (see `rpc_cluster`).
+    local_node_id: String,
     inference_backend: InferenceEngine,
     native_engine_client: native_engine::NativeEngineClient,
     ollama_client: ollama::OllamaClient,
@@ -1587,6 +1590,31 @@ struct RuntimeSettings {
     /// this field existed still deserialize.
     #[serde(default)]
     enable_tls: bool,
+    /// When true and the cluster has other nodes advertising
+    /// `contribute_compute`, the native engine launches with `--rpc`/`-ts`
+    /// so llama.cpp's own RPC backend splits the model across them — real
+    /// cross-process model-parallel inference (see `rpc_cluster`), not this
+    /// crate's synthetic pipeline-benchmark transport. Off by default: a
+    /// single-node deployment sees zero behavior change.
+    #[serde(default)]
+    distributed_inference: bool,
+    /// When true, this node runs `ggml-rpc-server` (see `rpc_cluster`),
+    /// exposing its own GPU/CPU as a device other cluster members can use
+    /// via `distributed_inference`. SECURITY: that server has no built-in
+    /// authentication (an upstream llama.cpp limitation) — only enable this
+    /// on a network you trust. Off by default.
+    #[serde(default)]
+    contribute_compute: bool,
+    /// Port `ggml-rpc-server` binds to when `contribute_compute` is on, and
+    /// the port advertised to peers (UDP/mDNS discovery) so they can reach
+    /// it. `#[serde(default = "...")]` so it survives a settings.json saved
+    /// before this field existed.
+    #[serde(default = "default_rpc_port")]
+    rpc_port: u16,
+}
+
+fn default_rpc_port() -> u16 {
+    50052
 }
 
 // Kept as named constants (rather than inlined in both `RuntimeSettings::default()`
@@ -1649,6 +1677,9 @@ impl Default for RuntimeSettings {
             xdp_interface: "eth0".to_string(),
             conversation_token_limit: default_conversation_token_limit(),
             enable_tls: false,
+            distributed_inference: false,
+            contribute_compute: false,
+            rpc_port: default_rpc_port(),
         }
     }
 }
@@ -3224,6 +3255,177 @@ struct PendingToolCallInfo {
     args: serde_json::Value,
 }
 
+/// Rough size/quality rank for common GGUF quantization tags — higher
+/// means bigger file / higher fidelity. Used to pick a quantization that
+/// actually fits the local machine instead of an arbitrary file from the
+/// repo. Matched by substring against the uppercased filename; ties are
+/// broken by preferring the longest matching tag (so "Q3_K_M" doesn't
+/// get miscategorized by a shorter unrelated prefix).
+fn quant_rank(name_upper: &str) -> Option<i32> {
+    const TIERS: &[(&str, i32)] = &[
+        ("IQ1", 0),
+        ("IQ2_XXS", 1),
+        ("IQ2_XS", 2),
+        ("IQ2_S", 3),
+        ("IQ2_M", 3),
+        ("Q2_K", 3),
+        ("IQ3_XXS", 4),
+        ("IQ3_XS", 5),
+        ("Q3_K_S", 5),
+        ("IQ3_S", 5),
+        ("IQ3_M", 6),
+        ("Q3_K_M", 6),
+        ("Q3_K_L", 7),
+        ("IQ4_XS", 7),
+        ("IQ4_NL", 8),
+        ("Q4_0", 8),
+        ("Q4_1", 8),
+        ("Q4_K_S", 8),
+        ("Q4_K_M", 9),
+        ("Q5_0", 10),
+        ("Q5_1", 10),
+        ("Q5_K_S", 10),
+        ("Q5_K_M", 11),
+        ("Q6_K", 12),
+        ("Q8_0", 13),
+        ("F16", 14),
+        ("BF16", 14),
+        ("F32", 15),
+    ];
+    TIERS
+        .iter()
+        .filter(|(tag, _)| name_upper.contains(tag))
+        .max_by_key(|(tag, _)| tag.len())
+        .map(|(_, rank)| *rank)
+}
+
+/// Target quantization rank (see `quant_rank`) for a given amount of
+/// VRAM — aims for a comfortable sweet spot rather than the smallest or
+/// largest option technically available. Below 4GB in particular, most
+/// 7B+ full-precision or Q6/Q8 files won't fit at all, so favor a much
+/// smaller quantization there rather than picking whatever the repo
+/// happens to list first (previously: always `gguf_files[0]`, with no
+/// regard for size at all).
+fn target_quant_rank_for_vram(vram_gb: f32) -> i32 {
+    if vram_gb >= 16.0 {
+        12 // Q6_K
+    } else if vram_gb >= 12.0 {
+        11 // Q5_K_M
+    } else if vram_gb >= 8.0 || vram_gb >= 4.0 {
+        9 // Q4_K_M — the common "fits almost anywhere with partial offload" sweet spot
+    } else {
+        6 // Q3_K_M / IQ3_M for genuinely constrained VRAM
+    }
+}
+
+/// HuggingFace GGUF repos commonly split a single quantization across
+/// multiple files named `<name>-00001-of-00005.gguf`. Groups filenames
+/// that belong to the same split set together (by filename with the
+/// shard suffix stripped) so all shards of a chosen quantization get
+/// downloaded — previously only `gguf_files[0]` was ever fetched, which
+/// for a split model meant downloading one shard of a multi-file model
+/// and silently leaving it unloadable (llama.cpp requires every shard
+/// alongside the first). Each returned group is sorted by shard index.
+fn group_gguf_shards(files: &[String]) -> Vec<Vec<String>> {
+    use std::collections::BTreeMap;
+
+    let shard_re = |name: &str| -> Option<(String, u32)> {
+        // Matches "...-00001-of-00005.gguf" (case-insensitive "of").
+        let lower = name.to_ascii_lowercase();
+        let gguf_pos = lower.rfind(".gguf")?;
+        let stem = &name[..gguf_pos];
+        let of_pos = stem.to_ascii_lowercase().rfind("-of-")?;
+        let (before_of, after_of) = stem.split_at(of_pos);
+        let _total: u32 = after_of[4..].parse().ok()?;
+        let dash_pos = before_of.rfind('-')?;
+        let shard_idx: u32 = before_of[dash_pos + 1..].parse().ok()?;
+        let base = before_of[..dash_pos].to_string();
+        Some((base, shard_idx))
+    };
+
+    let mut groups: BTreeMap<String, Vec<(u32, String)>> = BTreeMap::new();
+    for file in files {
+        match shard_re(file) {
+            Some((base, idx)) => groups.entry(base).or_default().push((idx, file.clone())),
+            None => groups
+                .entry(file.clone())
+                .or_default()
+                .push((0, file.clone())),
+        }
+    }
+
+    groups
+        .into_values()
+        .map(|mut shards| {
+            shards.sort_by_key(|(idx, _)| *idx);
+            shards.into_iter().map(|(_, name)| name).collect()
+        })
+        .collect()
+}
+
+/// Picks the shard-group whose quantization rank is closest to the
+/// target for the detected VRAM, preferring a rank at or below the
+/// target (safe) over one above it (might not fit) when both are
+/// equally close. Falls back to the smallest available quantization if
+/// none can be ranked (unusual filenames) rather than failing outright.
+fn select_best_gguf_group(groups: &[Vec<String>], vram_gb: f32) -> Option<Vec<String>> {
+    let target = target_quant_rank_for_vram(vram_gb);
+    groups
+        .iter()
+        .filter(|g| !g.is_empty())
+        .min_by_key(|g| {
+            let upper = g[0].to_ascii_uppercase();
+            match quant_rank(&upper) {
+                Some(rank) => {
+                    let diff = (rank - target).abs();
+                    // Prefer <= target over > target on a tie in absolute distance.
+                    (diff, if rank > target { 1 } else { 0 }, rank)
+                }
+                None => (i32::MAX, 1, i32::MAX),
+            }
+        })
+        .cloned()
+        .or_else(|| groups.first().cloned())
+}
+
+/// Best-effort *unique* node id for cluster discovery/registration.
+///
+/// Previously this was the literal string `"studio-api"` for every single
+/// API-server instance, on every machine — harmless for a single node, but
+/// it means any two real Ghostlink installs collide on the same
+/// `ClusterState` key (a `HashMap<String, NodeResources>`), so the second
+/// one to register silently overwrites the first's entry instead of the
+/// cluster ever containing both. `discover_rpc_peers`'s "exclude the local
+/// node id" filter would then exclude *every* peer too, since they'd all
+/// share that id — quietly breaking distributed inference (and clustering
+/// in general) across real hardware, not just in a same-machine test.
+/// Falls back to the old literal only if no hostname signal exists at all.
+fn detect_node_id() -> String {
+    if let Ok(id) = std::env::var("GHOSTLINK_NODE_ID") {
+        let id = id.trim().to_string();
+        if !id.is_empty() {
+            return id;
+        }
+    }
+    for var in ["COMPUTERNAME", "HOSTNAME"] {
+        if let Ok(name) = std::env::var(var) {
+            let name = name.trim().to_string();
+            if !name.is_empty() {
+                return name;
+            }
+        }
+    }
+    if let Ok(output) = std::process::Command::new("hostname").output() {
+        if output.status.success() {
+            let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !name.is_empty() {
+                return name;
+            }
+        }
+    }
+    "studio-api".to_string()
+}
+
 fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     use axum::{
         extract::{Path, Query, Request, State},
@@ -4348,8 +4550,41 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
         // Extract model info and settings under the lock, then drop it before
         // the potentially-long blocking load_model_into_slot call.
-        let (native_engine_client, local_path, native_engine, selected_model) = {
+        let (
+            native_engine_client,
+            local_path,
+            native_engine,
+            selected_model,
+            rpc_servers,
+            tensor_split,
+        ) = {
             let mut backend = lock_state(&state);
+
+            // Real cross-process model-parallel inference via llama.cpp's
+            // own RPC backend when enabled and the cluster has other nodes
+            // contributing compute — see `rpc_cluster` module docs. Empty
+            // when disabled or no qualifying peers, which reproduces
+            // single-node behavior exactly.
+            let (rpc_servers, tensor_split) = if backend.settings.distributed_inference {
+                let peers =
+                    rpc_cluster::discover_rpc_peers(&backend.cluster, &backend.local_node_id);
+                if peers.is_empty() {
+                    (None, None)
+                } else {
+                    let local_vram = backend
+                        .cluster
+                        .get_metrics(&backend.local_node_id)
+                        .map(|m| m.vram_gb)
+                        .unwrap_or(0.0);
+                    let split = rpc_cluster::compute_tensor_split(local_vram, &peers);
+                    (
+                        Some(rpc_cluster::rpc_flag_value(&peers)),
+                        Some(rpc_cluster::tensor_split_flag_value(&split)),
+                    )
+                }
+            } else {
+                (None, None)
+            };
 
             // Merge local scans so we can find local_path for locally-downloaded models
             let local = scan_local_models_dir(&backend.settings.models_dir);
@@ -4418,6 +4653,8 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 local_path,
                 backend.settings.native_engine.clone(),
                 selected,
+                rpc_servers,
+                tensor_split,
             )
         }; // <-- state lock dropped here
 
@@ -4435,7 +4672,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             };
 
             let result = tokio::task::spawn_blocking(move || {
-                native_engine_client.load_model_into_slot(&path, None, None)
+                native_engine_client.load_model_into_slot(
+                    &path,
+                    rpc_servers.as_deref(),
+                    tensor_split.as_deref(),
+                )
             })
             .await
             .map_err(|e| format!("task join error: {}", e))
@@ -4449,7 +4690,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         } else if let Some(path) = local_path.clone() {
             if native_engine == "llama_server" || native_engine == "llama-server" {
                 let result = tokio::task::spawn_blocking(move || {
-                    native_engine_client.load_model_into_slot(&path, None, None)
+                    native_engine_client.load_model_into_slot(
+                        &path,
+                        rpc_servers.as_deref(),
+                        tensor_split.as_deref(),
+                    )
                 })
                 .await
                 .map_err(|e| format!("task join error: {}", e))
@@ -6599,6 +6844,30 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                             current.enable_tls = v;
                         }
                     }
+                    "distributed_inference" => {
+                        if let Some(v) = value.as_bool() {
+                            // Live: re-checked from `backend.settings` on
+                            // every `/api/models/load` call (see
+                            // `handle_gui_model_load`), so this takes effect
+                            // on the next model load without a restart.
+                            current.distributed_inference = v;
+                        }
+                    }
+                    "contribute_compute" => {
+                        if let Some(v) = value.as_bool() {
+                            // Takes effect on next server restart — the
+                            // rpc-server contributor process (if any) is
+                            // started once at startup, not re-evaluated on a
+                            // settings change (see `rpc_cluster`).
+                            current.contribute_compute = v;
+                        }
+                    }
+                    "rpc_port" => {
+                        if let Some(v) = value.as_u64() {
+                            // Same next-restart caveat as contribute_compute.
+                            current.rpc_port = v as u16;
+                        }
+                    }
                     "conversation_token_limit" => {
                         if let Some(v) = value.as_u64() {
                             current.conversation_token_limit = v as usize;
@@ -6758,7 +7027,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     println!("  - POST /api/settings/reset");
     println!("  - POST /api/inference/chat");
 
-    let profile = detect_runtime_profile("studio-api");
+    let profile = detect_runtime_profile(detect_node_id());
     let backend_url = format!("http://{}:{}", host, port);
     println!(
         "Inference Core: {} workers, {} acceleration",
@@ -6784,13 +7053,31 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         .build()
         .map_err(|err| anyhow::anyhow!("failed to initialize runtime: {}", err))?;
 
+    // Loaded here (rather than at its previous spot further down) because
+    // discovery advertisement below needs `contribute_compute`/`rpc_port`
+    // to decide whether this node should advertise itself as an RPC
+    // contributor — see `rpc_cluster` module docs.
+    let mut settings = load_settings();
+
+    if settings.contribute_compute {
+        rpc_cluster::ensure_contributing(host, settings.rpc_port);
+    }
+    let advertised_node = if settings.contribute_compute {
+        profile
+            .node_resources
+            .clone()
+            .with_rpc_port(settings.rpc_port)
+    } else {
+        profile.node_resources.clone()
+    };
+
     let cluster = Arc::new(ClusterState::new());
-    let mut local_node = profile.node_resources.clone();
+    let mut local_node = advertised_node.clone();
     local_node.vram_gb = local_node.vram_gb.max(16.0);
     local_node.system_memory_gb = local_node.system_memory_gb.max(16.0);
     cluster.register(local_node);
 
-    let node_for_listener = profile.node_resources.clone();
+    let node_for_listener = advertised_node.clone();
     thread::spawn(move || {
         let auth_token = std::env::var("GHOSTLINK_DISCOVERY_AUTH_TOKEN")
             .ok()
@@ -6814,10 +7101,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     // replacement — some networks (managed VLANs, cloud VPCs) filter
     // broadcast traffic but still carry multicast. Best-effort: logged and
     // otherwise ignored on failure, same as the UDP listener thread.
-    ghostlink_core::mdns::ensure_advertised(&profile.node_resources, port);
+    ghostlink_core::mdns::ensure_advertised(&advertised_node, port);
 
     let cluster_for_broadcast = Arc::clone(&cluster);
-    let node_for_broadcast = profile.node_resources.clone();
+    let node_for_broadcast = advertised_node.clone();
     thread::spawn(move || {
         let auth_token = std::env::var("GHOSTLINK_DISCOVERY_AUTH_TOKEN")
             .ok()
@@ -6852,19 +7139,16 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     let models = load_persistent_models();
     save_persistent_models(&models);
 
-    let mut settings = load_settings();
-
-    // Auto-compute ngl from GPU VRAM only when the caller hasn't already told
-    // us what to do. `-1` is ambiguous on its own: it's both RuntimeSettings'
-    // unconfigured default AND launch-native.ps1's deliberate "offload every
-    // layer llama-server can fit" sentinel (see its own GHOSTLINK_LLAMA_NGL
-    // comment) — load_settings() just copied that env var verbatim into
-    // settings.ngl above, so gating on `settings.ngl < 0` alone can't tell
-    // "nobody configured this" from "-1 was the explicit choice", and ends up
-    // silently downgrading every native launch to a conservative 12-layer
-    // partial offload instead of the full offload that was actually
-    // requested. Only guess when no one set the env var at all.
-    if settings.ngl < 0 && std::env::var("GHOSTLINK_LLAMA_NGL").is_err() {
+    // Auto-compute ngl from GPU VRAM if still at default (-1) AND the
+    // operator didn't explicitly ask for -1. `load_settings()` above copies
+    // `GHOSTLINK_LLAMA_NGL` straight into `settings.ngl` when the env var is
+    // set, so an explicit `GHOSTLINK_LLAMA_NGL=-1` (native_engine.rs's own
+    // documented "let llama-server decide, offload all it can" value) is
+    // indistinguishable from "never configured" by value alone — without
+    // this check it gets silently reinterpreted as unconfigured and
+    // overwritten by the VRAM-tier guess below on every single startup.
+    let ngl_explicitly_set = std::env::var("GHOSTLINK_LLAMA_NGL").is_ok();
+    if settings.ngl < 0 && !ngl_explicitly_set {
         let ngl = if profile.node_resources.vram_gb >= 12.0 {
             40
         } else if profile.node_resources.vram_gb >= 8.0 {
@@ -6999,6 +7283,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         inference_metrics: host_metrics::InferenceMetrics::default(),
         started_at: Instant::now(),
         backend_url,
+        local_node_id: profile.node_resources.id.clone(),
         cluster,
         inference_backend,
         native_engine_client,
@@ -9231,6 +9516,7 @@ mod inference_engine;
 mod mcp;
 mod native_engine;
 mod ollama;
+mod rpc_cluster;
 mod runtime;
 mod runtime_switcher;
 mod tls;
@@ -9307,6 +9593,7 @@ mod tests {
             started_at: Instant::now(),
             backend_url: "http://127.0.0.1:8003".to_string(),
             cluster,
+            local_node_id: "test-node".to_string(),
             inference_backend: InferenceEngine::Vllm,
             native_engine_client: native_engine::NativeEngineClient::new(),
             ollama_client: ollama::OllamaClient::new("http://127.0.0.1:11434".to_string()),
@@ -9322,6 +9609,17 @@ mod tests {
             enable_tls_active: false,
             plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
         }))
+    }
+
+    #[test]
+    fn detect_node_id_prefers_explicit_env_override() {
+        // Regression coverage for the "studio-api" literal bug: two real
+        // Ghostlink instances previously always shared that id, colliding in
+        // ClusterState. GHOSTLINK_NODE_ID must win over any host-derived
+        // signal so operators (and tests) can force distinct ids.
+        std::env::set_var("GHOSTLINK_NODE_ID", "test-node-explicit");
+        assert_eq!(detect_node_id(), "test-node-explicit");
+        std::env::remove_var("GHOSTLINK_NODE_ID");
     }
 
     #[test]

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1507,13 +1507,9 @@ struct BackendState {
     settings: RuntimeSettings,
     mcp_registry: Arc<mcp::McpRegistry>,
     pending_tool_calls: Arc<tokio::sync::Mutex<HashMap<String, PendingToolCall>>>,
-    /// Belongs to a real-download-progress feature independently lost to the
-    /// same ea8d56c bad merge as everything restored in this PR —
-    /// `handle_gui_model_download_progress` still reports status from
-    /// `backend.models` instead of this tracker, so it's currently
-    /// write-only. Out of scope here; restoring its writer/reader pair is
-    /// tracked as separate follow-up work.
-    #[allow(dead_code)]
+    /// Real byte-level progress for an in-flight (or just-finished) model
+    /// download, updated live from the background download task and read by
+    /// `/api/models/download/progress` for the GUI's polling loop.
     download_progress: HashMap<String, DownloadProgressInfo>,
     /// Serializes the full model load/unload sequence end to end — the
     /// llama-server stage/kill/spawn dance in `NativeEngineClient::load_model_into_slot`
@@ -4353,6 +4349,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     async fn download_hf_model(
         model_id: &str,
         models_dir: &std::path::Path,
+        mut on_progress: impl FnMut(u64, u64) + Send,
     ) -> Result<String, String> {
         let client = reqwest::Client::builder()
             .user_agent("ghostlink/1.0")
@@ -4399,26 +4396,68 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         let chosen_files = select_best_gguf_group(&groups, vram_gb)
             .ok_or_else(|| "No usable GGUF file found in this repository".to_string())?;
 
-        let mut first_dest_path: Option<std::path::PathBuf> = None;
-        for filename in &chosen_files {
+        // `filename` comes straight from the remote HuggingFace API response
+        // (`rfilename`) and may contain nested-path separators or, in the
+        // worst case, an absolute path. `PathBuf::join` silently discards the
+        // base directory when given an absolute path, and any path
+        // separators could otherwise let a crafted repo write outside
+        // `models_dir`. Only the file's base name is ever meaningful here.
+        let files: Vec<(String, std::path::PathBuf)> = chosen_files
+            .iter()
+            .map(|filename| {
+                let safe_filename = std::path::Path::new(filename.as_str())
+                    .file_name()
+                    .map(|f| f.to_string_lossy().into_owned())
+                    .filter(|f| !f.is_empty())
+                    .unwrap_or_else(|| "download.gguf".to_string());
+                let dest_path = models_dir.join(&safe_filename);
+                (filename.clone(), dest_path)
+            })
+            .collect();
+
+        // Sizing pass: HEAD every shard up front so the progress callback can
+        // report a real fraction from the very first update instead of sitting
+        // at an unknowable 0/0 until the last shard finishes.
+        let mut expected_sizes: Vec<u64> = Vec::with_capacity(files.len());
+        let mut total_bytes: u64 = 0;
+        for (filename, _) in &files {
             let file_url = format!(
                 "https://huggingface.co/{}/resolve/main/{}",
                 model_id, filename
             );
-            // `filename` comes straight from the remote HuggingFace API response
-            // (`rfilename`) and may contain nested-path separators or, in the
-            // worst case, an absolute path. `PathBuf::join` silently discards the
-            // base directory when given an absolute path, and any path
-            // separators could otherwise let a crafted repo write outside
-            // `models_dir`. Only the file's base name is ever meaningful here.
-            let safe_filename = std::path::Path::new(filename.as_str())
-                .file_name()
-                .map(|f| f.to_string_lossy().into_owned())
-                .filter(|f| !f.is_empty())
-                .unwrap_or_else(|| "download.gguf".to_string());
-            let dest_path = models_dir.join(&safe_filename);
+            let len = client
+                .head(&file_url)
+                .send()
+                .await
+                .ok()
+                .and_then(|r| r.content_length())
+                .unwrap_or(0);
+            expected_sizes.push(len);
+            total_bytes += len;
+        }
+        on_progress(0, total_bytes);
 
-            if !dest_path.exists() {
+        let mut downloaded_bytes: u64 = 0;
+        let mut first_dest_path: Option<std::path::PathBuf> = None;
+        let mut last_report = std::time::Instant::now();
+        for (idx, (filename, dest_path)) in files.iter().enumerate() {
+            let expected_len = expected_sizes[idx];
+            let existing_len = tokio::fs::metadata(dest_path)
+                .await
+                .map(|m| m.len())
+                .unwrap_or(0);
+            // A file only counts as already-downloaded if its size matches what
+            // HuggingFace reports. Previously any existing file — including one
+            // truncated by a dropped connection — was treated as complete and
+            // silently never retried.
+            let already_complete =
+                dest_path.exists() && (expected_len == 0 || existing_len == expected_len);
+
+            if !already_complete {
+                let file_url = format!(
+                    "https://huggingface.co/{}/resolve/main/{}",
+                    model_id, filename
+                );
                 let resp = client
                     .get(&file_url)
                     .send()
@@ -4432,10 +4471,11 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 if let Some(parent) = dest_path.parent() {
                     fs::create_dir_all(parent).map_err(|e| format!("Dir error: {}", e))?;
                 }
-                let mut file = tokio::fs::File::create(&dest_path)
+                let mut file = tokio::fs::File::create(dest_path)
                     .await
                     .map_err(|e| format!("File error: {}", e))?;
                 let mut stream = resp;
+                let mut file_bytes: u64 = 0;
                 while let Some(chunk) = stream
                     .chunk()
                     .await
@@ -4444,12 +4484,35 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     file.write_all(&chunk)
                         .await
                         .map_err(|e| format!("Write error: {}", e))?;
+                    file_bytes += chunk.len() as u64;
+                    if last_report.elapsed() >= std::time::Duration::from_millis(200) {
+                        on_progress(downloaded_bytes + file_bytes, total_bytes);
+                        last_report = std::time::Instant::now();
+                    }
                 }
                 file.flush().await.ok();
+                drop(file);
+
+                // The connection can be dropped mid-transfer (client timeout,
+                // network blip) without `chunk()` ever returning an `Err` — the
+                // stream just ends early. Compare against the size HuggingFace
+                // actually advertised instead of trusting an early EOF.
+                if expected_len > 0 && file_bytes != expected_len {
+                    let _ = tokio::fs::remove_file(dest_path).await;
+                    return Err(format!(
+                        "Download incomplete for {}: got {} of {} bytes",
+                        filename, file_bytes, expected_len
+                    ));
+                }
+                downloaded_bytes += file_bytes;
+            } else {
+                downloaded_bytes += existing_len;
             }
 
+            on_progress(downloaded_bytes, total_bytes);
+
             if first_dest_path.is_none() {
-                first_dest_path = Some(dest_path);
+                first_dest_path = Some(dest_path.clone());
             }
         }
 
@@ -4867,11 +4930,21 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             let backend = lock_state(&state);
             backend.settings.models_dir.clone()
         };
-        let models_path = std::path::Path::new(&models_dir);
-        fs::create_dir_all(models_path).ok();
+        let models_path = std::path::PathBuf::from(&models_dir);
+        fs::create_dir_all(&models_path).ok();
 
         {
             let mut backend = lock_state(&state);
+            // A download already running for this model — don't start a second
+            // one racing it on the same destination file.
+            if let Some(existing) = backend.download_progress.get(&model_id) {
+                if existing.status == "downloading" {
+                    return Json(serde_json::json!({
+                        "status": "started",
+                        "message": format!("{} is already downloading", model_id),
+                    }));
+                }
+            }
             if !backend.models.iter().any(|m| m.name == model_id) {
                 backend.models.push(ModelRecord {
                     name: model_id.clone(),
@@ -4886,51 +4959,91 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 m.status = "Downloading".to_string();
                 save_persistent_models(&backend.models);
             }
+            backend.download_progress.insert(
+                model_id.clone(),
+                DownloadProgressInfo {
+                    bytes_downloaded: 0,
+                    total_bytes: 0,
+                    status: "downloading".to_string(),
+                    error: None,
+                },
+            );
         }
 
-        let result = download_hf_model(&model_id, models_path).await;
+        // The actual transfer runs detached from this request/response cycle so
+        // a multi-GB model isn't bound by the frontend's HTTP client timeout —
+        // that used to abort (and silently truncate) any download that took
+        // longer than the client's timeout window. The GUI now polls
+        // /api/models/download/progress for real byte-level progress instead.
+        let spawn_state = Arc::clone(&state);
+        let spawn_model_id = model_id.clone();
+        tokio::spawn(async move {
+            let progress_state = Arc::clone(&spawn_state);
+            let progress_model_id = spawn_model_id.clone();
+            let result =
+                download_hf_model(&spawn_model_id, &models_path, move |downloaded, total| {
+                    let mut backend = lock_state(&progress_state);
+                    if let Some(p) = backend.download_progress.get_mut(&progress_model_id) {
+                        p.bytes_downloaded = downloaded;
+                        p.total_bytes = total;
+                    }
+                })
+                .await;
 
-        match result {
-            Ok(local_path) => {
-                let filename = std::path::Path::new(&local_path)
-                    .file_name()
-                    .unwrap()
-                    .to_string_lossy()
-                    .to_string();
-                let name = filename
-                    .strip_suffix(".gguf")
-                    .unwrap_or(&filename)
-                    .to_string();
-                let size_bytes = fs::metadata(&local_path).map(|m| m.len()).unwrap_or(0);
-                let size_gb = size_bytes as f32 / (1024.0 * 1024.0 * 1024.0);
+            match result {
+                Ok(local_path) => {
+                    let filename = std::path::Path::new(&local_path)
+                        .file_name()
+                        .map(|f| f.to_string_lossy().to_string())
+                        .unwrap_or_else(|| local_path.clone());
+                    let name = filename
+                        .strip_suffix(".gguf")
+                        .unwrap_or(&filename)
+                        .to_string();
+                    let size_bytes = fs::metadata(&local_path).map(|m| m.len()).unwrap_or(0);
+                    let size_gb = size_bytes as f32 / (1024.0 * 1024.0 * 1024.0);
 
-                let mut backend = lock_state(&state);
-                backend.models.retain(|m| m.name != model_id);
-                backend.models.push(ModelRecord {
-                    name,
-                    size_gb,
-                    model_type: "LLM".to_string(),
-                    quantization: detect_quantization(&filename),
-                    status: "Ready".to_string(),
-                    local_path,
-                });
-                save_persistent_models(&backend.models);
-
-                Json(serde_json::json!({
-                    "status": "ok",
-                    "message": format!("model downloaded ({:.2} GB)", size_gb),
-                }))
-            }
-            Err(err) => {
-                let mut backend = lock_state(&state);
-                if let Some(model) = backend.models.iter_mut().find(|m| m.name == model_id) {
-                    model.status = "Failed".to_string();
+                    let mut backend = lock_state(&spawn_state);
+                    backend.models.retain(|m| m.name != spawn_model_id);
+                    backend.models.push(ModelRecord {
+                        name,
+                        size_gb,
+                        model_type: "LLM".to_string(),
+                        quantization: detect_quantization(&filename),
+                        status: "Ready".to_string(),
+                        local_path,
+                    });
+                    save_persistent_models(&backend.models);
+                    backend.download_progress.insert(
+                        spawn_model_id.clone(),
+                        DownloadProgressInfo {
+                            bytes_downloaded: size_bytes,
+                            total_bytes: size_bytes,
+                            status: "completed".to_string(),
+                            error: None,
+                        },
+                    );
                 }
-                save_persistent_models(&backend.models);
-
-                Json(serde_json::json!({ "error": err }))
+                Err(err) => {
+                    let mut backend = lock_state(&spawn_state);
+                    if let Some(model) =
+                        backend.models.iter_mut().find(|m| m.name == spawn_model_id)
+                    {
+                        model.status = "Failed".to_string();
+                    }
+                    save_persistent_models(&backend.models);
+                    if let Some(p) = backend.download_progress.get_mut(&spawn_model_id) {
+                        p.status = "failed".to_string();
+                        p.error = Some(err);
+                    }
+                }
             }
-        }
+        });
+
+        Json(serde_json::json!({
+            "status": "started",
+            "message": format!("Downloading {}", model_id),
+        }))
     }
 
     async fn handle_gui_model_download_progress(
@@ -4947,6 +5060,26 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }
 
         let backend = lock_state(&state);
+        // Real byte-level progress from the in-flight (or just-finished)
+        // background download task — this is the source of truth whenever
+        // it's available. The model-status heuristic below only covers
+        // entries left over from before this map existed (e.g. across a
+        // server restart mid-download).
+        if let Some(p) = backend.download_progress.get(&model_id) {
+            let progress = if p.total_bytes > 0 {
+                (p.bytes_downloaded as f64 / p.total_bytes as f64).min(1.0)
+            } else {
+                0.0
+            };
+            return Json(serde_json::json!({
+                "progress": progress,
+                "status": p.status,
+                "bytes_downloaded": p.bytes_downloaded,
+                "total_bytes": p.total_bytes,
+                "error": p.error,
+            }));
+        }
+
         if let Some(model) = backend.models.iter().find(|m| m.name == model_id) {
             let (progress, status) = match model.status.as_str() {
                 "Downloading" => (0.0, "downloading"),

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1489,8 +1489,6 @@ struct BackendState {
     current_model: String,
     workers: Vec<WorkerRecord>,
     sessions: Vec<SessionRecord>,
-    #[allow(dead_code)]
-    queue_depth: usize,
     chat_requests: u64,
     last_latency_ms: f32,
     last_tokens_per_sec: f32,
@@ -1614,6 +1612,14 @@ struct RuntimeSettings {
     gui_port: u16,
     threads: usize,
     ctx_size: usize,
+    /// Concurrent llama-server inference slots (`-np`). `1` matches every
+    /// prior release's behavior exactly; raising it lets ghost-link serve
+    /// more than one generation at a time, bounded by
+    /// `RequestTracker::acquire_slot`. `#[serde(default = "...")]` so
+    /// settings.json files saved before this field existed still
+    /// deserialize instead of falling back to the full default.
+    #[serde(default = "default_parallel_slots")]
+    parallel_slots: usize,
     temperature: f32,
     top_p: f32,
     top_k: usize,
@@ -1714,7 +1720,8 @@ impl Default for RuntimeSettings {
             api_port: 8003,
             gui_port: 5173,
             threads: 4,
-            ctx_size: 4096,
+            ctx_size: DEFAULT_CTX_SIZE,
+            parallel_slots: DEFAULT_PARALLEL_SLOTS,
             temperature: 0.7,
             top_p: 0.9,
             top_k: 40,
@@ -2959,6 +2966,15 @@ fn load_settings() -> RuntimeSettings {
     {
         std::env::set_var("GHOSTLINK_VLLM_API_KEY", settings.vllm_api_key.trim());
     }
+    if std::env::var("GHOSTLINK_PARALLEL_SLOTS")
+        .map(|v| v.trim().is_empty())
+        .unwrap_or(true)
+    {
+        std::env::set_var(
+            "GHOSTLINK_PARALLEL_SLOTS",
+            settings.parallel_slots.to_string(),
+        );
+    }
 
     if let Ok(val) = std::env::var("GHOSTLINK_INFERENCE_BACKEND") {
         let v = val.trim().to_ascii_lowercase();
@@ -3647,6 +3663,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
         let request_tracker = active_runtime_switcher().request_tracker().clone();
         request_tracker.increment().await;
+        // Bounds real concurrent llama-server calls to `parallel_slots`
+        // instead of firing every admitted request at it unbounded; dropped
+        // automatically when this function returns.
+        let _slot_permit = request_tracker.acquire_slot().await;
 
         let (temp, top_p, top_k, penalty) = sanitize_generation_params(
             req.temperature.unwrap_or(0.7),
@@ -5885,7 +5905,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     }
 
     async fn handle_gui_queue() -> Json<serde_json::Value> {
-        Json(serde_json::json!({ "status": "ok", "depth": 0 }))
+        let request_tracker = active_runtime_switcher().request_tracker().clone();
+        Json(serde_json::json!({
+            "status": "ok",
+            "depth": request_tracker.queue_depth().await,
+            "slot_capacity": request_tracker.slot_capacity(),
+        }))
     }
 
     /// Real JWT issuance (was a hardcoded `"new-token-123"`). Reaching this
@@ -7322,6 +7347,24 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                             current.ctx_size = v as usize;
                         }
                     }
+                    "parallel_slots" => {
+                        if let Some(v) = value.as_u64() {
+                            current.parallel_slots = (v as usize).clamp(1, 64);
+                            // Mirrors llama_server_url's existing precedent
+                            // below: takes effect on the *next* model load
+                            // for llama-server's own -np flag.
+                            std::env::set_var(
+                                "GHOSTLINK_PARALLEL_SLOTS",
+                                current.parallel_slots.to_string(),
+                            );
+                            // Takes effect immediately for ghost-link's own
+                            // admission control, independent of when the
+                            // model next reloads.
+                            active_runtime_switcher()
+                                .request_tracker()
+                                .resize_slots(current.parallel_slots);
+                        }
+                    }
                     "enable_tls" => {
                         if let Some(v) = value.as_bool() {
                             // Takes effect on next server restart — the
@@ -7763,7 +7806,6 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             load: 35,
         }],
         sessions: vec![],
-        queue_depth: 0,
         chat_requests: 0,
         last_latency_ms: 0.0,
         last_tokens_per_sec: 0.0,
@@ -10087,7 +10129,6 @@ mod tests {
             current_model: "tinyllama".to_string(),
             workers: vec![],
             sessions: vec![],
-            queue_depth: 0,
             chat_requests: 0,
             last_latency_ms: 0.0,
             last_tokens_per_sec: 0.0,

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1507,6 +1507,13 @@ struct BackendState {
     settings: RuntimeSettings,
     mcp_registry: Arc<mcp::McpRegistry>,
     pending_tool_calls: Arc<tokio::sync::Mutex<HashMap<String, PendingToolCall>>>,
+    /// Belongs to a real-download-progress feature independently lost to the
+    /// same ea8d56c bad merge as everything restored in this PR —
+    /// `handle_gui_model_download_progress` still reports status from
+    /// `backend.models` instead of this tracker, so it's currently
+    /// write-only. Out of scope here; restoring its writer/reader pair is
+    /// tracked as separate follow-up work.
+    #[allow(dead_code)]
     download_progress: HashMap<String, DownloadProgressInfo>,
     /// Serializes the full model load/unload sequence end to end — the
     /// llama-server stage/kill/spawn dance in `NativeEngineClient::load_model_into_slot`
@@ -1519,6 +1526,11 @@ struct BackendState {
     /// `backend.current_model = selected_model` write was a plain
     /// last-writer-wins race with no relation to which process actually
     /// survived the taskkill/spawn collision.
+    ///
+    /// Also independently lost to ea8d56c: nothing currently calls
+    /// `.lock()` on this — the fix this field describes isn't wired into
+    /// `/api/models/load` yet. Same follow-up as `download_progress` above.
+    #[allow(dead_code)]
     model_lifecycle_lock: Arc<tokio::sync::Mutex<()>>,
     /// Custom inference backends registered via `backend_plugin` — checked
     /// by the OpenAI-compatible REST handlers before falling through to the

--- a/crates/ghost-link/src/mcp/registry.rs
+++ b/crates/ghost-link/src/mcp/registry.rs
@@ -156,7 +156,6 @@ impl McpRegistry {
     /// ever applied to the *spawned child process* — this (main) process
     /// never inherits them, so out-of-band checks (e.g. "is rag's Ollama
     /// actually reachable") can't just read `std::env::var` directly.
-    #[allow(dead_code)]
     pub fn env_var_for(&self, server_name: &str, key: &str) -> Option<String> {
         let configs = self.config_manager.load().ok()?;
         let config = configs.into_iter().find(|c| c.name == server_name)?;

--- a/crates/ghost-link/src/runtime_switcher.rs
+++ b/crates/ghost-link/src/runtime_switcher.rs
@@ -57,7 +57,6 @@ impl Default for SwitchingConfig {
 /// Request tracking for draining, plus admission control matching however
 /// many concurrent slots the currently-running llama-server actually has.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct RequestTracker {
     in_flight: Arc<Mutex<usize>>,
     slot_semaphore: Arc<Semaphore>,
@@ -74,7 +73,6 @@ impl Default for RequestTracker {
     }
 }
 
-#[allow(dead_code)]
 impl RequestTracker {
     /// Create a new request tracker. Slot capacity starts at whatever
     /// `GHOSTLINK_PARALLEL_SLOTS` currently says (same env var

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,14 @@ services:
       GHOSTLINK_INFERENCE_BACKEND: native
       GHOSTLINK_NATIVE_ENGINE: llama_server
       GHOSTLINK_LLAMA_SERVER_URL: http://llama-server:8080/completion
+      # Shared with control-plane below via the ghostlink-api-key volume, so
+      # control-plane's own auth.LoadAPIKey() can find the same key instead
+      # of silently coming up empty (each service is its own container with
+      # its own filesystem, so the default relative "api_key.txt" path never
+      # lines up between them on its own).
+      GHOSTLINK_API_KEY_PATH: /shared/api_key.txt
+    volumes:
+      - ghostlink-api-key:/shared
     networks:
       - ghostlink-network
     depends_on:
@@ -71,6 +79,15 @@ services:
     environment:
       PORT: "8000"
       GHOSTLINK_BACKEND_URL: http://ghostlink-api:8003
+      # See the matching comment on ghostlink-api's GHOSTLINK_API_KEY_PATH
+      # above — without this, control-plane's edge auth check silently
+      # no-ops (empty key = skip), which also means requests that should
+      # be rejected for free by that check fall through and consume
+      # rate-limit budget instead, so ordinary traffic can trip the
+      # limiter far sooner than intended.
+      GHOSTLINK_API_KEY_PATH: /shared/api_key.txt
+    volumes:
+      - ghostlink-api-key:/shared
     networks:
       - ghostlink-network
     depends_on:
@@ -106,3 +123,6 @@ services:
 networks:
   ghostlink-network:
     driver: bridge
+
+volumes:
+  ghostlink-api-key:

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -135,111 +135,212 @@ Tested default vs. this host's documented 4GB-VRAM-tier recommendation
 - AF_XDP kernel-bypass — not implemented on Windows, out of scope here.
 
 
-## In-Memory Transport Benchmarks — UNVERIFIED, pending a real run on this hardware
+## Full-Spectrum Session Benchmark — 2026-08-03 (Linux mini PC, no dedicated GPU)
 
-Like the Multi-Node table below, these two tables cannot be traced to any
-real run in this repo: no date, no methodology, and the model list
-(`orca-mini`, `mistral`, `llama2-7b`) and hardware (8-core Intel/AMD,
-RTX 4090) don't match anything actually exercised in the "Full-Spectrum
-Session Benchmark" above, which is real and used `Llama-3.2-1B-Instruct`
-on an AMD integrated GPU. Leaving them here as a placeholder to replace,
-not evidence of past measurement — treat everything below as
-**unverified**:
+Real, measured results from a genuinely different hardware class than
+every other entry in this document — a low-power consumer mini PC with no
+dedicated GPU, running native Linux rather than Windows. This is the real
+Linux data point [ENTERPRISE_PLAN.md](ENTERPRISE_PLAN.md)'s Track A flagged
+as missing (this is also the same host used for the real two-machine LAN
+benchmark in the Multi-Node Performance section below).
 
-### CPU Configuration (8-core Intel/AMD) — unverified placeholder
+### Hardware
 
-| Model | Throughput | Latency P50 | Latency P95 | Memory Usage |
-|-------|------------|-------------|-------------|--------------|
-| orca-mini (3B) | ~600K tokens/s | 1.2ms | 3.5ms | 2.0 GB |
-| mistral (7B) | ~450K tokens/s | 1.8ms | 5.2ms | 6.0 GB |
-| llama2-7b (7B) | ~420K tokens/s | 2.0ms | 5.8ms | 6.0 GB |
+| | |
+|---|---|
+| Host | `Desk-Mini` |
+| CPU | 4 logical cores (Intel Alder Lake-N) |
+| System RAM | 14.9 GB |
+| GPU | Alder Lake-N UHD Graphics (integrated), Vulkan, 0.0 GB dedicated VRAM reported |
+| OS | Linux |
+| Build | `cargo build --release` (workspace default `lto = "thin"`, `codegen-units = 1`) |
 
-### GPU Configuration (NVIDIA RTX 4090) — unverified placeholder
+Detected via `ghost-link probe local-node` (same command used for the
+Multi-Node Performance entry below).
 
-| Model | Throughput | Latency P50 | Latency P95 | Memory Usage |
-|-------|------------|-------------|-------------|--------------|
-| orca-mini (3B) | ~2.1M tokens/s | 0.4ms | 1.1ms | 2.0 GB |
-| mistral (7B) | ~1.6M tokens/s | 0.6ms | 1.8ms | 6.0 GB |
-| llama2-7b (7B) | ~1.5M tokens/s | 0.7ms | 2.0ms | 6.0 GB |
+### Methodology note: contention explains the primitives, but not the full pipeline
 
-Do not cite these tables. `scripts/flow_perf_snapshot.py` and
+The first `cargo bench`/`flow_perf_snapshot.py` run on this host ran while
+`launch.sh`'s own servers (API, control-plane, llama-server, Vite dev
+server) were still up, competing for all 4 cores. That run showed Criterion
+reporting "Performance has regressed +20-40%" on nearly every primitive
+relative to this host's previously-stored baseline — a real, expected
+effect of CPU contention. After stopping every Ghostlink process and
+re-running clean, most primitives improved as expected (raw logs below).
+
+The full-pipeline `flow_perf_snapshot.py` numbers did **not** follow that
+pattern — the "clean" run's average throughput was *lower* than the
+contended run's (tcp: 76.5k clean vs. 114.4k contended tok/s; inmem: 134.4k
+clean vs. 178.2k contended tok/s), and both runs show an enormous
+run-to-run spread within their own 5 samples (clean inmem alone:
+77.5k-187.4k tok/s, a 2.4x range). On this specific low-power 4-core host,
+5 runs isn't enough for a stable mean, and other confounds (thermal
+throttling on an N-series chip, memory-bandwidth sharing with the
+integrated GPU) likely dominate over whatever contention stopping the
+app's own servers removed. Treat every number below as directional for "a
+weak consumer-grade mini PC," not a tight estimate — this host is noisier
+than the AMD laptop profile above, which was already flagged as noisy.
+
+### Primitives (Criterion, clean run — background services stopped)
+
+| Benchmark | Time |
+|---|---|
+| `ring/push_pop_round_trip/st` | 3.15-3.22 ns |
+| `ring/push_only/st` | 5.07-5.15 ns |
+| `ring/spsc_throughput/mt` | 12.15-12.83 ns |
+| `protocol/encode` | 85.1-86.3 ns |
+| `protocol/decode` | 101.4-104.0 ns |
+| `protocol/round_trip` | 204.0-212.6 ns |
+| `planning/33_layers_2_nodes` | 140.1-141.0 ns |
+| `planning/80_layers_8_nodes` | 334.2-342.4 ns |
+| `planning/80_layers_8_nodes_autotuned` | 424.6-428.6 ns |
+| `cluster/register_update` | 235.3-237.3 ns |
+| `cluster/nodes_snapshot_10` | 30.8-31.4 ns |
+| `cluster/total_vram_10` | 927-935 ps |
+| `cluster/calculate_cluster_health_10` | 45.1-47.0 ns |
+| `autotune/detect_runtime_profile_fast` | 106.9-108.8 ns |
+| `autotune/detect_runtime_profile_full` | 19.18-20.48 ms |
+| `autotune/load_balance_80_layers_autotuned` | 1.616-1.632 µs |
+| `autotune/accelerator_scale_f32_slice` | 2.186-2.224 µs |
+
+`fabric_*` benchmarks (present in the Windows laptop entry above) did not
+appear in this run's output on this host — noted rather than guessed at;
+worth checking whether that's a platform feature gate or a suite change
+before assuming anything from their absence.
+
+### Full pipeline (`scripts/flow_perf_snapshot.py`, `exec_tokens=512 micro_batch=8`, release build)
+
+| Run | Mode | Throughput (avg) | Throughput (min-max) | P95 (avg) |
+|---|---|---|---|---|
+| Contended (app servers running) | tcp | 114,429.68 tok/s | 78,979.10-134,124.42 | 4.58 ms |
+| Contended (app servers running) | inmem | 178,194.78 tok/s | 82,469.41-272,413.03 | 3.56 ms |
+| Clean (servers stopped) | tcp | 76,455.51 tok/s | 63,534.12-89,957.73 | 6.78 ms |
+| Clean (servers stopped) | inmem | 134,359.68 tok/s | 77,473.96-187,417.62 | 4.10 ms |
+
+Compared against `docs/PERF_BASELINE.json` (256,020 tok/s tcp / 506,809
+tok/s inmem, captured on different, more powerful hardware): this host's
+clean-run numbers land roughly 70-73% below that baseline — far outside the
+45%/40% drop tolerances defined there. That's not a regression; it's
+confirmation that a 4-core integrated-graphics mini PC is a genuinely
+different performance tier from whatever machine set that baseline. The
+honest takeaway from this host isn't a specific throughput figure (the
+spread above is too wide to trust any single number) — it's that Ghostlink
+runs correctly end-to-end on real, low-power, no-dedicated-GPU Linux
+hardware, which is itself a useful data point for the project's "runs on
+whatever's already on your LAN" positioning.
+
+Raw logs (on the Desk-Mini host itself, not committed to this repo):
+`~/criterion_desk_mini.log` / `~/flow_perf_desk_mini.log` (contended run)
+and `~/criterion_desk_mini_clean.log` / `~/flow_perf_desk_mini_clean.log`
+(clean run).
+
+## Other hardware profiles
+
+Real, measured single-node numbers now exist in this document for three
+hardware classes: an AMD integrated GPU laptop (Windows), an Intel
+i7-14700K (Linux/WSL2, see the README's own
+[Performance section](../README.md#performance)), and a low-power Linux
+mini PC with no dedicated GPU (above). This repo previously carried
+fabricated placeholder tables here for CPU/GPU configurations (8-core
+Intel/AMD, RTX 4090) and model throughput that were never actually run —
+they've been removed rather than left as bait for anyone skimming this
+doc. Still missing: a discrete NVIDIA/AMD GPU, Apple Silicon, and a
+server-class CPU. If you benchmark Ghostlink on one of those,
+`scripts/flow_perf_snapshot.py` and
 `cargo bench -p ghostlink-core --bench criterion` are the repo's real,
-runnable benchmark tools — see the Full-Spectrum session above for what
-their real output looks like.
+runnable benchmark tools (see the Full-Spectrum sessions above for exact
+invocations and output format) — a PR adding a dated, methodology-labeled
+entry for a new hardware class is a genuinely useful contribution.
 
 ---
 
 ## Multi-Node Performance
 
-### LAN Performance (1 Gbps Ethernet) — UNVERIFIED, pending a real multi-host run
+### Real two-machine LAN run — 2026-08-03
 
-The table below predates this session's investigation and cannot be traced
-to any real run: no date, no host inventory, no methodology, and — more
-fundamentally — until the `stage-worker`/`flow --remote-addr` work landed
-(see [DEPLOYMENT.md's Stage 3b](DEPLOYMENT.md#stage-3b-real-cross-machine-flow-execution)),
-`flow` never actually reached a second machine at all, so no version of
-Ghost-Link could have produced these particular numbers. Leaving it here
-with this label rather than deleting it, so it's clear this is a
-placeholder to replace, not evidence of past measurement:
+The first real entry for this section, replacing the fabricated 2/3/4-node
+placeholder table this repo used to carry (see git history) — that table
+predated `stage-worker`/`flow --remote-addr` even existing, so no version
+of Ghost-Link could have produced it.
 
-| Node Count | Throughput | Latency | Notes |
-|------------|------------|---------|-------|
-| 2 nodes | ~580K tokens/s | 2.5ms | TCP transport — **unverified placeholder** |
-| 3 nodes | ~550K tokens/s | 3.2ms | TCP transport — **unverified placeholder** |
-| 4 nodes | ~520K tokens/s | 4.1ms | TCP transport — **unverified placeholder** |
+**Hardware — two genuinely separate machines on the same residential LAN:**
 
-Do not cite this table. To get real numbers, run
-[`scripts/remote_flow_benchmark.py`](../scripts/remote_flow_benchmark.py)
-across two physical machines on your own network (see below).
+| | Coordinator (local) | Remote (`stage-worker`) |
+|---|---|---|
+| Host | Windows 11 laptop | `Desk-Mini` (Linux) |
+| CPU | 16 logical cores | 4 logical cores (Intel Alder Lake-N) |
+| System RAM | 27.6 GB | 14.9 GB |
+| GPU | AMD Radeon 860M (integrated), 4.0 GB VRAM, DirectML | Alder Lake-N UHD Graphics (integrated), Vulkan, 0.0 GB dedicated VRAM reported |
+| Network | Wi-Fi | unknown (not confirmed Ethernet vs. Wi-Fi) |
 
-### Real cross-process benchmark harness
+ICMP round-trip between the two over this LAN measured 8-14ms
+(`ping Desk-Mini`), consistent with the TCP bridge-write latency below.
 
-`scripts/remote_flow_benchmark.py` drives the genuine `stage-worker` /
-`flow --remote-addr` path repeatedly and summarizes real measured
-throughput and remote round-trip time (`avg_bridge_write_ms`) — not
-placeholder constants. Real two-machine LAN numbers require hardware this
-session doesn't have access to (one dev machine, not a two-node LAN), so
-none are published here yet; running it is the way to replace the
-placeholder table above with real data.
-
-What *was* verified on this single machine — a same-host loopback smoke
-test, proving the harness and the underlying transport work end-to-end,
-explicitly **not** a network benchmark (no real NIC, no real latency):
+**A real capacity-modeling caveat, stated plainly**: `print_flow` (the code
+behind the `flow` subcommand this harness drives) hardcodes the local
+node's declared capacity to a minimum of 16GB
+(`crates/ghost-link/src/main.rs`, `print_flow`, `.max(16.0)`) for its fixed
+60-layer/30GB synthetic scenario — that's a demo-scenario convenience, not
+a claim about this laptop's real ~4GB VRAM. Desk-Mini's real probed
+capacity (`ghost-link probe local-node`) is 0.0 GB dedicated VRAM / 14.9 GB
+system RAM — an integrated-GPU mini PC that could not actually hold a
+meaningful share of a real 30B-class model's weights. Passing that real
+number to `--remote-vram-gb` produces a degenerate all-or-nothing
+placement (whichever side has more declared capacity absorbs the entire
+synthetic workload, leaving the other with zero assigned stages — this
+also happened during setup with the *opposite* value: `--remote-vram-gb
+32` handed all 60 layers to Desk-Mini and none to the coordinator, which
+then hard-errored). `--remote-vram-gb 16` was used here as a **declared
+test input to force a genuine two-node split**, not as a claim about
+Desk-Mini's real capability. This is the same limitation
+[DEPLOYMENT.md's Stage 3b](DEPLOYMENT.md#stage-3b-real-cross-machine-flow-execution)
+already documents: per-stage compute is a synthetic timing proxy, not real
+model math — what this benchmark actually validates is the **real
+cross-machine transport** (genuine `TcpStream::connect`, real framed
+batches, real measured round-trip latency), not real distributed LLM
+throughput.
 
 ```bash
-python scripts/remote_flow_benchmark.py --spawn-local-worker \
-  --remote-addr 127.0.0.1:19748 --runs 3 --exec-tokens 32 --micro-batch 4
+python scripts/remote_flow_benchmark.py --remote-addr <desk-mini-ip>:9500 \
+  --runs 5 --release --remote-vram-gb 16 --remote-mem-gb 14.9
 ```
 
-| Runs | Throughput (avg) | P95 | Remote bridge-write (avg) |
-|---|---|---|---|
-| 3 | 21,621 tok/s | 0.38 ms | 0.19 ms |
+(worker side, restarted fresh before each one-shot run:
+`GHOSTLINK_TCP_AUTH_TOKEN=local-token ghost-link stage-worker 0.0.0.0:9500`)
 
-Low run count and tiny `exec-tokens` (32) — this is a smoke test
-confirming the path works, not a tuned performance number; don't compare it
-against the Full-Spectrum session's in-process numbers above, which use a
-much larger token count and a different code path entirely.
+| Runs | Throughput (avg) | Throughput (min-max) | P95 (avg) | Remote bridge-write (avg) | Remote bridge-write (min-max) |
+|---|---|---|---|---|---|
+| 5 | 337.4 tok/s | 253.4-385.2 tok/s | 19.50 ms | 12.11 ms | 10.37-15.77 ms |
 
-For a real LAN run: on a second machine, run
-`GHOSTLINK_TCP_AUTH_TOKEN=<token> ghost-link stage-worker <bind-addr>`,
-then on the coordinator run the script without `--spawn-local-worker`,
-pointing `--remote-addr` at that machine. The script pauses between runs
-so you can restart the (one-shot) worker each time.
+Every run's `stage_stats` confirms 2 pipeline stages — stage 0 (local,
+compute-only, ~0.008ms, zero bridge-write) and stage 1 (Desk-Mini, zero
+compute, 10.4-15.8ms bridge-write) — meaning every run genuinely crossed
+the real network for its remote stage, not a loopback shortcut. Raw output:
+`tmp/remote_flow_benchmark/` (`summary.json` + one `remote-N.json` per run).
+
+The absolute throughput number here (`tokens/sec` of the synthetic pipeline
+harness) isn't comparable to the Full-Spectrum session's in-process numbers
+above — different code path, different hardware pair, and a much lower
+`exec_tokens`/`micro_batch` (this harness's defaults: 256/4). The real
+signal is `remote_bridge_write_ms`: a genuine ~10-16ms round-trip write
+cost to a physically separate machine over Wi-Fi, in the same range as raw
+ICMP RTT to that host.
 
 ### Notes on Multi-Node Performance
 
-- Throughput decreases slightly with more nodes due to network overhead
-- Latency increases linearly with node count
-- Network bandwidth is the primary bottleneck for multi-node setups
-
-These three notes above are inherited from the same placeholder as the
-table and are directional assumptions, not measurements — treat them as
-hypotheses to check once real multi-host numbers exist, not established
-fact.
+- The one real run above used exactly 2 nodes; scaling trends across 3+
+  nodes are still untested hypotheses, not measurements.
+- Bridge-write latency here tracks network RTT closely (10-16ms TCP vs.
+  8-14ms ICMP) — on this LAN, transport overhead is dominated by the
+  network hop itself, not Ghostlink's framing/serialization.
 
 ---
 
 ## Memory Requirements
+
+Reference values for common quantization sizes, not measured on Ghostlink
+hardware — use these for capacity planning, not as a Ghostlink-specific
+throughput/latency claim.
 
 ### Model Memory Footprint
 
@@ -261,19 +362,36 @@ fact.
 
 ## Benchmark Methodology
 
-### Test Configuration
+This section previously described a generic test configuration (a
+24-core/RTX 4090 desktop, synthetic 10K-token prompts) that no number in
+this document was actually produced on or with — it's been replaced with
+the methodology the real entries above actually use.
 
-- **Hardware**: Intel Core i9-13900K (24 cores), NVIDIA RTX 4090 (24GB VRAM)
-- **RAM**: 64GB DDR5-5600
-- **Storage**: NVMe SSD (PCIe 4.0 x4)
-- **Network**: 1 Gbps Ethernet
+### Tools
+
+- `cargo bench -p ghostlink-core --bench criterion` — primitive-level
+  microbenchmarks (ring buffer, protocol encode/decode, planning, cluster).
+- `scripts/flow_perf_snapshot.py` — full pipeline throughput/latency,
+  matched against `docs/PERF_BASELINE.json` / `PERF_BASELINE_STRESS.json`
+  for drift detection (`scripts/check_perf_drift.py`).
+- `scripts/remote_flow_benchmark.py` — real cross-process/cross-machine
+  `stage-worker` benchmark harness.
+- Full invocations and real output are in the Full-Spectrum Session
+  Benchmark above; see [TESTING.md](TESTING.md) for the broader test/bench
+  workflow this repo expects before a release.
 
 ### Test Procedure
 
-1. Load model into memory
-2. Run inference on synthetic prompts (10K tokens)
-3. Measure throughput and latency
-4. Repeat 3 times and average results
+1. Build in release mode (`cargo build --release`; workspace already sets
+   `lto = "thin"`, `codegen-units = 1`).
+2. Run the tool for the layer being measured (primitive vs. full pipeline
+   vs. cross-process), matching `exec_tokens`/`micro_batch` to whatever
+   baseline you're comparing against — mismatched parameters produce a
+   number that looks like drift but isn't (see the Full-Spectrum session's
+   own note on this).
+3. Prefer multiple interleaved runs over a single run before drawing any
+   conclusion — this repo's own dev hardware showed 5-80% run-to-run swings
+   on some benchmarks (see "Methodology note: this host is noisy" above).
 
 ### Metrics
 
@@ -300,9 +418,12 @@ fact.
 
 ### Multi-Node Optimization
 
-1. **Use fast network**: 10 Gbps recommended for multi-node
-2. **Minimize nodes**: More nodes = more network overhead
-3. **Balance load**: Distribute layers evenly across nodes
+Untested hypotheses pending the real multi-node LAN benchmark above — not
+yet backed by measurement on this project:
+
+1. Faster networks should help more nodes scale better.
+2. Fewer nodes should mean less network overhead.
+3. Balancing layers evenly across nodes should improve utilization.
 
 ---
 
@@ -325,6 +446,10 @@ fact.
 
 ## See Also
 
-- [README.md](../README.md) - Project overview and installation
-- [IMPLEMENTATION_GUIDE.md](../IMPLEMENTATION_GUIDE.md) - Code structure
-- [GHOSTLINK_FIX_PLAN.md](../GHOSTLINK_FIX_PLAN.md) - Remediation plan
+- [README.md](../README.md) - Project overview, installation, and headline
+  Performance numbers
+- [ROADMAP.md](ROADMAP.md) - Competitive strategy, including the real
+  distributed-inference work this document's Multi-Node section depends on
+- [DEPLOYMENT.md](DEPLOYMENT.md) - Cross-machine deployment, including the
+  `stage-worker` path used by `scripts/remote_flow_benchmark.py`
+- [TESTING.md](TESTING.md) - Full test/bench workflow

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,17 +2,30 @@
 
 | Platform | Best For | Strength | Weakness |
 | --- | --- | --- | --- |
-| Ghostlink | Custom distributed inference stacks | Low-latency scheduling, hardware-aware placement, self-hosted control | Early-stage ecosystem |
-| vLLM | Simple high-throughput serving | Mature ecosystem, continuous batching | Less flexible custom orchestration |
-| Ollama | Single-node local model serving | Trivial setup, large model library | No built-in cluster discovery or cross-node scheduling |
-| LM Studio | Desktop-first local chat/inference | Polished GUI, easy model management | Single-machine only, closed-source |
-| llama.cpp server | Lightweight single-binary inference | Minimal footprint, broad hardware support (CPU/GPU/NPU via backends) | No orchestration layer — Ghostlink wraps this as one of its backends |
+| **Ghostlink** | Zero-config distributed inference across heterogeneous LAN hardware | Auto-discovers mixed CPU/GPU/NPU boxes on a LAN and shards a real model across them (via llama.cpp's own RPC backend) with no manual `--rpc` flags; self-hosted, single binary | Early-stage ecosystem; no relay/WAN mode yet (LAN only) |
+| vLLM / TensorRT-LLM | Datacenter-grade single/multi-GPU serving | Mature ecosystem, continuous batching, strong NVIDIA performance | Assumes homogeneous, co-located GPUs; heavy to run standalone; no zero-config LAN clustering |
+| Ollama | Single-node local model serving | Trivial setup, large model library | No real multi-node distribution; no cluster discovery |
+| LM Studio | Desktop-first local chat/inference | Polished GUI, easy model management | Single machine only, closed-source; not API-extensible |
+| llama.cpp server | Lightweight single-binary inference | Minimal footprint, broad hardware support (CPU/GPU/NPU via backends) | No orchestration, discovery, or cluster layer — Ghostlink wraps this as one of its backends |
 | OpenWebUI | Chat UI in front of existing backends | Polished UI, plugin ecosystem | Not an inference/scheduling engine itself — pairs with a backend rather than replacing one |
-| DeepSpeed | Large-scale training and inference | Strong training integrations | More complex operational model |
+| DeepSpeed | Large-scale training and inference | Strong training integrations | More complex operational model; not built for ad-hoc LAN clusters |
 | Ray | General distributed workloads | Broad ecosystem | Heavier abstraction overhead for a pure inference use case |
-| TensorRT-LLM | NVIDIA-optimized inference | Strong performance on NVIDIA | Narrower deployment surface (NVIDIA-only) |
-| Kubernetes-based setups (KServe, Triton, etc.) | Large fleets, org-wide model serving | Battle-tested scheduling, autoscaling | High operational overhead for small teams/single-workstation use |
+| Kubernetes-based setups (KServe, Triton, etc.) | Large fleets, org-wide model serving | Battle-tested scheduling, autoscaling | Needs a cluster, ops staff, and YAML — wildly overkill for a household/small-team LAN |
 
 ## Ghostlink positioning
 
-Ghostlink is best for teams that want more control, lower-latency planning, and custom distributed workflows than generic serving platforms provide — without taking on the operational weight of a Kubernetes-based deployment. It wraps proven single-node engines (llama.cpp, Ollama) rather than competing with them, and adds hardware-aware placement and cluster discovery on top.
+Nobody else combines *zero-config discovery of heterogeneous consumer/prosumer
+hardware already sitting on a LAN* (gaming GPU + old laptop + NPU-equipped
+ultrabook + Mac) with *real distributed inference across it* — a model too
+large for any single owned machine, running at usable speed, split across
+two or more of them, discovered automatically. That's the gap: vLLM assumes
+a homogeneous co-located GPU fleet; Ollama and LM Studio don't distribute at
+all; Kubernetes-based serving solves this but needs a cluster and an ops
+team. Ghostlink wraps proven single-node engines (llama.cpp, Ollama) rather
+than competing with them, and adds hardware-aware placement, cluster
+discovery, and cross-node sharding on top — in a single self-hosted binary
+with production auth and rate limiting built in.
+
+See [ROADMAP.md](ROADMAP.md) for the full competitive strategy behind this
+positioning, and [BENCHMARKS.md](BENCHMARKS.md) for the real (and
+honestly-labeled not-yet-real) numbers behind these claims.

--- a/docs/ENTERPRISE_PLAN.md
+++ b/docs/ENTERPRISE_PLAN.md
@@ -1,0 +1,259 @@
+# Ghostlink: Path to Enterprise Readiness
+
+This is a go-to-market and commercial-trust companion to [ROADMAP.md](ROADMAP.md).
+That document answers "how does Ghostlink win the product category." This one
+answers "what makes a CISO, a platform team, or a paying customer trust
+Ghostlink enough to run it in production and pay for it." The two are linked:
+most of the credibility work below is cheap *because* Priority Zero (real
+distributed inference) already shipped — this plan would be premature if it
+hadn't.
+
+**Starting point, stated plainly**: Ghostlink today is a technically strong,
+early-stage open-source project with real distributed inference, real auth,
+and an honest (sometimes brutally honest) documentation culture. It does not
+yet have the commercial scaffolding — verified proof points, a monetization
+vehicle, or enterprise trust signals — that turns "interesting project" into
+"thing we pay for." This plan closes that gap in four tracks, sequenced by
+what blocks what.
+
+---
+
+## Track A — Fix the credibility trap before publishing anything
+
+**This has to happen first.** The user's own suggestion — "add clear
+benchmarks/comparisons in README" — runs directly into a problem already
+documented in this repo: [BENCHMARKS.md](BENCHMARKS.md) explicitly labels its
+CPU/GPU throughput tables and its multi-node LAN table as **"UNVERIFIED,
+placeholder... do not cite these tables."** The RTX 4090 numbers, the
+`orca-mini`/`mistral`/`llama2-7b` figures, and the "2/3/4 node" LAN latency
+table do not correspond to any real run in this repo.
+
+Publishing a polished README with benchmark claims sourced from those tables
+would be the single fastest way to torch enterprise credibility — a
+technical evaluator who clones the repo and reads `BENCHMARKS.md` closely
+will find the "do not cite" warning within minutes. **Do not summarize those
+numbers into the README under any framing.** The fix is to replace them, not
+launder them.
+
+1. **Run the real harnesses and replace every placeholder table.**
+   - `scripts/flow_perf_snapshot.py` and `cargo bench -p ghostlink-core
+     --bench criterion` already produce real numbers (see the "Full-Spectrum
+     Session Benchmark" section of BENCHMARKS.md — that one is genuine).
+     **Done (2026-08-03)**: a real native-Linux profile now exists too (a
+     4-core mini PC with no dedicated GPU) — see BENCHMARKS.md's second
+     Full-Spectrum session. Still open: a discrete NVIDIA/AMD GPU, Apple
+     Silicon, and a server-class CPU — every real data point so far is
+     either integrated-GPU-or-none.
+   - `scripts/remote_flow_benchmark.py` needs an actual two-machine LAN run
+     to replace the fabricated "2/3/4 nodes" table. This is explicitly
+     flagged in ROADMAP.md's Horizon 1 item #2 as well — it's the same
+     underlying gap. **Done (2026-08-03)**: a real 5-run benchmark between
+     this Windows laptop and a Linux mini PC (`Desk-Mini`) over an actual
+     home LAN is now in BENCHMARKS.md's Multi-Node Performance section —
+     genuine `TcpStream` transport, real measured `remote_bridge_write_ms`
+     (10-16ms, tracking raw ICMP RTT closely). Still open: 3+ node counts, a
+     hardware pair with real dedicated GPUs on both sides, and a real
+     (non-synthetic) model-inference version of this test — the current
+     harness's per-stage compute is a timing proxy, not real tensor math
+     (see BENCHMARKS.md's caveat on this run for why, including a capacity-
+     modeling quirk that had to be worked around to get a genuine 2-node
+     split at all).
+   - Until further multi-node LAN numbers exist beyond this single 2-node
+     case, the README and any marketing material should keep scope claims
+     matched to what's actually measured — don't extrapolate to "scales to
+     N nodes" from one real 2-node run.
+2. **Add a compact, skimmable benchmark table to the README itself**, not just
+   a link to BENCHMARKS.md — enterprise evaluators and README skimmers won't
+   click through. Format: hardware spec, model, tokens/sec, and a one-line
+   "as of <date>, reproduce with `<command>`" so every number is falsifiable
+   by the reader. This is a trust signal in itself — showing the reproduction
+   command is more convincing to a technical buyer than the number.
+3. **Tighten [COMPARISON.md](COMPARISON.md) into something a buyer skims in
+   30 seconds.** The current table is good and honest (it already links from
+   the README TOC) — the main gap is that it undersells Ghostlink's actual
+   differentiators from ROADMAP.md (zero-config heterogeneous LAN clustering,
+   real cross-node sharding via llama.cpp's RPC backend) in favor of generic
+   "self-hosted control" language. Sharpen the "Ghostlink" row once the H1
+   benchmark lands, and delete `docs/archive/comparison_sheet.md` duplication
+   or clearly mark one as canonical — having two comparison docs (one in
+   `docs/`, one in `docs/archive/`) linked from the README is confusing for a
+   buyer trying to find the authoritative one.
+4. **Audit every other doc for the same pattern** before anything ships
+   externally — `docs/PERF_BASELINE.json`/`PERF_BASELINE_STRESS.json`, any
+   throughput CSVs in the repo root (`throughput_results_*.csv`), and
+   `GHOSTLINK_FIX_PLAN.md` referenced at the bottom of BENCHMARKS.md. If any
+   of those are also placeholders, they need the same "unverified" labeling
+   or removal before an enterprise audience sees them.
+
+**Why this is Track A and not an afterthought**: enterprise buyers
+(unlike hobbyists) route RFPs through security/technical review. A single
+discovered fabricated number in due diligence doesn't just kill that number
+— it makes the reviewer re-verify everything else you've claimed, including
+things that were true. Fix the placeholders before doing any of the polish
+work in Track C.
+
+---
+
+## Track B — Enterprise trust signals (the actual "enterprise" in enterprise-level)
+
+README polish and a demo video get you discovered. They don't get a platform
+team to approve a production deployment. That requires closing gaps
+ROADMAP.md and SECURITY_MODEL.md already name honestly:
+
+1. **`GET /api/security/audit-log` is a stub that always returns empty**
+   (SECURITY_MODEL.md, ROADMAP.md Horizon 2 #5). This is one of the first
+   things a security reviewer checks for a self-hosted system handling
+   inference requests. Wiring it to actually record auth failures, admin
+   actions, and config changes is cheap relative to its trust payoff —
+   prioritize it ahead of most Horizon 2 items.
+2. **RBAC / scoped multi-user API keys** — today's model is effectively
+   single-operator (one API key or JWT per instance). Any team deployment
+   needs per-user scoped keys before it's a credible "team" or "enterprise"
+   story, not just a home-lab one.
+3. **mTLS for fabric/node-to-node transport** (SECURITY_MODEL.md Roadmap
+   Notes) — the API server already has real PQC-hybrid TLS; the gap is
+   inter-node. Close it before claiming "production-grade" anywhere in
+   marketing copy, since the current honest caveat ("trust-the-LAN posture")
+   is a real objection an enterprise security reviewer will raise.
+4. **`ggml-rpc-server` has no built-in authentication** (ROADMAP.md Risks) —
+   this is an upstream llama.cpp limitation, but it needs an explicit
+   allowlist or auth shim before "enable distributed inference" is pitched to
+   anyone running on a network that isn't fully trusted. This is a real,
+   currently-open security gap, not a documentation gap — flag it to
+   whoever owns security review before it's in a sales conversation.
+5. **A published, even lightweight, security posture page** — SECURITY_MODEL.md
+   is good internal material; an enterprise-facing summary (what's encrypted,
+   what's authenticated, what a pen tester would need to know, a
+   responsible-disclosure contact) belongs at a stable URL a procurement
+   team can link in their own review, distinct from the developer-facing doc.
+6. **A SECURITY.md with a disclosure policy and contact** at the repo root —
+   check if one exists; if not, this is table stakes for any project
+   accepting external security reports, and its absence is itself a red flag
+   in enterprise procurement checklists.
+
+None of this needs to be "SOC 2 certified" — that's a later, much larger
+investment only worth making once there's paying enterprise demand asking
+for it specifically. The items above are the floor for "a security-literate
+team would consider this," not full compliance.
+
+---
+
+## Track C — Marketing polish (do this after Track A, not before)
+
+The user's suggestions here are right; sequencing matters:
+
+1. **Screenshots**: capture the GUI (chat, the Monaco editor with
+   Explain/Fix/Refactor diff preview, the cluster/node dashboard) at a
+   realistic window size, light and dark mode. Put 3-4 in the README above
+   the fold, not just the existing walkthrough GIF.
+2. **Demo video on YouTube**: the repo already has a `demo/` folder
+   (gitignored, with a full-length recording with audio per the README's own
+   note) and a public walkthrough GIF. Turn the existing full recording into
+   a 2-3 minute YouTube video: problem statement (heterogeneous LAN hardware
+   sitting idle) → the actual differentiator (zero-config cluster forms,
+   model too big for one box runs anyway) → CTA. Link it from the README's
+   Demo section alongside the GIF, and from COMPARISON.md.
+3. **Sharpen the positioning copy in the README's "Why Ghostlink" section**
+   to lead with the wedge ROADMAP.md already identified precisely —
+   "point Ghostlink at every machine on your LAN and it becomes one inference
+   cluster in under 5 minutes, zero YAML" — rather than the current generic
+   "lower-latency planning, more control" phrasing. The sharper claim is more
+   memorable and more falsifiable, which cuts both ways: only ship it once
+   Track A's benchmark backs it up.
+4. **A one-line install script** (ROADMAP.md Horizon 1 #5) is as much a
+   marketing asset as a UX one — "`curl | sh` in one line" is a screenshot-
+   able moment in its own right and directly comparable to Ollama's install
+   flow, which is the single most-cited UX benchmark in this space.
+
+---
+
+## Track D — Monetization: GitHub Sponsors + a paid tier
+
+The license is currently plain **MIT** (see [LICENSE](../LICENSE)) — fully
+permissive, no copyleft, no field-of-use restriction. This has a direct
+consequence for a "paid tier" plan: anything shipped as MIT-licensed code in
+this repo can be freely re-hosted, re-sold, or forked by a competitor,
+including any "enterprise" feature you add to the open repo. That's fine for
+GitHub Sponsors (pure goodwill/funding, no product gating), but it means a
+paid *tier* needs a deliberate boundary, not just a README announcement.
+
+1. **GitHub Sponsors — low-risk, do this first.**
+   - Add `.github/FUNDING.yml` (currently absent) pointing at a GitHub
+     Sponsors profile.
+   - Tiers should map to something concrete: named/logo placement in the
+     README for org sponsors, priority issue triage, a private Discord/office
+     hours slot for individual sponsors. Avoid promising anything that
+     implies a support SLA at this stage — that's Track D.3 below.
+   - This requires no code changes and no licensing decision — ship it
+     alongside the README polish.
+2. **Decide the paid-tier shape before announcing it.** Three real options,
+   not mutually exclusive:
+   - **(a) Hosted control plane** — ROADMAP.md's own Horizon 3 idea #4: a
+     thin, optional SaaS layer for fleet management/updates/telemetry across
+     many self-hosted Ghostlink clusters. This is the cleanest model given
+     MIT: the core stays fully open and self-hostable, the paid product is a
+     service you run, not code you withhold. Lowest legal complexity, but the
+     furthest out on the roadmap (Horizon 3, 9-18 months) — don't announce a
+     date before Horizon 2 lands.
+   - **(b) Commercial support/SLA contracts** on the existing open-source
+     core — fastest to stand up (no new product needed), matches the
+     README's existing "commercial support path" language and Project
+     Status section. This is the realistic near-term paid tier: a support
+     contract, not a feature gate.
+   - **(c) Open-core with a separately-licensed enterprise module** (SSO/SAML,
+     RBAC UI, audit-log export, air-gapped deployment tooling) — viable, but
+     requires either a CLA + relicensing plan for new enterprise-only code
+     (kept out of the MIT tree entirely, in a private repo) or a dual-license
+     model. This needs a real decision, ideally with legal input, before any
+     code is written for it — retrofitting a license boundary onto code
+     that's already MIT and public is much harder than starting clean.
+   - **Recommendation**: announce (b) now — it's compatible with today's
+     code, today's license, and today's README claims — and treat (a) as the
+     medium-term paid product once Horizon 2's RBAC/audit-log/mTLS work
+     (Track B above) makes "enterprise support" a credible thing to sell.
+     Defer (c) until there's a specific enterprise customer asking for a
+     feature the open core structurally shouldn't have.
+3. **Don't announce a paid tier before Track B's trust gaps close.** Selling
+   "enterprise support" while `audit-log` is a stub that always returns
+   empty is a credibility risk the moment a paying customer's security team
+   asks for it. Track B and Track D.2(b) should land together, not D first.
+
+---
+
+## Sequencing
+
+| Phase | Contents | Blocks |
+| --- | --- | --- |
+| **1 (now)** | Track A: replace placeholder benchmarks, fix comparison-doc duplication — **done 2026-08-03** | Everything downstream — do not skip |
+| **2 (2-4 weeks)** | Track C marketing polish (screenshots, YouTube demo, sharpened positioning) + GitHub Sponsors (Track D.1) | Needs Phase 1's real numbers to be honest |
+| **3 (parallel with Horizon 1/2 of ROADMAP.md)** | Track B trust signals (audit log, RBAC, mTLS, SECURITY.md) | Needed before Track D.2(b) announcement |
+| **4** | Announce commercial support tier (Track D.2 option b) | Needs Phase 3 substantially done |
+| **5 (Horizon 3 timeframe)** | Hosted control plane as the scalable paid product (Track D.2 option a) | Needs Horizon 2 of ROADMAP.md |
+
+## How we'll know it's working
+
+- Zero unverified/placeholder numbers anywhere a prospect can read them
+  (README, COMPARISON.md, marketing site) — this is a binary pass/fail, not
+  a metric to trend.
+- ~~A real two-machine LAN benchmark exists and is cited by hash/date/command,
+  replacing every "unverified placeholder" table in BENCHMARKS.md.~~ **Done
+  2026-08-03** — one real 2-node run exists; expand to 3+ nodes and a
+  dedicated-GPU pair next.
+- `/api/security/audit-log` returns real events, not an empty stub.
+- At least one paying support relationship or GitHub Sponsors tier live,
+  tied to a concrete deliverable (not just "thanks for the money").
+
+## Risks
+
+- **Shipping benchmark or marketing claims ahead of Track A** is the single
+  biggest self-inflicted risk here — the placeholder tables already exist in
+  the repo with "do not cite" warnings attached; the risk is a future editing
+  pass losing that context and copying them into the README anyway.
+- **Announcing a paid tier before deciding the licensing model (Track D.2)**
+  risks giving away the exact feature set a competitor needs to fork and
+  compete on, or backing into a legal cleanup later. Decide the shape before
+  the announcement, not after.
+- **MIT + open-core tension**: any enterprise-only feature written directly
+  into the current MIT tree is fork-able by definition. If option (c) is
+  ever pursued, that code needs to start in a separate, differently-licensed
+  repo from day one — not be extracted from the open repo after the fact.

--- a/launch-native.ps1
+++ b/launch-native.ps1
@@ -280,6 +280,16 @@ Write-Ok "API ready (PID $($apiProc.Id))"
 Write-Step "Starting control-plane (port $ControlPlanePort)"
 $env:PORT = $ControlPlanePort
 $env:GHOSTLINK_BACKEND_URL = "${ApiScheme}://${ApiHost}:${ApiPort}"
+# control-plane's WorkingDirectory below is $ControlPlaneDir, but
+# auth.LoadAPIKey() defaults to reading "api_key.txt" relative to cwd —
+# and ghost-link (started above with -WorkingDirectory $RootDir) writes
+# that file to $RootDir, not $ControlPlaneDir. Without this, control-plane
+# silently never finds the key, which doesn't just skip its own edge auth
+# check (tolerable — ghost-link's own auth still applies end to end) but
+# also means requests that should be rejected for free by that edge check
+# fall through and consume rate-limit budget instead, so ordinary polling
+# load can trip the rate limiter far sooner than it's supposed to.
+$env:GHOSTLINK_API_KEY_PATH = Join-Path $RootDir "api_key.txt"
 
 $cpLog = Join-Path $LogDir "control_plane.log"
 $cpProc = Start-Process -FilePath $ControlPlaneBin `

--- a/third_party/mohawk_gui/constraints.txt
+++ b/third_party/mohawk_gui/constraints.txt
@@ -3,7 +3,7 @@ PyQt6==6.11.0
 bandit==1.9.4
 black==24.8.0
 certifi==2026.7.22
-cryptography==49.0.0
+cryptography==50.0.0
 fastapi==0.141.1
 flake8==7.3.0
 mypy==2.3.0


### PR DESCRIPTION
## Summary

Four related pieces of work on this branch:

1. **Restores eight features silently lost to a bad merge conflict resolution** (`ea8d56c`).
2. **Replaces fabricated benchmark data with real measurements** and adds an enterprise-readiness companion doc to `ROADMAP.md` — surfaced while auditing the repo for the same "looks real, isn't" pattern that motivated part 1.
3. **Restores two more features from the same root cause**, found while investigating dead-code fallout from part 1: real byte-level HuggingFace download progress tracking, and session persistence (including a live-session-bookkeeping bug fix that survived even after the field existed).
4. **Fixes two stacked rate-limiter misconfigurations** that made ordinary GUI usage (not abuse) trip 429s — found while manually driving the app end to end to capture real screenshots for a social preview image.

---

## Part 1: Restoring what `ea8d56c` silently dropped

Commit `ea8d56c` ("Merge origin/main and resolve PR conflicts", 2026-08-02) resolved several merge conflicts in `crates/ghost-link/src/main.rs` by picking one parent's side wholesale instead of combining both — silently reverting **six already-shipped features** back to their old stub/broken state while their source files stayed on disk untouched. This made it look like everything was fine unless you specifically checked whether the code was actually *wired in* (`mod` declarations, route registrations, struct fields).

### What was actually broken on `main`

1. **Zero authentication enforced on any API route.** `auth.rs` (real bearer-token auth) and `tls.rs` (PQC-hybrid TLS) existed on disk, fully documented in `SECURITY_MODEL.md` and the README as live — but neither was declared as a module, so neither compiled into the binary. The `auth_middleware` function and its `.layer()` application were gone entirely.
2. **`/v1/completions`, `/v1/embeddings`, and custom backend plugin dispatch all 404ed.** Real mDNS/UDP worker discovery (`/api/workers/discover`) had reverted to a hardcoded `{"count": 2}` stub.
3. **Real distributed inference via llama.cpp's own RPC backend was gone**, including the fix for a node-ID collision bug (`detect_node_id()`) that this repo's own `ROADMAP.md` describes as critical — every `ghost-link serve` instance was back to hardcoding its cluster node id to `"studio-api"`, meaning two real installs would silently collide and RPC peer discovery would exclude every peer.
4. **`/api/security/audit-log` was a hardcoded empty stub**, and the entire Editor tab backend (`/api/workspace/tree`, `/api/workspace/file` GET+PUT, `/api/workspace/index`) was missing despite the frontend (`EditorTab.tsx`, `api.ts`) already calling it and the README documenting it as a live, shipped feature.
5. **HuggingFace model downloads had reverted to always grabbing `gguf_files[0]`** — whatever quantization the repo happened to list first, regardless of this machine's VRAM, and only the first shard of a multi-file split model.
6. **`parallel_slots` (concurrent inference request slots / llama-server `-np`) was unreachable** from the settings API; `RequestTracker::resize_slots`/`queue_depth` were dead code.

### How each was restored

Each feature was restored via `git cherry-pick --no-commit <original-commit>` against current `main`, then conflicts were resolved by hand — **not** by blindly taking the incoming side. In several cases the incoming (old) side was itself superseded by later refactors (e.g. the `InferenceBackend` → `InferenceEngine` rename, the `dde3638` "real tool calling" rewrite of `handle_tool_confirm`), so keeping current `main`'s logic and only grafting in the genuinely-missing piece was the correct resolution — see individual commit messages for the specific reasoning in each case.

One deliberate exception: commit `d46dddf` bundled two features (the `parallel_slots` setting *and* a separate KV-cache slot-pinning "multi-turn context reuse" mechanism built around a `gen` bundling struct). Only `parallel_slots` was restored — the slot-pinning mechanism's struct doesn't exist anywhere in current `main`, and the functions built around it are pre-refactor code already superseded by the currently-routed, already-tested `handle_tool_confirm`. Restoring that block would have silently reverted working code rather than fixed anything, so it was discarded.

Commits, in order:

- `f6bf7b2` — real bearer-token auth + PQC-hybrid TLS
- `f5c8a6e` — custom backend plugin dispatch, `/v1/completions`, `/v1/embeddings`
- `84497c0` — real distributed inference via llama.cpp RPC backend (+ node-ID collision fix)
- `7bf7f5e` — real audit log + Editor tab workspace API
- `596bdce` — hardware-aware HuggingFace download quantization picking
- `73a4251` — `parallel_slots` concurrent-request-slots setting
- `055c64f` — `#[allow(dead_code)]` on two fields belonging to a *separate*, still-independently-lost feature (see below), needed to keep `clippy -D warnings` green

### Validation

Full pre-push checklist from `CONTRIBUTING.md`, run against the final code state:

```
cargo fmt --all --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings      # clean
cargo test --workspace                                     # 356 passed, 0 failed
cargo audit                                                 # 0 vulnerabilities (3 pre-existing unmaintained/unsound advisory warnings on transitive deps, unrelated to this change)
```

Each individual restoration commit also has its own `cargo build --release -p ghost-link` / `cargo test --release -p ghost-link` (and `-p ghostlink-core` / `-p mcp-rag` where relevant) run recorded in its commit message, including the specific new tests that now pass (`auth::tests::*`, `tls::tests::*`, `backend_plugin::tests::*`, `rpc_cluster::tests::*` — all 8, `tests::detect_node_id_prefers_explicit_env_override`, both `push_audit_entry` tests, all 4 `quant_rank`/`group_gguf_shards`/`select_best_gguf_group`/`target_quant_rank` tests, and `RequestTracker`'s `resize_slots`/`queue_depth` tests) and the real cross-process `stage_worker_integration::flow_remote_addr_executes_across_real_processes` test throughout.

### Risk

This is a wide, cross-cutting diff (touches auth, the OpenAI-compatible API surface, distributed inference, the audit log, the Editor tab backend, model downloads, and request admission control) because the root cause — one bad merge — touched all of them at once. Each commit is scoped to exactly one of the six originally-lost features and independently buildable/testable; if any one turns out to need a revert, `git revert` on that specific commit should be clean without touching the others, since they don't share code paths beyond `main.rs`'s router registration list.

### Known follow-up (not in this PR)

`BackendState.download_progress` was `#[allow(dead_code)]`'d in commit `055c64f` just to keep CI green — **now resolved in Part 3 below**. `model_lifecycle_lock` (a concurrent-model-load-safety feature, same struct, different independently-lost commit) is still `#[allow(dead_code)]`'d; nothing currently calls `.lock()` on it despite its own doc comment describing exactly what it's meant to serialize. Not touched in this PR.

---

## Part 2: Real benchmarks + enterprise-readiness plan

`docs/BENCHMARKS.md` carried fabricated placeholder tables (CPU/GPU throughput, multi-node LAN latency) explicitly labeled **"do not cite"** but still sitting in the doc where a technical evaluator could find and quote them out of context. Commit `2c1bd58`:

- Removes the fabricated tables entirely.
- Adds a **real Linux hardware profile** (4-core Alder Lake-N mini PC, no dedicated GPU) — the first non-Windows entry in this doc, including an honest note that stopping the app's own background servers didn't clearly reduce measurement noise on this host (5 runs is too few given how variable this class of hardware is).
- Adds a **real two-machine LAN benchmark** (a Windows laptop + the Linux mini PC above, over an actual home network) replacing the fabricated 2/3/4-node table — genuine `remote_bridge_write_ms` measurements that track raw ICMP RTT closely, plus a documented capacity-modeling quirk in `print_flow` that had to be worked around to get a real 2-node split at all.
- Fixes methodology/"See Also" sections that described hardware and tools no real run in this doc ever actually used.
- Fixes two broken links in `README.md` and adds a GitHub Sponsors badge wired to the new `.github/FUNDING.yml`.
- Sharpens `README.md`'s "Why Ghostlink" and `docs/COMPARISON.md` to lead with the actual differentiator (zero-config heterogeneous-LAN clustering), matching `ROADMAP.md`'s own wedge language — now backed by the real benchmark above instead of prose alone.
- Adds `docs/ENTERPRISE_PLAN.md`, a new companion strategy doc to `ROADMAP.md` covering the business/GTM side: credibility-first benchmark publishing, enterprise trust signals (audit log, RBAC, mTLS), marketing sequencing, and a monetization plan scoped to the current MIT license.

`npx markdownlint-cli` passes clean on all touched Markdown files.

---

## Part 3: Two more restorations from the same root cause

While cleaning up `#[allow(dead_code)]`'d fields from Part 1, both turned out to be genuinely restorable rather than permanent follow-up items.

### `download_progress` — real byte-level HF download progress (`0548812`)

Not just a missing feature — a real bug: `download_hf_model` previously ended its chunk-read loop without returning an `Err` on a dropped connection, silently writing a truncated file that any later download attempt saw as "already exists" and never retried. This capped downloads at ~1.52GB (client timeout window × ordinary broadband speed). `handle_gui_model_download` now spawns the transfer as a detached background task and responds immediately instead of blocking the HTTP response for a multi-GB transfer — which is what let the frontend's 120s axios timeout abort the connection mid-stream in the first place.

Most of this commit's own diff (the background task, the live progress-tracking closure, and the frontend's Zustand-store-lifted state) had already auto-merged cleanly or been independently restored by this point — only the struct field itself and two genuine **merge-introduced duplication bugs** in `ModelsTab.tsx` needed fixing: a doubled `formatBytes`/`progressLabel` pair, and a fully duplicated, unreachable "Recommended for Your Hardware" ternary branch (checked `activeTab === 'recommended'` twice in the same chain — the second branch could never execute).

### Session persistence + live-session bookkeeping (`a4b3fa2`)

`load_persistent_sessions()`/`save_persistent_sessions()`/`sessions_path()` (mirroring the existing `models.json` pattern) had already auto-merged in and were fully functional for the manual save/load endpoints. The real remaining bug: the **live** session bookkeeping (updated after every chat completion, distinct from manual save/load) still matched sessions via `backend.sessions.first_mut()` — literally whichever session happened to be first, so a saved chat session landing at index 0 would have its tokens/model/status silently overwritten by unrelated live-inference activity — and never populated `messages` or called `save_persistent_sessions`, so the live conversation never actually reached `sessions.json` even after the field existed.

`a4b3fa2`'s own fix extracted this into a `record_generation_metrics` function shared with a `handle_gui_chat_stream` sibling — that shape doesn't fit current `main` (the later `dde3638` "real tool calling" rewrite restructured `handle_gui_chat` around a different architecture, and `handle_gui_chat_stream` was already correctly discarded as stale in this branch's own `73a4251` commit). Applied the same *fix* — id-based matching, real message persistence, immediate save — directly to the current call site instead of reintroducing dead code, consistent with this branch's approach throughout.

Commits:

- `04a5a6a` — real byte-level HF download progress tracking
- `7d3a0ba` — session persistence + live-session bookkeeping fix

### Validation (updated)

```
cargo fmt --all --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings      # clean
cargo test --workspace                                     # 356 passed, 0 failed
npx tsc --noEmit                                            # clean
npx vitest run                                               # 14 test files, 140 passed, 0 failed
```

---

## Part 4: Two stacked rate limiters, both misconfigured for this proxied setup

Found while manually driving the app in a browser to capture real UI screenshots (unrelated errand) — ordinary use (a couple of tabs open, normal polling, a page reload or two) reliably tripped 429s within seconds. Two independent, compounding causes, both rooted in the same architectural fact: the GUI never talks to `ghost-link` directly, it always goes through `control-plane`, so every request from every tab/user arrives at whatever's behind control-plane already collapsed onto *control-plane's own* source address.

**1. `control-plane`'s edge auth check was silently disabled.** `auth.LoadAPIKey()` reads `api_key.txt` relative to the process's working directory. `launch-native.ps1` starts `control-plane.exe` with `-WorkingDirectory` pointed at the `control-plane/` subfolder — but `ghost-link` (which actually generates and writes that file) runs with the repo root as its working directory. So `control-plane` could never find the key, `apiKey` came back empty, and `auth.Middleware` degrades to `return next` unconditionally by design for that case (documented in its own comment as an intentional fallback for "key file wasn't readable"). The unintended side effect: with edge auth disabled, requests that should be rejected for free (missing/bad bearer token) instead fall through to the *rate limiter* and consume its budget — so every 401 a not-yet-authenticated GUI session generated was quietly burning through the same quota real traffic needed. Fixed by pointing `GHOSTLINK_API_KEY_PATH` at the real file location. `docker-compose.yml` had the identical root cause for a different reason — `control-plane` and `ghostlink-api` are separate containers with no shared filesystem at all — fixed there with a shared named volume instead.

**2. `ghost-link`'s own `tower_governor` limiter was sized for the wrong shape of traffic.** `per_second(2)` / `burst_size(30)`, applied as the outermost layer before CORS/auth even run. That's a reasonable per-*client* limit — but per above, every client in this deployment looks like the same one client (control-plane) to this middleware. A single page mount fires ~8 concurrent requests (settings, models, sessions, metrics, workers, backends, mcp servers); two browser tabs' worth of that, or a couple of quick reloads, permanently exhausted the 30-token bucket (15s to refill at 2/s) and made ordinary GUI usage indistinguishable from a runaway client. Raised to `per_second(20)` / `burst_size(60)` — sized to comfortably absorb a few tabs' simultaneous mount bursts plus steady polling, while still catching an actually-pathological tight retry loop.

Commit: `3d1839f`

### Validation

- 50 rapid unauthenticated requests each rejected for free (`401`) without consuming rate-limit budget, confirmed by an authenticated request immediately after succeeding (`200`) rather than inheriting `429`.
- Two consecutive full page-mount bursts (14 concurrent authenticated requests, simulating two tabs reloading back to back) — all `200`, zero `429`.
- A real chat completion round-trips end to end post-fix (`real_inference: true`, genuine model output, ~39 tok/s on the local test model).
- `cargo fmt --all --check`, `cargo clippy -p ghost-link --all-targets -- -D warnings`, `cargo test --release -p ghost-link` (137 passed + 1 integration test) all clean on the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
