### PR TITLE
fix(gui): resolve Monaco worker build error and chat proxy timeout

### DIFF
--- a/ghostlink_gui_modern/vite.config.ts
+++ b/ghostlink_gui_modern/vite.config.ts
@@ -12,6 +12,21 @@ export default defineConfig({
   // to — Ghostlink is local-first everywhere else, so the Editor tab's code
   // editor shouldn't be the one piece that silently needs internet access.
   plugins: [react(), monacoEditorEsmPlugin()],
+  resolve: {
+    alias: [
+      // vite-plugin-monaco-editor-esm hardcodes worker entry points as
+      // e.g. "monaco-editor/esm/vs/editor/editor.worker" (last updated
+      // against monaco-editor ^0.52, which had no package.json "exports"
+      // map, so that full path resolved directly off disk). monaco-editor
+      // 0.56 added an exports map — "./*": "./esm/vs/*.js" — meant for
+      // *shorter* subpaths like "monaco-editor/editor/editor.worker"; fed
+      // the plugin's already-full path, it double-prefixes to
+      // esm/vs/esm/vs/... and esbuild fails with "Could not resolve".
+      // Strip the redundant esm/vs/ before it hits package resolution so
+      // the exports map re-adds exactly one copy.
+      { find: /^monaco-editor\/esm\/vs\/(.*)$/, replacement: 'monaco-editor/$1' },
+    ],
+  },
   server: {
     port: 5173,
     proxy: {
@@ -21,7 +36,12 @@ export default defineConfig({
         rewrite: (path) => path,
         configure: (proxy) => {
           proxy.on('proxyReq', (proxyReq) => {
-            proxyReq.setTimeout(120000);
+            // Matches api.ts's toolCallTimeout (see the comment there) -
+            // a slow/large local model plus multi-round tool-calling can
+            // legitimately run past 120s, and this proxy leg was cutting
+            // the connection out from under a client that was still
+            // willing to wait.
+            proxyReq.setTimeout(300000);
           });
         },
       },
@@ -39,7 +59,7 @@ export default defineConfig({
         changeOrigin: true,
         configure: (proxy) => {
           proxy.on('proxyReq', (proxyReq) => {
-            proxyReq.setTimeout(120000);
+            proxyReq.setTimeout(300000);
           });
         },
       }


### PR DESCRIPTION
## Summary

Two dev-server issues found while actually driving the app end to end: the Editor tab and long chat generations.

### 1. Editor tab build error
```
Build failed with 1 error:
error: Could not resolve "monaco-editor/esm/vs/editor/editor.worker"
```
`vite-plugin-monaco-editor-esm@2.0.2` (its own devDependency/test target is `monaco-editor@^0.52.2`, which had no `package.json` `"exports"` map) hardcodes worker entry points as full `esm/vs/`-prefixed paths, e.g. `monaco-editor/esm/vs/editor/editor.worker`. `monaco-editor@0.56.0` added an exports map — `"./*": "./esm/vs/*.js"` — meant for *shorter* subpaths like `monaco-editor/editor/editor.worker`. Fed the plugin's already-full path, it double-prefixes to `esm/vs/esm/vs/...`, which doesn't exist on disk, and esbuild fails to resolve it.

Fixed with a `resolve.alias` regex that strips the redundant `esm/vs/` before Vite/esbuild applies the package's exports map, so it resolves to the correct single-prefixed path. No patching of `node_modules`, no downgrading `monaco-editor`.

### 2. Chat requests timing out around 2 minutes
On slower/larger models (reported live with Qwen3.5-9B on a 4GB-VRAM iGPU), chat requests failed with no error and no UI update around the 2-minute mark. `api.ts`'s `toolCallTimeout` already budgets 300s client-side for exactly this (see its own comment — this bit before, for tool-calling turns). But the Vite dev-server proxy's own `proxyReq.setTimeout(120000)` on `/api` and `/v1` was still cutting the underlying connection at 120s regardless — the client was willing to wait, the proxy wasn't. Raised both to `300000` to match.

## Validation
- `npx tsc --noEmit` — clean.
- Editor tab manually verified: opened `README.md`, real Monaco content with line numbers rendered, zero console errors, no build-error overlay (previously blocked the whole tab).
- Chat timeout: confirmed the actual bottleneck is real (GPU compute engine observed at ~29% utilization during generation via `Get-Counter '\GPU Engine(*)\Utilization Percentage'`, not a silent CPU fallback) — this fix removes the *artificial* 120s cutoff so genuinely-slow-but-working generations complete instead of being killed mid-flight.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>