### PR TITLE
fix(chat): restore multi-turn conversation memory for the Native engine

### DIFF
--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1996,6 +1996,11 @@ async fn native_tool_loop_core(
     top_p: f32,
     top_k: usize,
     penalty: f32,
+    // Prior conversation turns (role, content), oldest first, from *before*
+    // this tool-calling exchange started. Constant across every iteration of
+    // this loop - the scratchpad below carries the exchange's own
+    // in-progress tool-call/observation turns, which are a separate thing.
+    history: &[(String, String)],
     mut scratchpad: String,
     mut tool_results: Vec<ToolResult>,
     mut iterations_left: usize,
@@ -2014,6 +2019,7 @@ async fn native_tool_loop_core(
                 top_k,
                 penalty,
                 native_engine,
+                history,
                 None,
                 false,
                 None,
@@ -2058,6 +2064,7 @@ async fn native_tool_loop_core(
                     native_engine: native_engine.to_string(),
                     tool_instructions: tool_instructions.to_string(),
                     user_message: user_message.to_string(),
+                    history: history.to_vec(),
                     scratchpad,
                     tools: tools.to_vec(),
                     exec_tokens,
@@ -2121,6 +2128,7 @@ async fn run_native_tool_loop(
     penalty: f32,
     native_engine: &str,
     tools: &[mcp::McpToolSchema],
+    history: &[(String, String)],
 ) -> NativeLoopStep {
     let tool_instructions = mcp::toolcall::build_tool_instructions(tools);
     native_tool_loop_core(
@@ -2136,6 +2144,7 @@ async fn run_native_tool_loop(
         top_p,
         top_k,
         penalty,
+        history,
         String::new(),
         Vec::new(),
         mcp::toolcall::MAX_TOOL_ITERATIONS,
@@ -2159,6 +2168,7 @@ async fn resume_native_tool_loop(
         native_engine,
         tool_instructions,
         user_message,
+        history,
         mut scratchpad,
         tools,
         exec_tokens,
@@ -2235,6 +2245,7 @@ async fn resume_native_tool_loop(
         top_p,
         top_k,
         penalty,
+        &history,
         scratchpad,
         tool_results_so_far,
         iterations_left,
@@ -3071,9 +3082,24 @@ struct ChatCompletionRequest {
     #[allow(dead_code)]
     max_tokens: Option<usize>,
 }
+/// One turn of conversation history, as sent by api.ts's `sendMessage`
+/// `messages` field: "Full transcript (oldest first, including the latest
+/// turn) so the model has memory of the conversation instead of seeing
+/// `message` alone." That last-turn duplication with `GuiChatRequest.message`
+/// is intentional on the client side (older callers only send `message`) -
+/// `handle_gui_chat` drops the final entry here before using the rest as
+/// prior-turn context, since `message` already covers it.
+#[derive(Debug, Deserialize, Clone)]
+struct ChatHistoryTurn {
+    role: String,
+    content: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct GuiChatRequest {
     message: String,
+    #[serde(default)]
+    messages: Option<Vec<ChatHistoryTurn>>,
     #[allow(dead_code)]
     model: Option<String>,
     #[allow(dead_code)]
@@ -3303,6 +3329,10 @@ enum PendingToolCall {
         native_engine: String,
         tool_instructions: String,
         user_message: String,
+        /// Prior conversation turns (role, content), oldest first, from
+        /// before this tool-calling exchange started — see
+        /// `native_tool_loop_core`'s matching doc comment.
+        history: Vec<(String, String)>,
         scratchpad: String,
         tools: Vec<mcp::McpToolSchema>,
         exec_tokens: usize,
@@ -3935,6 +3965,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     40,
                     1.1,
                     &settings.native_engine,
+                    &[],
                     None,
                     false,
                     None,
@@ -4200,6 +4231,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     &settings.native_engine,
                     // Stateless endpoint, no session to pin a slot to —
                     // matches handle_chat_completions' same behavior.
+                    &[],
                     None,
                     false,
                     None,
@@ -6752,6 +6784,46 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }
     }
 
+    /// Builds prior-turn history for `generate()`/`native_tool_loop_core`
+    /// from the client's full transcript, trimmed to fit `token_budget`
+    /// (oldest dropped first) - the actual enforcement point for
+    /// `RuntimeSettings.conversation_token_limit`, which until this function
+    /// existed was stored and displayed but never applied to anything.
+    ///
+    /// `messages` is the *full* transcript including the latest turn (see
+    /// `ChatHistoryTurn`'s doc comment) - the last entry is dropped here
+    /// since callers already send that turn separately as the `prompt`
+    /// argument to `generate()`. Token cost per turn is the same
+    /// whitespace-word estimate used elsewhere in this file (e.g. the
+    /// `token_estimate` computed a few lines into `handle_gui_chat`) rather
+    /// than a real tokenizer - consistent, not exact, which is all a rough
+    /// budget needs.
+    fn trim_conversation_history(
+        messages: &[ChatHistoryTurn],
+        token_budget: usize,
+    ) -> (Vec<(String, String)>, bool) {
+        let prior = if messages.is_empty() {
+            &[][..]
+        } else {
+            &messages[..messages.len() - 1]
+        };
+
+        let mut budget = token_budget;
+        let mut kept: Vec<(String, String)> = Vec::new();
+        for turn in prior.iter().rev() {
+            let cost = turn.content.split_whitespace().count().max(1);
+            if cost > budget {
+                break;
+            }
+            budget -= cost;
+            kept.push((turn.role.clone(), turn.content.clone()));
+        }
+        kept.reverse();
+
+        let truncated = kept.len() < prior.len();
+        (kept, truncated)
+    }
+
     async fn handle_gui_chat(
         State(state): State<Arc<Mutex<BackendState>>>,
         Json(req): Json<GuiChatRequest>,
@@ -6817,6 +6889,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }
 
         let token_estimate = req.message.split_whitespace().count().clamp(1, 1024);
+        let (history_turns, history_truncated) = trim_conversation_history(
+            req.messages.as_deref().unwrap_or(&[]),
+            settings.conversation_token_limit,
+        );
         let temp = req.temperature.unwrap_or(settings.temperature);
         let top_p = req.top_p.unwrap_or(settings.top_p);
         let top_k = req.top_k.unwrap_or(settings.top_k);
@@ -6991,6 +7067,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     penalty,
                     &settings.native_engine,
                     &enabled_tools,
+                    &history_turns,
                 )
                 .await;
                 match step {
@@ -7023,8 +7100,17 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                         top_k,
                         penalty,
                         &settings.native_engine,
+                        &history_turns,
+                        // "any idle slot" (llama-server's own default), not a
+                        // pinned slot number - safe with the default
+                        // parallel_slots=1 (there's only ever one slot to
+                        // land on anyway) and no worse than before if the
+                        // user's raised it. cache_prompt: true only helps
+                        // when consecutive calls land on the same slot with
+                        // a matching prefix; harmless (just a fresh eval, as
+                        // before) when they don't.
                         None,
-                        false,
+                        true,
                         req.response_format.clone(),
                     )
                     .await
@@ -7219,6 +7305,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             "exec_tokens": exec_tokens,
             "exec_micro_batch": exec_micro_batch,
             "real_inference": real_inference,
+            // Set when trim_conversation_history dropped one or more of the
+            // client's older turns to fit conversation_token_limit - the GUI
+            // renders a divider above this reply so the gap is visible (see
+            // ChatMessage.truncatedBefore) instead of looking like the model
+            // just forgot on its own.
+            "truncated": history_truncated,
             "metrics": metrics_json
         });
 

--- a/crates/ghost-link/src/native_engine.rs
+++ b/crates/ghost-link/src/native_engine.rs
@@ -780,6 +780,14 @@ impl NativeEngineClient {
         top_k: usize,
         repeat_penalty: f32,
         native_engine: &str,
+        // Prior conversation turns (role, content), oldest first, *not*
+        // including `prompt` itself (that's sent separately as the final
+        // user turn). Empty for stateless call sites (the OpenAI-compatible
+        // completions endpoints, tool-loop iterations after the first,
+        // simulated/llama_cpp paths). Ignored by the llama_cpp/simulated
+        // paths below, which build a single flat prompt string with no
+        // chat-template concept.
+        history: &[(String, String)],
         // See `generate_with_llama_server`'s doc comment. Ignored by the
         // llama_cpp/simulated paths below, which have no slot concept.
         id_slot: Option<i64>,
@@ -819,6 +827,7 @@ impl NativeEngineClient {
                         top_p,
                         top_k,
                         repeat_penalty,
+                        history,
                         id_slot,
                         cache_prompt,
                         response_format,
@@ -933,6 +942,11 @@ impl NativeEngineClient {
         top_p: f32,
         top_k: usize,
         repeat_penalty: f32,
+        // Prior conversation turns (role, content), oldest first. Woven into
+        // both the chat-completions `messages` array and the `/completion`
+        // fallback's flat prompt, between the system prompt and the current
+        // `cleaned_prompt` turn.
+        history: &[(String, String)],
         // Slot/context reuse: `id_slot` pins this generation to a specific
         // llama-server slot (-1, llama-server's own "any idle slot" sentinel,
         // when None) and `cache_prompt` lets llama-server reuse whatever KV
@@ -965,12 +979,16 @@ impl NativeEngineClient {
         // Try chat completion endpoint first (for models with chat templates)
         let chat_url = format!("{base_url}/v1/chat/completions");
 
+        let mut chat_messages =
+            vec![serde_json::json!({"role": "system", "content": system_prompt})];
+        for (role, content) in history {
+            chat_messages.push(serde_json::json!({"role": role, "content": content}));
+        }
+        chat_messages.push(serde_json::json!({"role": "user", "content": cleaned_prompt}));
+
         let mut chat_payload = serde_json::json!({
             "model": model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": cleaned_prompt}
-            ],
+            "messages": chat_messages,
             "max_tokens": max_tokens,
             "temperature": temperature.clamp(0.0, 2.0),
             "top_p": top_p.clamp(0.0, 1.0),
@@ -1034,11 +1052,21 @@ impl NativeEngineClient {
         // Fall back to completion endpoint for models without chat template
         let completion_url = format!("{base_url}/completion");
 
-        // Format prompt for completion endpoint: system + user
-        let completion_prompt = format!(
-            "{}\n\nUser: {}\n\nAssistant:",
-            system_prompt, cleaned_prompt
-        );
+        // Format prompt for completion endpoint: system + prior turns + user.
+        // No real chat template here (this is the no-template fallback), so
+        // prior turns are just labelled plain-text lines - good enough for
+        // models that fell through to this path specifically because they
+        // don't understand structured `messages`.
+        let mut completion_prompt = system_prompt.clone();
+        for (role, content) in history {
+            let label = if role.eq_ignore_ascii_case("assistant") {
+                "Assistant"
+            } else {
+                "User"
+            };
+            completion_prompt.push_str(&format!("\n\n{label}: {content}"));
+        }
+        completion_prompt.push_str(&format!("\n\nUser: {cleaned_prompt}\n\nAssistant:"));
 
         let completion_payload = serde_json::json!({
             "model": model,
@@ -1182,6 +1210,7 @@ impl NativeEngineClient {
                     top_p,
                     top_k,
                     repeat_penalty,
+                    &[],
                     id_slot,
                     cache_prompt,
                     None,
@@ -1480,6 +1509,7 @@ mod tests {
                         40,
                         1.1,
                         "simulated",
+                        &[],
                         None,
                         false,
                         None,
@@ -1563,6 +1593,7 @@ mod tests {
                         40,
                         1.1,
                         "llama_server",
+                        &[],
                         Some(0),
                         true,
                         None,
@@ -1590,6 +1621,90 @@ mod tests {
     }
 
     #[test]
+    fn generate_weaves_prior_turns_into_the_messages_array() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("failed to bind test listener");
+        let addr = listener.local_addr().expect("failed to read local_addr");
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept coordinator connection");
+            let body = read_http_request_body(&mut stream);
+            let response_body = serde_json::json!({
+                "choices": [{"message": {"content": "hello again"}}]
+            })
+            .to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            use std::io::Write;
+            stream
+                .write_all(response.as_bytes())
+                .expect("write mock response");
+            body
+        });
+
+        std::env::set_var("GHOSTLINK_LLAMA_SERVER_URL", format!("http://{addr}"));
+
+        let history = vec![
+            (
+                "user".to_string(),
+                "what's the capital of France?".to_string(),
+            ),
+            ("assistant".to_string(), "Paris.".to_string()),
+        ];
+
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let engine = NativeEngineClient::new();
+        rt.block_on(async {
+            engine
+                .generate(
+                    "test-model",
+                    "and its population?",
+                    32,
+                    0.7,
+                    0.9,
+                    40,
+                    1.1,
+                    "llama_server",
+                    &history,
+                    None,
+                    false,
+                    None,
+                )
+                .await
+        })
+        .expect("generation against the test server should succeed");
+
+        let captured_body = server.join().expect("server thread should not panic");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&captured_body).expect("captured body should be valid JSON");
+        let messages = parsed
+            .get("messages")
+            .and_then(|v| v.as_array())
+            .expect("messages array");
+
+        // system, then the two history turns in order, then the new user turn.
+        assert_eq!(
+            messages.len(),
+            4,
+            "unexpected messages shape: {captured_body}"
+        );
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[1]["content"], "what's the capital of France?");
+        assert_eq!(messages[2]["role"], "assistant");
+        assert_eq!(messages[2]["content"], "Paris.");
+        assert_eq!(messages[3]["role"], "user");
+        assert_eq!(messages[3]["content"], "and its population?");
+
+        std::env::remove_var("GHOSTLINK_LLAMA_SERVER_URL");
+    }
+
+    #[test]
     fn llama_mode_requires_model_path() {
         let _guard = env_lock().lock().expect("env lock poisoned");
 
@@ -1609,6 +1724,7 @@ mod tests {
                         40,
                         1.1,
                         "llama_cpp",
+                        &[],
                         None,
                         false,
                         None,


### PR DESCRIPTION
## Summary

Found while investigating why "cap `conversation_token_limit` more aggressively for larger models" (a follow-up to earlier performance work) wouldn't actually do anything: `conversation_token_limit` was stored, editable in Settings, and displayed with a live usage badge in the GUI — but never once read anywhere to build a prompt. Tracing why turned up the real bug underneath it.

`api.ts`'s `sendMessage` already builds and sends a full `messages` transcript specifically "so the model has memory of the conversation instead of seeing `message` alone" (its own comment) — but `GuiChatRequest` had no field to receive it, so serde silently dropped it on arrival. The Native engine's actual call into the model, `native_engine_client.generate(&current_model, &req.message, ...)`, only ever sent the single latest message, with `cache_prompt: false` and no `id_slot` pinning, so there was no server-side KV-cache continuity either. **Every chat "conversation" was answered as an isolated, memoryless single turn** — confirmed live before this fix: a follow-up question about something stated one message earlier got no correct answer, because the model never saw the earlier message at all.

## Fix

- `GuiChatRequest` gains `messages: Option<Vec<ChatHistoryTurn>>`, matching `api.ts`'s contract (full transcript, oldest first, including the latest turn).
- New `trim_conversation_history()` is the first real consumer of `conversation_token_limit`: drops the client's last entry (already covered by `message`), then trims from the *oldest* end of what's left to fit the configured budget, returning whether anything was dropped.
- `generate()`/`generate_with_llama_server()` (`native_engine.rs`) gain a `history: &[(String, String)]` parameter, woven into the real `/v1/chat/completions` `messages` array (and the `/completion` fallback's flat prompt) between the system prompt and the current turn. Threaded through `native_tool_loop_core` and `PendingToolCall::Native` too, so tool-calling turns keep prior conversation context across a pause/resume as well.
- The direct (non-tool) chat path now also passes `cache_prompt: true` — inert before this fix (nothing sent a stable prefix worth caching), genuinely useful now that a real, growing transcript is sent each turn.
- Response JSON gains `"truncated"`, wired to the GUI's existing (also previously-inert) `truncatedBefore` divider.

**Deliberately out of scope**: Ollama/vLLM chat backends have the same single-message gap but use different client types and message-building conventions — a separate fix. The genuinely unused `generate_chat_stream` (real incremental streaming, tested but never called from any real handler — `handle_gui_chat`'s own "streaming" instead chunks an already-complete response after the fact) is a separate finding, not touched here.

## Validation

- `cargo fmt --all --check`, `cargo clippy -p ghost-link --all-targets -- -D warnings`, `cargo test --release -p ghost-link` (138 passed incl. a new test asserting the exact outgoing `messages` shape) — all clean.
- **Verified live end to end**: told the model "my favorite color is teal," then in a second request asked "what is my favorite color?" with the full two-turn transcript attached — correct answer ("Teal"), which is only possible if the history actually reached the model.
- Verified the truncation path fires (`"truncated": true`) when history exceeds a deliberately tiny `conversation_token_limit`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>