### PR TITLE
fix(rate-limit): correct inverted tower_governor per_second() semantics

### DIFF
--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -8144,14 +8144,25 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         // servers), and steady-state polling (metrics+sessions every 3s,
         // workers every 15s) adds ~0.7 req/s per open tab on top of that —
         // two tabs, or a couple of reloads in quick succession, was enough
-        // to permanently exhaust the 30-token bucket (15s to refill at
-        // 2/s) and made ordinary GUI usage indistinguishable from a
-        // runaway client. Sized here to comfortably absorb a few tabs'
-        // worth of simultaneous mount bursts plus their steady polling,
-        // while still catching an actually-pathological tight retry loop.
+        // to permanently exhaust the 30-token bucket and made ordinary GUI
+        // usage indistinguishable from a runaway client.
+        //
+        // NOTE: `per_second(N)` is *not* "N requests per second" — despite
+        // the name, it sets the replenishment *interval* ("one element of
+        // the quota is replenished every N seconds", per tower_governor's
+        // own docs), so a bigger N means a *slower* refill. A prior fix
+        // here set `.per_second(20)`, intending ~20 req/s of sustained
+        // throughput, and instead configured 1 token per 20 seconds —
+        // 10x slower than the original `.per_second(2)` it was replacing.
+        // `.per_millisecond(N)` is the method that actually takes a rate
+        // in the usual sense once inverted: `per_millisecond(50)` = one
+        // token every 50ms = 20 tokens/sec sustained, comfortably above
+        // a few tabs' worth of steady polling while still catching an
+        // actually-pathological tight retry loop. `burst_size` is
+        // unaffected by this mixup — it's already a plain token count.
         let governor_conf = std::sync::Arc::new(
             tower_governor::governor::GovernorConfigBuilder::default()
-                .per_second(20)
+                .per_millisecond(50)
                 .burst_size(60)
                 .finish()
                 .expect("static governor config is always valid"),


### PR DESCRIPTION
## Summary

Follow-up to #225's rate-limit fix, which turned out to be itself broken — reported by the user as persistent 429s (including on ordinary Settings-tab loads) even after that PR merged.

`per_second(N)` on `tower_governor::GovernorConfigBuilder` is **not** "N requests per second." Per the crate's own docs, it "sets the interval after which one element of the quota is replenished in seconds" — i.e. one token every N seconds. #225 changed `.per_second(2)` to `.per_second(20)`, intending to raise sustained throughput to ~20 req/s; it actually configured a refill rate of **one token per 20 seconds (0.05/s)** — ten times *slower* than the `per_second(2)` (0.5/s) it replaced.

The larger `burst_size(60)` masked this in #225's own verification: a single concurrent burst under 60 requests always passes regardless of refill rate, so that test never exercised sustained load hitting an empty bucket. Only real, ongoing GUI polling (the actual complaint) exposed it.

## Fix

`.per_millisecond(50)` — one token every 50ms, i.e. 20 tokens/sec sustained, which is what `.per_second(20)` was always meant to express. `burst_size(60)` is untouched (it's already a plain token count, unaffected by the per_second/per_millisecond mixup).

## Validation

- `cargo fmt --all --check`, `cargo clippy -p ghost-link --all-targets -- -D warnings` — clean.
- Real sustained-load test this time (not just a burst): a Playwright-driven browser session hit the live GUI for a continuous 30 seconds. **34/34 requests returned 200, zero 429s.** Same test against the pre-fix binary showed 22/23 requests failing with 429 from a single fresh page load.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>