### PR TITLE
release: v1.16.0 — GPU-probe timeout fix, TCP circuit breaker, model-list caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.16.0] - 2026-08-05 (Reliability fixes: GPU probe timeout, TCP circuit breaker, model-list caching)
+
+### Fixed
+
+- GPU hardware detection (`system_profile.rs`) had a probe-timeout regression: each `probe_*_with_timeout` wrapper unconditionally slept the full timeout duration before checking whether the probe had already finished, so every startup paid the full 5-10s per probe instead of returning as soon as the fast path completed. Replaced with a real bounded wait (detached thread + `mpsc::recv_timeout`) that returns immediately on completion and only blocks up to the timeout on a genuinely slow/hung probe. Full profile detection now completes in ~1.5s on a typical dev machine instead of a guaranteed multi-second floor.
+- GUI production build (`npm run build`) was broken: `vite-plugin-monaco-editor-esm`'s built-in worker entries hardcode `monaco-editor/esm/vs/...` paths that, against `monaco-editor`'s current package.json `"exports"` map, resolve to a doubled `esm/vs/esm/vs/...` path that doesn't exist ("Could not resolve"). Reconfigured [ghostlink_gui_modern/vite.config.ts](ghostlink_gui_modern/vite.config.ts) to supply the same 5 workers (editor core, CSS, HTML, JSON, TypeScript) via `customWorkers` with the prefix stripped, which the exports map re-adds correctly. Affects both `npm run build` and `npm run dev`; this was blocking the `release-artifacts.yml` CI gate outright.
+
+### Added
+
+- `circuit_breaker` module in [crates/ghostlink-core/src/circuit_breaker.rs](crates/ghostlink-core/src/circuit_breaker.rs): a 3-state (Closed/Open/Half-Open) circuit breaker with jittered exponential backoff. Wired into the TCP transport bridge's reconnect loop ([crates/ghostlink-core/src/runtime.rs](crates/ghostlink-core/src/runtime.rs) `spawn_tcp_bridge`) via a new per-node breaker registry on `ClusterState` (`circuit_breaker_for`) — failure history now persists *across* pipeline executions targeting the same remote node, so a chronically-unreachable node fails fast on later calls instead of repeating the full connect/backoff sequence every time. Opt-in per call site (`Option<CircuitBreaker>`); the loopback benchmarking path passes `None` and is unaffected.
+- `api_response_cache` module in [crates/ghostlink-core/src/api_response_cache.rs](crates/ghostlink-core/src/api_response_cache.rs): a TTL + ETag response cache. Wired into `GET /api/models`, which previously ran a real `fs::read_dir`/`fs::metadata` disk scan on every request — now cached for 5s and explicitly invalidated the moment a download completes or a model is deleted.
+- `LayerKvCache::write_kv_batch` in [crates/ghostlink-core/src/kv_cache.rs](crates/ghostlink-core/src/kv_cache.rs): writes multiple tokens' KV entries under a single write-lock acquisition, validating every entry upfront so a bad entry fails the whole batch atomically. Available as a primitive; like the rest of `kv_cache.rs`, it has no current caller in `runtime.rs` (Ghostlink delegates model execution to an external inference engine).
+
+### Removed
+
+- Three modules from an in-progress performance pass didn't hold up under review and were cut before landing: a churn-coalescing module that duplicated `ClusterState`'s existing lock-free snapshot cache, an MCP "server pool" that pooled against a per-call subprocess-spawn cost the real MCP client (`mcp/registry.rs`, persistent connections) doesn't have, and a protocol buffer pool targeting `DiscoveryFrame::encode()`, which already encodes into a stack buffer on a low-frequency discovery path.
+
+### Validation
+
+- `cargo fmt --all --check` — OK
+- `cargo clippy --workspace --all-targets -- -D warnings` — OK
+- `cargo test --workspace` — OK
+- `cd control-plane && go test ./...` — OK
+- `cd ghostlink_gui_modern && npm run test` — OK (14 files, 142 tests)
+- `cd ghostlink_gui_modern && npm run build` — OK
+
+---
+
 ## [1.3.2] - 2026-08-02 (vLLM Integration & Release Packaging Readiness)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-link"
-version = "1.3.0"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "ghostlink-core"
-version = "1.3.0"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghost-link"
-version = "1.3.0"
+version = "1.16.0"
 edition = "2021"
 authors = ["Ryan K Williams"]
 description = "CLI and API runtime for Ghostlink, a distributed inference fabric for routing and scheduling custom LLM workloads across heterogeneous hardware."
@@ -21,7 +21,7 @@ cuda = []
 rocm = ["ghostlink-core/rocm"]
 
 [dependencies]
-ghostlink-core = { path = "../ghostlink-core", version = "1.3.0" }
+ghostlink-core = { path = "../ghostlink-core", version = "1.16.0" }
 
 # Local date/time for the assistant system prompt
 chrono = "0.4"

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -8,6 +8,7 @@
 use crate::inference_engine::InferenceEngine;
 use crate::runtime::Runtime;
 use anyhow::Result;
+use ghostlink_core::api_response_cache::ApiResponseCache;
 use ghostlink_core::autotune::AutoTuner;
 use ghostlink_core::cluster::{ClusterState, NodeMetrics};
 use ghostlink_core::dashboard::Dashboard;
@@ -1546,6 +1547,13 @@ struct BackendState {
     /// would need an append-only file, which is a bigger step than this
     /// first real version takes.
     audit_log: std::collections::VecDeque<AuditLogEntry>,
+    /// Caches `scan_local_models_dir`'s result — a real `fs::read_dir` +
+    /// `fs::metadata`-per-file disk scan `handle_gui_models` previously did
+    /// on every single `GET /api/models` call. Short TTL (see
+    /// `MODELS_SCAN_CACHE_TTL`); explicitly cleared by the load/download/
+    /// delete handlers so a change is visible immediately rather than
+    /// waiting out the TTL.
+    models_scan_cache: ApiResponseCache,
 }
 
 /// One row for the GUI's Security tab audit log — field names/shape match
@@ -1750,6 +1758,33 @@ impl Default for RuntimeSettings {
             rpc_port: default_rpc_port(),
         }
     }
+}
+
+/// How long `handle_gui_models` trusts a cached local-disk model scan before
+/// re-scanning. The load/download/delete handlers explicitly clear the cache
+/// on completion, so this only bounds staleness for changes made outside
+/// Ghostlink (e.g. a model file dropped in by hand).
+const MODELS_SCAN_CACHE_TTL: Duration = Duration::from_secs(5);
+
+/// Runs `compute` (a real `fs::read_dir`/`fs::metadata` disk scan) through
+/// `cache`, so repeated calls within `MODELS_SCAN_CACHE_TTL` reuse the prior
+/// scan instead of re-touching the filesystem every time. Top-level (rather
+/// than inlined in the nested `handle_gui_models` handler, which — like the
+/// rest of this file's axum handlers — is a local fn inside `main()` and so
+/// isn't directly reachable from `mod tests`) specifically so it's callable
+/// from a test without spinning up the whole handler/state plumbing.
+fn cached_models_scan(
+    cache: &ApiResponseCache,
+    compute: impl FnOnce() -> Vec<ModelRecord>,
+) -> Vec<ModelRecord> {
+    cache
+        .get_or_compute("local_models_scan", MODELS_SCAN_CACHE_TTL, move || {
+            serde_json::to_vec(&compute())
+                .map_err(|e| format!("failed to serialize local model scan: {e}"))
+        })
+        .ok()
+        .and_then(|(body, _etag)| serde_json::from_slice(&body).ok())
+        .unwrap_or_default()
 }
 
 fn build_cluster_topology_json(cluster: &ClusterState) -> serde_json::Value {
@@ -4619,8 +4654,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     ) -> Json<serde_json::Value> {
         let backend = lock_state(&state);
 
+        let models_dir = backend.settings.models_dir.clone();
+        let local = cached_models_scan(&backend.models_scan_cache, move || {
+            scan_local_models_dir(&models_dir)
+        });
+
         let mut merged: Vec<ModelRecord> = backend.models.clone();
-        let local = scan_local_models_dir(&backend.settings.models_dir);
         for l in &local {
             if let Some(existing) = merged.iter_mut().find(|m| m.name == l.name) {
                 existing.local_path = l.local_path.clone();
@@ -5083,6 +5122,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                         local_path,
                     });
                     save_persistent_models(&backend.models);
+                    // The download wrote a new .gguf file — the cached disk
+                    // scan is stale as of this exact moment, not just after
+                    // its TTL elapses.
+                    backend.models_scan_cache.clear();
                     backend.download_progress.insert(
                         spawn_model_id.clone(),
                         DownloadProgressInfo {
@@ -5218,6 +5261,8 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             backend.current_model = "none".to_string();
         }
         save_persistent_models(&backend.models);
+        // The delete(s) above may have removed real files from disk.
+        backend.models_scan_cache.clear();
         Json(serde_json::json!({
             "status": "ok",
             "model": model_name
@@ -8204,6 +8249,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
         enable_tls_active: use_tls,
         audit_log: std::collections::VecDeque::new(),
+        models_scan_cache: ApiResponseCache::new(),
     }));
 
     // Background CPU/RAM/GPU sampler — keeps /api/metrics non-blocking.
@@ -10575,6 +10621,7 @@ mod tests {
             enable_tls_active: false,
             plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
             audit_log: std::collections::VecDeque::new(),
+            models_scan_cache: ApiResponseCache::new(),
         }))
     }
 
@@ -10647,6 +10694,44 @@ mod tests {
         assert!(json["nodes"][1]["throughput_history_gbps"]
             .as_array()
             .is_some());
+    }
+
+    #[test]
+    fn cached_models_scan_reuses_the_prior_scan_within_the_ttl() {
+        let cache = ApiResponseCache::new();
+        let call_count = std::sync::atomic::AtomicUsize::new(0);
+        let fake_scan = || {
+            call_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            vec![ModelRecord {
+                name: "tinyllama".to_string(),
+                size_gb: 1.0,
+                model_type: "LLM".to_string(),
+                quantization: "Q4_K_M".to_string(),
+                status: "Ready".to_string(),
+                local_path: "/models/tinyllama.gguf".to_string(),
+            }]
+        };
+
+        let first = cached_models_scan(&cache, fake_scan);
+        let second = cached_models_scan(&cache, fake_scan);
+
+        assert_eq!(first.len(), second.len());
+        assert_eq!(first[0].name, second[0].name);
+        assert_eq!(
+            call_count.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "second call within the TTL should reuse the cached scan, not rescan the disk"
+        );
+        assert_eq!(cache.stats().cache_hits, 1);
+
+        cache.clear();
+        let third = cached_models_scan(&cache, fake_scan);
+        assert_eq!(third[0].name, first[0].name);
+        assert_eq!(
+            call_count.load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "clearing the cache (as the download/delete handlers do) must force a rescan"
+        );
     }
 
     #[tokio::test]

--- a/crates/ghostlink-core/Cargo.toml
+++ b/crates/ghostlink-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghostlink-core"
-version = "1.3.0"
+version = "1.16.0"
 edition = "2021"
 authors = ["Ryan K Williams"]
 description = "Core runtime primitives for Ghostlink, including planning, routing, health monitoring, and transport logic for distributed inference workloads."

--- a/crates/ghostlink-core/src/api_response_cache.rs
+++ b/crates/ghostlink-core/src/api_response_cache.rs
@@ -1,0 +1,319 @@
+//! API Response Caching Layer with ETag Support
+//!
+//! Reduces serialization overhead and bandwidth by caching API responses with:
+//! - TTL-based expiration
+//! - ETag support for conditional requests (304 Not Modified)
+//! - Hit ratio tracking and statistics
+//! - Optional pre-warming on startup
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+/// Cached API response
+#[derive(Clone, Debug)]
+struct CachedResponse {
+    /// Response body
+    body: Vec<u8>,
+    /// ETag hash
+    etag: String,
+    /// Expiration time
+    expires_at: Instant,
+}
+
+/// Cache statistics for observability
+#[derive(Clone, Debug, Default)]
+pub struct CacheStats {
+    pub total_requests: usize,
+    pub cache_hits: usize,
+    pub cache_misses: usize,
+    pub etag_hits: usize,
+}
+
+impl CacheStats {
+    pub fn hit_ratio(&self) -> f64 {
+        if self.total_requests == 0 {
+            0.0
+        } else {
+            (self.cache_hits + self.etag_hits) as f64 / self.total_requests as f64
+        }
+    }
+}
+
+/// Thread-safe API response cache
+#[derive(Debug)]
+pub struct ApiResponseCache {
+    cache: Arc<RwLock<HashMap<String, CachedResponse>>>,
+    stats: Arc<RwLock<CacheStats>>,
+}
+
+impl ApiResponseCache {
+    /// Create a new cache
+    pub fn new() -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            stats: Arc::new(RwLock::new(CacheStats::default())),
+        }
+    }
+
+    /// Get cached response or compute new one
+    pub fn get_or_compute<F>(
+        &self,
+        key: &str,
+        ttl: Duration,
+        compute_fn: F,
+    ) -> Result<(Vec<u8>, String), String>
+    where
+        F: FnOnce() -> Result<Vec<u8>, String>,
+    {
+        let mut stats = self.stats.write().unwrap();
+        stats.total_requests += 1;
+
+        // Check cache
+        {
+            let cache = self.cache.read().unwrap();
+            if let Some(cached) = cache.get(key) {
+                if cached.expires_at > Instant::now() {
+                    stats.cache_hits += 1;
+                    return Ok((cached.body.clone(), cached.etag.clone()));
+                }
+            }
+        }
+
+        // Cache miss or expired
+        stats.cache_misses += 1;
+        let body = compute_fn()?;
+        let etag = compute_etag(&body);
+
+        let mut cache = self.cache.write().unwrap();
+        cache.insert(
+            key.to_string(),
+            CachedResponse {
+                body: body.clone(),
+                etag: etag.clone(),
+                expires_at: Instant::now() + ttl,
+            },
+        );
+
+        Ok((body, etag))
+    }
+
+    /// Check if client's ETag matches (for 304 responses)
+    pub fn etag_matches(&self, key: &str, client_etag: &str) -> bool {
+        let cache = self.cache.read().unwrap();
+        if let Some(cached) = cache.get(key) {
+            if cached.expires_at > Instant::now() {
+                return cached.etag == client_etag;
+            }
+        }
+        false
+    }
+
+    /// Record ETag hit (304 response sent)
+    pub fn record_etag_hit(&self) {
+        let mut stats = self.stats.write().unwrap();
+        stats.etag_hits += 1;
+    }
+
+    /// Get current cache statistics
+    pub fn stats(&self) -> CacheStats {
+        self.stats.read().unwrap().clone()
+    }
+
+    /// Clear all cache entries
+    pub fn clear(&self) {
+        self.cache.write().unwrap().clear();
+        *self.stats.write().unwrap() = CacheStats::default();
+    }
+
+    /// Pre-warm cache with known endpoints
+    pub fn pre_warm<F>(&self, endpoints: Vec<(&str, Duration)>, compute_fn: F) -> Result<(), String>
+    where
+        F: Fn(&str) -> Result<Vec<u8>, String>,
+    {
+        for (key, ttl) in endpoints {
+            self.get_or_compute(key, ttl, || compute_fn(key))?;
+        }
+        Ok(())
+    }
+
+    /// Get cache size (number of entries)
+    pub fn size(&self) -> usize {
+        self.cache.read().unwrap().len()
+    }
+}
+
+impl Default for ApiResponseCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for ApiResponseCache {
+    fn clone(&self) -> Self {
+        Self {
+            cache: Arc::clone(&self.cache),
+            stats: Arc::clone(&self.stats),
+        }
+    }
+}
+
+/// Compute a weak ETag (RFC 7232 `W/` prefix — a content fingerprint for
+/// conditional-GET purposes, not a claim of byte-exact equivalence) from a
+/// response body. Mixes the body length into the hash state and appends it
+/// to the digest so two different-length bodies that happen to collide in
+/// the 64-bit hash are still distinguishable — plain `DefaultHasher::finish()`
+/// alone shares this any-fixed-width-hash's theoretical collision risk, but
+/// unlike a 32-bit CRC (already used elsewhere in this crate for wire-frame
+/// corruption detection, a different threat model) this doesn't halve the
+/// effective space to make it worse.
+fn compute_etag(body: &[u8]) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    body.len().hash(&mut hasher);
+    body.hash(&mut hasher);
+    format!("W/\"{:x}-{:x}\"", hasher.finish(), body.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_miss_computes_value() {
+        let cache = ApiResponseCache::new();
+        let body = b"response data".to_vec();
+        let body_clone = body.clone();
+
+        let (result, etag) = cache
+            .get_or_compute("test", Duration::from_secs(60), || Ok(body_clone))
+            .unwrap();
+
+        assert_eq!(result, body);
+        assert!(!etag.is_empty());
+    }
+
+    #[test]
+    fn cache_hit_reuses() {
+        let cache = ApiResponseCache::new();
+        let body1 = b"response1".to_vec();
+        let body1_clone = body1.clone();
+
+        let (result1, etag1) = cache
+            .get_or_compute("test", Duration::from_secs(60), || Ok(body1_clone))
+            .unwrap();
+
+        let (result2, etag2) = cache
+            .get_or_compute(
+                "test",
+                Duration::from_secs(60),
+                || Ok(b"response2".to_vec()),
+            )
+            .unwrap();
+
+        assert_eq!(result1, result2);
+        assert_eq!(etag1, etag2);
+        assert_eq!(cache.stats().cache_hits, 1);
+    }
+
+    #[test]
+    fn etag_match_detection() {
+        let cache = ApiResponseCache::new();
+        let body = b"data".to_vec();
+        let body_clone = body.clone();
+
+        let (_result, etag) = cache
+            .get_or_compute("test", Duration::from_secs(60), || Ok(body_clone))
+            .unwrap();
+
+        assert!(cache.etag_matches("test", &etag));
+        assert!(!cache.etag_matches("test", "wrong-etag"));
+    }
+
+    #[test]
+    fn expiration_and_recompute() {
+        let cache = ApiResponseCache::new();
+
+        // First request: cache miss
+        cache
+            .get_or_compute("test", Duration::from_millis(5), || Ok(b"data1".to_vec()))
+            .unwrap();
+
+        // Wait for expiration
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Second request on expired key: should recompute
+        let (result2, _etag2) = cache
+            .get_or_compute("test", Duration::from_secs(60), || Ok(b"data2".to_vec()))
+            .unwrap();
+
+        assert_eq!(result2, b"data2");
+    }
+
+    #[test]
+    fn statistics_tracking() {
+        let cache = ApiResponseCache::new();
+
+        for i in 0..5 {
+            let body = format!("response{}", i).into_bytes();
+            cache
+                .get_or_compute(&format!("endpoint{}", i), Duration::from_secs(60), || {
+                    Ok(body)
+                })
+                .unwrap();
+        }
+
+        let stats = cache.stats();
+        assert_eq!(stats.total_requests, 5);
+        assert_eq!(stats.cache_misses, 5);
+        assert_eq!(stats.cache_hits, 0);
+    }
+
+    #[test]
+    fn hit_ratio_calculation() {
+        let cache = ApiResponseCache::new();
+
+        for _ in 0..3 {
+            cache
+                .get_or_compute("test", Duration::from_secs(60), || Ok(b"data".to_vec()))
+                .unwrap();
+            cache
+                .get_or_compute("test", Duration::from_secs(60), || Ok(b"data".to_vec()))
+                .unwrap();
+        }
+
+        let stats = cache.stats();
+        let ratio = stats.hit_ratio();
+        assert!(ratio > 0.5);
+    }
+
+    #[test]
+    fn pre_warm_populates() {
+        let cache = ApiResponseCache::new();
+
+        cache
+            .pre_warm(
+                vec![
+                    ("models", Duration::from_secs(60)),
+                    ("runtime", Duration::from_secs(300)),
+                ],
+                |_key| Ok(b"warm data".to_vec()),
+            )
+            .unwrap();
+
+        assert_eq!(cache.size(), 2);
+    }
+
+    #[test]
+    fn clone_shares_state() {
+        let cache1 = ApiResponseCache::new();
+        cache1
+            .get_or_compute("test", Duration::from_secs(60), || Ok(b"data".to_vec()))
+            .unwrap();
+
+        let cache2 = cache1.clone();
+        assert_eq!(cache1.size(), cache2.size());
+    }
+}

--- a/crates/ghostlink-core/src/circuit_breaker.rs
+++ b/crates/ghostlink-core/src/circuit_breaker.rs
@@ -1,0 +1,390 @@
+//! Circuit Breaker Pattern for Resilient Network Communication
+//!
+//! Implements the circuit breaker pattern to prevent cascading failures when
+//! communicating with remote nodes. Transitions through three states:
+//! - Closed: Normal operation, requests pass through
+//! - Open: Failures detected, requests fail fast without attempting connection
+//! - Half-Open: Recovery probe window, allows single connection attempt
+
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Circuit breaker states
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CircuitState {
+    /// Normal operation - requests pass through
+    Closed = 0,
+    /// Failure threshold exceeded - fail-fast without retrying
+    Open = 1,
+    /// Recovery probing - allows single request attempt
+    HalfOpen = 2,
+}
+
+impl CircuitState {
+    fn from_u8(val: u8) -> Self {
+        match val {
+            0 => CircuitState::Closed,
+            1 => CircuitState::Open,
+            2 => CircuitState::HalfOpen,
+            _ => CircuitState::Closed,
+        }
+    }
+}
+
+/// Per-node circuit breaker for detecting and responding to failures
+#[derive(Debug)]
+pub struct CircuitBreaker {
+    /// Current state (0=closed, 1=open, 2=half-open)
+    state: Arc<AtomicU8>,
+    /// Count of consecutive failures
+    failures: Arc<AtomicUsize>,
+    /// Timestamp of last failure
+    last_failure: Arc<Mutex<Instant>>,
+    /// Set while a half-open recovery probe is in flight, so only one caller
+    /// gets to probe per recovery window instead of every concurrent caller
+    /// piling onto the just-recovered node at once.
+    half_open_probe_in_flight: Arc<AtomicBool>,
+    /// Configuration
+    config: Arc<CircuitBreakerConfig>,
+}
+
+/// Configuration for circuit breaker behavior
+#[derive(Clone, Debug)]
+pub struct CircuitBreakerConfig {
+    /// Number of failures before opening circuit
+    pub failure_threshold: usize,
+    /// Time to wait in open state before transitioning to half-open
+    pub open_duration_secs: u64,
+    /// Time window for resetting failure counter (after successful request)
+    pub reset_timeout_secs: u64,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 5,
+            open_duration_secs: 30,
+            reset_timeout_secs: 60,
+        }
+    }
+}
+
+impl CircuitBreaker {
+    /// Create a new circuit breaker with default configuration
+    pub fn new() -> Self {
+        Self::with_config(CircuitBreakerConfig::default())
+    }
+
+    /// Create a circuit breaker with custom configuration
+    pub fn with_config(config: CircuitBreakerConfig) -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(0)), // Closed
+            failures: Arc::new(AtomicUsize::new(0)),
+            last_failure: Arc::new(Mutex::new(Instant::now())),
+            half_open_probe_in_flight: Arc::new(AtomicBool::new(false)),
+            config: Arc::new(config),
+        }
+    }
+
+    /// Get current circuit state
+    pub fn current_state(&self) -> CircuitState {
+        let state_byte = self.state.load(Ordering::Relaxed);
+        CircuitState::from_u8(state_byte)
+    }
+
+    /// Check if the circuit allows a request attempt.
+    ///
+    /// At most one caller gets `true` per half-open recovery window: the
+    /// thread that wins the `Open -> HalfOpen` transition claims the probe
+    /// slot in the same step, and every other concurrent caller (whether
+    /// racing that same transition or arriving after it) loses the
+    /// `half_open_probe_in_flight` CAS and gets `false` until
+    /// `record_success`/`record_failure` resolves the probe.
+    pub fn should_attempt(&self) -> bool {
+        match self.current_state() {
+            CircuitState::Closed => true,
+            CircuitState::Open => {
+                // Check if it's time to transition to half-open
+                let last_failure = *self.last_failure.lock().unwrap();
+                let elapsed = last_failure.elapsed();
+
+                if elapsed > Duration::from_secs(self.config.open_duration_secs)
+                    && self
+                        .state
+                        .compare_exchange(1, 2, Ordering::AcqRel, Ordering::Relaxed)
+                        .is_ok()
+                {
+                    self.half_open_probe_in_flight
+                        .store(true, Ordering::Release);
+                    true
+                } else {
+                    false
+                }
+            }
+            CircuitState::HalfOpen => self
+                .half_open_probe_in_flight
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok(),
+        }
+    }
+
+    /// Record a successful request - reset failure counter
+    pub fn record_success(&self) {
+        // Reset only if enough time has passed (reset_timeout_secs)
+        let last_failure = *self.last_failure.lock().unwrap();
+        if last_failure.elapsed() > Duration::from_secs(self.config.reset_timeout_secs) {
+            self.failures.store(0, Ordering::Relaxed);
+            self.state.store(0, Ordering::Relaxed); // Transition to Closed
+            self.half_open_probe_in_flight
+                .store(false, Ordering::Release);
+        } else if self.current_state() == CircuitState::HalfOpen {
+            // Transition from half-open to closed on successful probe
+            self.failures.store(0, Ordering::Relaxed);
+            self.state.store(0, Ordering::Relaxed);
+            self.half_open_probe_in_flight
+                .store(false, Ordering::Release);
+        }
+    }
+
+    /// Record a failed request - increment failure counter
+    pub fn record_failure(&self) {
+        let failure_count = self.failures.fetch_add(1, Ordering::Relaxed) + 1;
+        *self.last_failure.lock().unwrap() = Instant::now();
+
+        // A failed half-open probe reopens the circuit immediately, same as
+        // crossing the failure threshold from closed.
+        if failure_count >= self.config.failure_threshold
+            || self.current_state() == CircuitState::HalfOpen
+        {
+            self.state.store(1, Ordering::Relaxed); // Open
+            self.half_open_probe_in_flight
+                .store(false, Ordering::Release);
+        }
+    }
+
+    /// Get failure count
+    pub fn failure_count(&self) -> usize {
+        self.failures.load(Ordering::Relaxed)
+    }
+
+    /// Get time since last failure
+    pub fn time_since_last_failure(&self) -> Duration {
+        self.last_failure.lock().unwrap().elapsed()
+    }
+
+    /// Reset the circuit breaker to closed state
+    pub fn reset(&self) {
+        self.state.store(0, Ordering::Relaxed);
+        self.failures.store(0, Ordering::Relaxed);
+        self.half_open_probe_in_flight
+            .store(false, Ordering::Release);
+        *self.last_failure.lock().unwrap() = Instant::now();
+    }
+}
+
+impl Default for CircuitBreaker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for CircuitBreaker {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+            failures: Arc::clone(&self.failures),
+            last_failure: Arc::clone(&self.last_failure),
+            half_open_probe_in_flight: Arc::clone(&self.half_open_probe_in_flight),
+            config: Arc::clone(&self.config),
+        }
+    }
+}
+
+/// Jittered exponential backoff for retry delays
+pub struct JitteredBackoff {
+    attempt: u32,
+    max_backoff_ms: u64,
+}
+
+impl JitteredBackoff {
+    /// Create a new jittered backoff starting at attempt 0
+    pub fn new() -> Self {
+        Self {
+            attempt: 0,
+            max_backoff_ms: 30_000, // 30 seconds max
+        }
+    }
+
+    /// With custom max backoff duration
+    pub fn with_max_backoff(max_backoff_ms: u64) -> Self {
+        Self {
+            attempt: 0,
+            max_backoff_ms,
+        }
+    }
+
+    /// Calculate backoff duration for current attempt (with jitter)
+    pub fn backoff_duration(&self) -> Duration {
+        // Base exponential: 100 * 2^attempt, capped at max_backoff_ms
+        let base_ms = (100u64 * 2_u64.pow(self.attempt.min(10))).min(self.max_backoff_ms);
+
+        // Add jitter: 0–10% of base
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let jitter_ms = rng.gen_range(0..=(base_ms / 10));
+
+        Duration::from_millis(base_ms + jitter_ms)
+    }
+
+    /// Advance to next attempt, return backoff duration
+    pub fn next_backoff(&mut self) -> Duration {
+        let duration = self.backoff_duration();
+        self.attempt += 1;
+        duration
+    }
+
+    /// Reset to attempt 0
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+    }
+}
+
+impl Default for JitteredBackoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn circuit_starts_closed() {
+        let cb = CircuitBreaker::new();
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert!(cb.should_attempt());
+    }
+
+    #[test]
+    fn circuit_opens_after_threshold_failures() {
+        let cb = CircuitBreaker::new();
+        for _ in 0..5 {
+            cb.record_failure();
+        }
+        assert_eq!(cb.current_state(), CircuitState::Open);
+        assert!(!cb.should_attempt());
+    }
+
+    #[test]
+    fn circuit_half_opens_after_timeout() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            open_duration_secs: 0,
+            reset_timeout_secs: 60,
+        };
+        let cb = CircuitBreaker::with_config(config);
+        cb.record_failure();
+        assert_eq!(cb.current_state(), CircuitState::Open);
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(cb.should_attempt());
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn circuit_closes_on_successful_probe() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            open_duration_secs: 0,
+            reset_timeout_secs: 0,
+        };
+        let cb = CircuitBreaker::with_config(config);
+        cb.record_failure();
+        assert_eq!(cb.current_state(), CircuitState::Open);
+
+        // Trigger transition to half-open
+        std::thread::sleep(Duration::from_millis(100));
+        let can_attempt = cb.should_attempt();
+        assert!(can_attempt);
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+
+        // Record success and verify transition to closed
+        cb.record_success();
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert_eq!(cb.failure_count(), 0);
+    }
+
+    #[test]
+    fn jittered_backoff_increases() {
+        let mut backoff = JitteredBackoff::new();
+        let backoff1 = backoff.next_backoff();
+        let backoff2 = backoff.next_backoff();
+        let backoff3 = backoff.next_backoff();
+
+        assert!(backoff1.as_millis() >= 100 && backoff1.as_millis() <= 220);
+        assert!(backoff2.as_millis() >= 200 && backoff2.as_millis() <= 440);
+        assert!(backoff3.as_millis() >= 400 && backoff3.as_millis() <= 880);
+    }
+
+    #[test]
+    fn jittered_backoff_has_jitter() {
+        let mut backoffs = Vec::new();
+        for _ in 0..10 {
+            let backoff = JitteredBackoff::new().next_backoff();
+            backoffs.push(backoff.as_millis());
+        }
+
+        let min = *backoffs.iter().min().unwrap();
+        let max = *backoffs.iter().max().unwrap();
+        assert!(max > min, "Jitter should produce different values");
+    }
+
+    #[test]
+    fn half_open_grants_probe_to_exactly_one_concurrent_caller() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            open_duration_secs: 0,
+            reset_timeout_secs: 60,
+        };
+        let cb = CircuitBreaker::with_config(config);
+        cb.record_failure();
+        assert_eq!(cb.current_state(), CircuitState::Open);
+        std::thread::sleep(Duration::from_millis(50));
+
+        let granted = Arc::new(AtomicUsize::new(0));
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                let cb = cb.clone();
+                let granted = Arc::clone(&granted);
+                std::thread::spawn(move || {
+                    if cb.should_attempt() {
+                        granted.fetch_add(1, Ordering::Relaxed);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert_eq!(
+            granted.load(Ordering::Relaxed),
+            1,
+            "exactly one concurrent caller should win the half-open probe slot"
+        );
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn circuit_breaker_is_cloneable() {
+        let cb1 = CircuitBreaker::new();
+        cb1.record_failure();
+        let cb2 = cb1.clone();
+
+        assert_eq!(cb2.failure_count(), 1);
+        cb2.record_failure();
+        assert_eq!(cb1.failure_count(), 2);
+    }
+}

--- a/crates/ghostlink-core/src/cluster.rs
+++ b/crates/ghostlink-core/src/cluster.rs
@@ -234,6 +234,12 @@ pub struct ClusterState {
     total_vram_cache: Arc<AtomicU64>,
     /// Cached total system memory across all registered nodes
     total_system_memory_cache: Arc<AtomicU64>,
+    /// Per-node circuit breakers for the TCP transport bridge (`runtime::spawn_tcp_bridge`).
+    /// Lazily created on first use via `circuit_breaker_for` and kept here — rather than
+    /// inside a single pipeline execution — so failures accumulate *across* pipeline runs
+    /// targeting the same node: a node that's been chronically unreachable trips open and
+    /// stays fail-fast instead of re-running the full connect/backoff dance every call.
+    circuit_breakers: Arc<Mutex<HashMap<String, crate::circuit_breaker::CircuitBreaker>>>,
 }
 
 impl Clone for ClusterState {
@@ -246,6 +252,7 @@ impl Clone for ClusterState {
             last_update: Arc::clone(&self.last_update),
             total_vram_cache: Arc::clone(&self.total_vram_cache),
             total_system_memory_cache: Arc::clone(&self.total_system_memory_cache),
+            circuit_breakers: Arc::clone(&self.circuit_breakers),
         }
     }
 }
@@ -267,7 +274,21 @@ impl ClusterState {
             last_update: Arc::new(AtomicU64::new(0)),
             total_vram_cache: Arc::new(AtomicU64::new(0.0_f64.to_bits())),
             total_system_memory_cache: Arc::new(AtomicU64::new(0.0_f64.to_bits())),
+            circuit_breakers: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Gets (creating with default config on first use) the circuit breaker
+    /// tracking TCP transport failures for one node. The returned handle is
+    /// a cheap `Arc`-backed clone sharing state with every other caller for
+    /// the same `node_id` — recording a failure through one clone is visible
+    /// to all of them.
+    pub fn circuit_breaker_for(&self, node_id: &str) -> crate::circuit_breaker::CircuitBreaker {
+        let mut breakers = self
+            .circuit_breakers
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        breakers.entry(node_id.to_string()).or_default().clone()
     }
 
     /// Register a new node with the cluster

--- a/crates/ghostlink-core/src/kv_cache.rs
+++ b/crates/ghostlink-core/src/kv_cache.rs
@@ -176,6 +176,52 @@ impl LayerKvCache {
         Ok(())
     }
 
+    /// Writes multiple tokens' key/value vectors under a single write-lock
+    /// acquisition, validating every entry upfront (before taking the lock)
+    /// so a bad entry anywhere in the batch fails the whole call without
+    /// partially writing it. Same per-token semantics as calling `write_kv`
+    /// in a loop — this only changes how many times the lock is acquired.
+    pub fn write_kv_batch(&self, entries: &[(usize, &[f32], &[f32])]) -> Result<(), String> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        let width = self.config.token_width();
+
+        // Validate all entries upfront before taking write lock
+        for (token_idx, keys, values) in entries {
+            if keys.len() != values.len() {
+                return Err("keys/values length mismatch".to_string());
+            }
+            if keys.len() != width {
+                return Err(format!("expected {width} elements, got {}", keys.len()));
+            }
+            if *token_idx >= self.config.max_tokens_per_seq {
+                return Err(format!("token index {token_idx} out of bounds"));
+            }
+        }
+
+        // Single write lock acquisition
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| "kv cache lock poisoned".to_string())?;
+        if state.keys.is_empty() {
+            return Err("cache not initialized".to_string());
+        }
+
+        let mut max_token_idx = 0;
+        for (token_idx, keys, values) in entries {
+            let start = token_idx * width;
+            state.keys[start..start + width].copy_from_slice(keys);
+            state.values[start..start + width].copy_from_slice(values);
+            max_token_idx = max_token_idx.max(*token_idx);
+        }
+
+        state.current_len = state.current_len.max(max_token_idx + 1);
+        Ok(())
+    }
+
     /// Reads one token's cached key/value vectors as an owned, fixed-size
     /// copy (`config.token_width()` floats each — not the whole cache).
     pub fn read_kv(&self, token_idx: usize) -> Result<KVCacheEntry, String> {
@@ -400,5 +446,72 @@ mod tests {
         // Written through the clone, visible through the original — same
         // underlying Arc<RwLock<..>>, not a deep copy.
         assert_eq!(cache.read_kv(0).unwrap().keys, data);
+    }
+
+    #[test]
+    fn write_kv_batch_multiple() {
+        let cache = LayerKvCache::new(small_config());
+        cache.initialize(8).unwrap();
+        let width = cache.config.token_width();
+
+        let k0 = vec![0.0_f32; width];
+        let v0 = vec![0.0_f32; width];
+        let k1 = vec![1.0_f32; width];
+        let v1 = vec![10.0_f32; width];
+
+        let entries = [
+            (0, k0.as_slice(), v0.as_slice()),
+            (1, k1.as_slice(), v1.as_slice()),
+        ];
+
+        cache.write_kv_batch(&entries).unwrap();
+        assert_eq!(cache.read_kv(0).unwrap().keys[0], 0.0);
+        assert_eq!(cache.read_kv(1).unwrap().values[0], 10.0);
+    }
+
+    #[test]
+    fn write_kv_batch_empty() {
+        let cache = LayerKvCache::new(small_config());
+        cache.initialize(4).unwrap();
+        assert!(cache.write_kv_batch(&[]).is_ok());
+    }
+
+    #[test]
+    fn write_kv_batch_validation_fails() {
+        let cache = LayerKvCache::new(small_config());
+        cache.initialize(4).unwrap();
+        let width = cache.config.token_width();
+
+        let k0 = vec![1.0_f32; width];
+        let v0 = vec![2.0_f32; width];
+        let bad_k = vec![0.0_f32; width + 1];
+
+        let entries = [
+            (0, k0.as_slice(), v0.as_slice()),
+            (1, bad_k.as_slice(), v0.as_slice()),
+        ];
+
+        assert!(cache.write_kv_batch(&entries).is_err());
+    }
+
+    #[test]
+    fn write_kv_batch_is_atomic_on_validation_failure() {
+        let cache = LayerKvCache::new(small_config());
+        cache.initialize(4).unwrap();
+        let width = cache.config.token_width();
+
+        let good_keys = vec![5.0_f32; width];
+        let bad_keys = vec![0.0_f32; width + 1];
+
+        let entries = [
+            (0, good_keys.as_slice(), good_keys.as_slice()),
+            (1, bad_keys.as_slice(), good_keys.as_slice()),
+        ];
+
+        assert!(cache.write_kv_batch(&entries).is_err());
+        // Upfront validation must reject the whole batch before the write
+        // lock is even taken, so entry 0 must still hold its zero-initialized
+        // default rather than the batch's (never-applied) value.
+        assert_eq!(cache.read_kv(0).unwrap().keys[0], 0.0);
     }
 }

--- a/crates/ghostlink-core/src/lib.rs
+++ b/crates/ghostlink-core/src/lib.rs
@@ -29,7 +29,9 @@
 //! ```
 
 pub mod accelerator;
+pub mod api_response_cache;
 pub mod autotune;
+pub mod circuit_breaker;
 pub mod cluster;
 pub mod dashboard;
 pub mod discovery;
@@ -50,7 +52,9 @@ pub mod xdp;
 
 // Re-export common types for convenience
 pub use accelerator::ExecutionBackend;
+pub use api_response_cache::{ApiResponseCache, CacheStats};
 pub use autotune::AutoTuner;
+pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, CircuitState, JitteredBackoff};
 pub use cluster::{ClusterState, NodeMetrics, NodeStatus};
 pub use discovery::{broadcast_and_collect, UdpDiscoveryConfig, DEFAULT_DISCOVERY_PORT};
 pub use host::{

--- a/crates/ghostlink-core/src/runtime.rs
+++ b/crates/ghostlink-core/src/runtime.rs
@@ -3,6 +3,7 @@
 //! This module provides lightweight execution planning primitives that bridge
 //! placement plans to token-step pipeline schedules across heterogeneous devices.
 
+use crate::circuit_breaker::CircuitBreaker;
 use crate::planning::LayerAssignment;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
@@ -1046,6 +1047,15 @@ fn _read_payload(
 ///
 /// In a multi-node deployment, the `bind_addr` and `connect_addr` can point to
 /// different physical interfaces or remote hosts.
+///
+/// `circuit_breaker` is optional and persists failure history *across* calls
+/// (unlike `config.reconnect_attempts`, which only bounds retries within this
+/// one call) — pass `ClusterState::circuit_breaker_for(node_id)` for a real
+/// remote node so a chronically-unreachable node fails fast on subsequent
+/// pipeline runs instead of repeating the full connect/backoff sequence every
+/// time. `None` (e.g. loopback benchmarking, where there's no real remote
+/// failure mode to protect against) reproduces the prior always-retry behavior
+/// exactly.
 pub fn spawn_tcp_bridge(
     source_stage: usize,
     input_rx: mpsc::Receiver<TransportBatch>,
@@ -1053,33 +1063,53 @@ pub fn spawn_tcp_bridge(
     config: TcpTransportConfig,
     listener: BridgeListener,
     addr: BridgeAddr,
+    circuit_breaker: Option<CircuitBreaker>,
 ) -> thread::JoinHandle<BridgeAccumulator> {
     thread::spawn(move || {
         let client_stream = {
+            let breaker_open = circuit_breaker
+                .as_ref()
+                .is_some_and(|breaker| !breaker.should_attempt());
+
             let mut connected = None;
-            let attempts = config.reconnect_attempts.max(1);
-            for attempt in 0..attempts {
-                match addr.connect(Duration::from_secs(1)) {
-                    Ok(stream) => {
-                        connected = Some(stream);
-                        break;
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            "Bridge: Connection attempt {}/{} failed for {:?}: {}",
-                            attempt + 1,
-                            attempts,
-                            addr,
-                            e
-                        );
-                        thread::sleep(Duration::from_millis(config.reconnect_backoff_ms));
+            if breaker_open {
+                tracing::warn!(
+                    "Bridge: circuit breaker open for {:?}; skipping connection attempts",
+                    addr
+                );
+            } else {
+                let attempts = config.reconnect_attempts.max(1);
+                for attempt in 0..attempts {
+                    match addr.connect(Duration::from_secs(1)) {
+                        Ok(stream) => {
+                            connected = Some(stream);
+                            break;
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                "Bridge: Connection attempt {}/{} failed for {:?}: {}",
+                                attempt + 1,
+                                attempts,
+                                addr,
+                                e
+                            );
+                            thread::sleep(Duration::from_millis(config.reconnect_backoff_ms));
+                        }
                     }
                 }
             }
 
             match connected {
-                Some(stream) => stream,
+                Some(stream) => {
+                    if let Some(breaker) = &circuit_breaker {
+                        breaker.record_success();
+                    }
+                    stream
+                }
                 None => {
+                    if let Some(breaker) = &circuit_breaker {
+                        breaker.record_failure();
+                    }
                     tracing::error!(
                         "Bridge: Exhausted retries for {:?}. Falling back to passthrough.",
                         addr
@@ -1417,6 +1447,7 @@ pub fn execute_pipeline_distributed(
             )
         };
 
+        let breaker = Some(cluster.circuit_breaker_for(&target_stage_p.node_id));
         bridge_handles.push(spawn_tcp_bridge(
             source_stage_idx,
             bridge_in_rx,
@@ -1424,6 +1455,7 @@ pub fn execute_pipeline_distributed(
             config.clone(),
             listener,
             addr,
+            breaker,
         ));
     }
 
@@ -1691,6 +1723,7 @@ pub fn execute_pipeline_tcp_loopback_with_config(
             config.clone(),
             listener,
             addr,
+            None, // loopback benchmarking: no real remote-node failure mode to track
         ));
     }
 
@@ -2614,6 +2647,56 @@ mod tests {
             result.stage_stats[1].avg_bridge_write_ms > 0.0,
             "remote round-trip time must be non-zero for a real socket hop, got {}",
             result.stage_stats[1].avg_bridge_write_ms
+        );
+    }
+
+    #[test]
+    fn spawn_tcp_bridge_skips_connection_attempts_when_circuit_breaker_is_open() {
+        use crate::circuit_breaker::{CircuitBreakerConfig, CircuitState};
+
+        // Bind-then-drop reliably yields an address nothing is listening on.
+        let dead_addr = {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap()
+        };
+        let dummy_listener = BridgeListener::Tcp(TcpListener::bind("127.0.0.1:0").unwrap());
+
+        let breaker = CircuitBreaker::with_config(CircuitBreakerConfig {
+            failure_threshold: 1,
+            open_duration_secs: 3600,
+            reset_timeout_secs: 3600,
+        });
+        breaker.record_failure();
+        assert_eq!(breaker.current_state(), CircuitState::Open);
+
+        let (in_tx, in_rx) = mpsc::sync_channel::<TransportBatch>(1);
+        let (out_tx, _out_rx) = mpsc::sync_channel::<TransportBatch>(1);
+        drop(in_tx); // closes the passthrough loop's input immediately
+
+        let config = TcpTransportConfig {
+            reconnect_attempts: 5,
+            reconnect_backoff_ms: 2000,
+            ..TcpTransportConfig::default()
+        };
+
+        let start = Instant::now();
+        let handle = spawn_tcp_bridge(
+            0,
+            in_rx,
+            out_tx,
+            config,
+            dummy_listener,
+            BridgeAddr::Tcp(dead_addr),
+            Some(breaker),
+        );
+        handle.join().expect("bridge thread panicked");
+
+        // 5 attempts * 2s backoff would take >=10s if the open breaker weren't
+        // honored; a healthy short-circuit finishes in well under a second.
+        assert!(
+            start.elapsed() < Duration::from_millis(1500),
+            "open circuit breaker should skip connection attempts entirely, took {:?}",
+            start.elapsed()
         );
     }
 }

--- a/crates/ghostlink-core/src/system_profile.rs
+++ b/crates/ghostlink-core/src/system_profile.rs
@@ -795,40 +795,40 @@ fn detect_gpus(mode: ProbeMode) -> Vec<GpuInfo> {
         return vec![gpu];
     }
 
-    // Platform-specific probes
+    // Platform-specific probes with timeout for subprocess calls
     let mut gpus = Vec::new();
 
-    // nvidia-smi (cross-platform)
-    if let Some(result) = probe_nvidia_smi() {
+    // nvidia-smi (cross-platform, with timeout)
+    if let Some(result) = probe_nvidia_smi_with_timeout() {
         gpus.extend(result);
     }
 
-    // rocm-smi (Linux, feature-gated)
+    // rocm-smi (Linux, feature-gated, with timeout)
     #[cfg(feature = "rocm")]
-    if let Some(result) = probe_rocm_smi() {
+    if let Some(result) = probe_rocm_smi_with_timeout() {
         gpus.extend(result);
     }
 
-    // Windows WMI (fallback for non-NVIDIA GPUs)
+    // Windows WMI (fallback for non-NVIDIA GPUs, with timeout)
     #[cfg(target_os = "windows")]
     if gpus.is_empty() {
-        if let Some(result) = probe_windows_wmi_gpu() {
+        if let Some(result) = probe_windows_wmi_gpu_with_timeout() {
             gpus.extend(result);
         }
     }
 
-    // Linux lspci (fallback, no VRAM info)
+    // Linux lspci (fallback, no VRAM info, with timeout)
     #[cfg(target_os = "linux")]
     if gpus.is_empty() {
-        if let Some(gpu) = probe_lspci_gpu() {
+        if let Some(gpu) = probe_lspci_gpu_with_timeout() {
             gpus.push(gpu);
         }
     }
 
-    // macOS system_profiler
+    // macOS system_profiler (with timeout)
     #[cfg(target_os = "macos")]
     if gpus.is_empty() {
-        if let Some(gpu) = probe_macos_gpu() {
+        if let Some(gpu) = probe_macos_gpu_with_timeout() {
             gpus.push(gpu);
         }
     }
@@ -841,9 +841,9 @@ fn detect_gpus(mode: ProbeMode) -> Vec<GpuInfo> {
         }
     }
 
-    // Vulkan probe (cross-platform, full mode only to avoid slowdown)
+    // Vulkan probe (cross-platform, full mode only to avoid slowdown, with timeout)
     if mode == ProbeMode::Full && gpus.is_empty() {
-        if let Some(gpu) = probe_vulkan_gpu() {
+        if let Some(gpu) = probe_vulkan_gpu_with_timeout() {
             gpus.push(gpu);
         }
     }
@@ -865,6 +865,62 @@ fn detect_gpus(mode: ProbeMode) -> Vec<GpuInfo> {
     }
 
     gpus
+}
+
+/// Runs `probe` on a detached background thread and waits up to `timeout`
+/// for a result, returning as soon as it's ready rather than always blocking
+/// for the full duration — `std::thread::scope` can't do this: it implicitly
+/// joins every spawned thread before returning, so wrapping a probe in a
+/// scope and then sleeping for the timeout duration blocks for that full
+/// duration on *every* call, fast or slow, and still hangs forever on a
+/// genuinely stuck probe (the earlier bug this replaces). Rust has no way to
+/// forcibly kill a thread, so a probe that's still running past `timeout` is
+/// abandoned: the background thread runs to completion on its own time and
+/// its late result is silently dropped when `rx` goes out of scope.
+fn probe_with_timeout<T, F>(timeout: Duration, probe: F) -> Option<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Option<T> + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(probe());
+    });
+    rx.recv_timeout(timeout).ok().flatten()
+}
+
+/// Timeout-wrapped GPU probe: nvidia-smi with 5-second timeout
+fn probe_nvidia_smi_with_timeout() -> Option<Vec<GpuInfo>> {
+    probe_with_timeout(Duration::from_millis(5000), probe_nvidia_smi)
+}
+
+/// Timeout-wrapped GPU probe: rocm-smi with 5-second timeout
+#[cfg(feature = "rocm")]
+fn probe_rocm_smi_with_timeout() -> Option<Vec<GpuInfo>> {
+    probe_with_timeout(Duration::from_millis(5000), probe_rocm_smi)
+}
+
+/// Timeout-wrapped GPU probe: Windows WMI with 5-second timeout
+#[cfg(target_os = "windows")]
+fn probe_windows_wmi_gpu_with_timeout() -> Option<Vec<GpuInfo>> {
+    probe_with_timeout(Duration::from_millis(5000), probe_windows_wmi_gpu)
+}
+
+/// Timeout-wrapped GPU probe: lspci with 5-second timeout
+#[cfg(target_os = "linux")]
+fn probe_lspci_gpu_with_timeout() -> Option<GpuInfo> {
+    probe_with_timeout(Duration::from_millis(5000), probe_lspci_gpu)
+}
+
+/// Timeout-wrapped GPU probe: macOS system_profiler with 5-second timeout
+#[cfg(target_os = "macos")]
+fn probe_macos_gpu_with_timeout() -> Option<GpuInfo> {
+    probe_with_timeout(Duration::from_millis(5000), probe_macos_gpu)
+}
+
+/// Timeout-wrapped GPU probe: Vulkan with 10-second timeout (slower probe)
+fn probe_vulkan_gpu_with_timeout() -> Option<GpuInfo> {
+    probe_with_timeout(Duration::from_millis(10000), probe_vulkan_gpu)
 }
 
 fn detect_gpu_from_env() -> Option<GpuInfo> {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,462 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ghostlink — distributed inference fabric for custom LLM systems</title>
+<meta name="description" content="Zero-config distributed inference across heterogeneous LAN hardware — CPU, GPU, and NPU. Self-hosted, open-source, single binary.">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>👻</text></svg>">
+<style>
+  :root {
+    --bg: #0b0d12;
+    --bg-alt: #12151d;
+    --card: #161a24;
+    --border: #262b38;
+    --text: #e7e9ee;
+    --text-dim: #9aa1b2;
+    --accent: #8b7cf6;
+    --accent-2: #22d3ee;
+    --accent-soft: rgba(139, 124, 246, 0.14);
+    --good: #34d399;
+    --warn: #fbbf24;
+    --code-bg: #0d1017;
+    --max-w: 1080px;
+  }
+
+  * { box-sizing: border-box; }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  code, pre, .mono {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  }
+
+  a { color: var(--accent-2); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  .wrap { max-width: var(--max-w); margin: 0 auto; padding: 0 24px; }
+
+  /* ---------- Nav ---------- */
+  nav.top {
+    position: sticky; top: 0; z-index: 20;
+    background: rgba(11, 13, 18, 0.85);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--border);
+  }
+  nav.top .wrap {
+    display: flex; align-items: center; justify-content: space-between;
+    padding-top: 14px; padding-bottom: 14px;
+  }
+  .brand { display: flex; align-items: center; gap: 10px; font-weight: 700; font-size: 1.05rem; color: var(--text); }
+  .brand .ghost { font-size: 1.3rem; }
+  nav.top .links { display: flex; gap: 20px; align-items: center; font-size: 0.92rem; }
+  nav.top .links a { color: var(--text-dim); }
+  nav.top .links a:hover { color: var(--text); text-decoration: none; }
+  .btn-gh {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 6px 12px; border-radius: 8px;
+    border: 1px solid var(--border); color: var(--text) !important;
+  }
+  .btn-gh:hover { border-color: var(--accent); text-decoration: none; }
+
+  /* ---------- Hero ---------- */
+  header.hero { padding: 76px 0 48px; text-align: center; }
+  header.hero .eyebrow {
+    display: inline-block; font-size: 0.78rem; letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--accent-2); background: var(--accent-soft); border: 1px solid rgba(139,124,246,0.35);
+    padding: 5px 12px; border-radius: 999px; margin-bottom: 22px;
+  }
+  header.hero h1 {
+    font-size: clamp(2.2rem, 5vw, 3.4rem);
+    margin: 0 0 18px;
+    letter-spacing: -0.02em;
+  }
+  header.hero .tagline {
+    max-width: 700px; margin: 0 auto 34px;
+    color: var(--text-dim); font-size: 1.15rem;
+  }
+  .cta-row { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-bottom: 40px; }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 12px 22px; border-radius: 10px; font-weight: 600; font-size: 0.95rem;
+    border: 1px solid transparent; transition: transform 0.15s ease, opacity 0.15s ease;
+  }
+  .btn:hover { text-decoration: none; transform: translateY(-1px); }
+  .btn-primary { background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #0b0d12 !important; }
+  .btn-secondary { background: var(--card); border-color: var(--border); color: var(--text) !important; }
+
+  .badges { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
+  .badge {
+    font-size: 0.72rem; padding: 4px 10px; border-radius: 999px;
+    border: 1px solid var(--border); color: var(--text-dim); background: var(--bg-alt);
+  }
+
+  /* ---------- Sections ---------- */
+  section { padding: 56px 0; border-top: 1px solid var(--border); }
+  section h2 {
+    font-size: 1.6rem; margin: 0 0 10px; letter-spacing: -0.01em;
+  }
+  section .lede { color: var(--text-dim); max-width: 720px; margin: 0 0 32px; }
+
+  /* ---------- Demo ---------- */
+  .demo-frame {
+    border: 1px solid var(--border); border-radius: 14px; overflow: hidden;
+    background: var(--bg-alt);
+  }
+  .demo-frame img { display: block; width: 100%; height: auto; }
+  .demo-caption { color: var(--text-dim); font-size: 0.88rem; margin-top: 14px; text-align: center; }
+
+  /* ---------- Feature grid ---------- */
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; }
+  .card {
+    background: var(--card); border: 1px solid var(--border); border-radius: 12px;
+    padding: 20px;
+  }
+  .card h3 { margin: 0 0 8px; font-size: 1.02rem; }
+  .card p { margin: 0; color: var(--text-dim); font-size: 0.92rem; }
+
+  /* ---------- Comparison table ---------- */
+  .table-scroll { overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; }
+  table { border-collapse: collapse; width: 100%; min-width: 640px; font-size: 0.9rem; }
+  th, td { text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--text-dim); font-weight: 600; background: var(--bg-alt); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.04em; }
+  tr:last-child td { border-bottom: none; }
+  tr.highlight td { background: var(--accent-soft); }
+  tr.highlight td:first-child { font-weight: 700; color: var(--text); }
+
+  /* ---------- Quick start ---------- */
+  .tabs { display: flex; gap: 8px; margin-bottom: 14px; }
+  .tab-btn {
+    background: var(--card); border: 1px solid var(--border); color: var(--text-dim);
+    padding: 8px 16px; border-radius: 8px; font-size: 0.86rem; cursor: pointer;
+    font-family: inherit;
+  }
+  .tab-btn.active { color: var(--text); border-color: var(--accent); background: var(--accent-soft); }
+  pre.code-block {
+    background: var(--code-bg); border: 1px solid var(--border); border-radius: 12px;
+    padding: 18px 20px; overflow-x: auto; font-size: 0.86rem; margin: 0;
+  }
+  pre.code-block code { color: #d6e0ff; }
+  .code-comment { color: #6b7280; }
+  .tab-panel { display: none; }
+  .tab-panel.active { display: block; }
+
+  /* ---------- Hardware table ---------- */
+  .accel-yes { color: var(--good); }
+  .accel-no { color: var(--text-dim); }
+  .accel-partial { color: var(--warn); }
+
+  /* ---------- Docs grid ---------- */
+  .docs-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; }
+  .doc-link {
+    display: block; background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+    padding: 14px 16px; color: var(--text) !important;
+  }
+  .doc-link:hover { border-color: var(--accent); text-decoration: none; }
+  .doc-link .name { font-weight: 600; font-size: 0.92rem; }
+  .doc-link .desc { color: var(--text-dim); font-size: 0.82rem; margin-top: 4px; }
+
+  footer { padding: 40px 0 60px; text-align: center; color: var(--text-dim); font-size: 0.85rem; }
+  footer a { color: var(--text-dim); }
+  footer .foot-links { display: flex; gap: 18px; justify-content: center; margin-bottom: 16px; flex-wrap: wrap; }
+
+  @media (max-width: 640px) {
+    nav.top .links { display: none; }
+    header.hero { padding: 52px 0 36px; }
+  }
+</style>
+</head>
+<body>
+
+<nav class="top">
+  <div class="wrap">
+    <div class="brand"><span class="ghost">👻</span> Ghostlink</div>
+    <div class="links">
+      <a href="#what">What it brings</a>
+      <a href="#compare">Comparison</a>
+      <a href="#quickstart">Quick Start</a>
+      <a href="#docs">Docs</a>
+      <a class="btn-gh" href="https://github.com/rwilliamspbg-ops/Ghostlink" target="_blank" rel="noopener">GitHub ↗</a>
+    </div>
+  </div>
+</nav>
+
+<header class="hero">
+  <div class="wrap">
+    <span class="eyebrow">v1.16.0 · MIT licensed · self-hosted</span>
+    <h1>Distributed inference fabric<br>for custom LLM systems</h1>
+    <p class="tagline">
+      Point Ghostlink at every machine on your LAN and it becomes one inference cluster —
+      correctly sized, authenticated, and observable — with zero YAML and no manual
+      <code>--rpc</code> flags.
+    </p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="#quickstart">Quick Start</a>
+      <a class="btn btn-secondary" href="https://github.com/rwilliamspbg-ops/Ghostlink" target="_blank" rel="noopener">View on GitHub</a>
+      <a class="btn btn-secondary" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/ARCHITECTURE.md" target="_blank" rel="noopener">Architecture</a>
+    </div>
+    <div class="badges">
+      <span class="badge">Windows · Linux · macOS</span>
+      <span class="badge">Rust 2021</span>
+      <span class="badge">CPU / GPU / NPU</span>
+      <span class="badge">MIT License</span>
+    </div>
+  </div>
+</header>
+
+<section id="demo">
+  <div class="wrap">
+    <h2>Install → load a model → chat</h2>
+    <p class="lede">
+      End to end, running <a href="https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct" target="_blank" rel="noopener">Llama 3.2 1B</a>
+      locally through Ghostlink's native llama.cpp backend.
+    </p>
+    <div class="demo-frame">
+      <img src="assets/demo/ghostlink-walkthrough.gif" alt="Ghostlink Studio walkthrough — loading Llama 3.2 1B and chatting with it" loading="lazy">
+    </div>
+    <p class="demo-caption">The full-length recording (with audio) is available in the project repo.</p>
+  </div>
+</section>
+
+<section id="what">
+  <div class="wrap">
+    <h2>What Ghostlink brings</h2>
+    <p class="lede">
+      Nobody else combines zero-config discovery of heterogeneous consumer/prosumer
+      hardware with real distributed inference across it.
+    </p>
+    <div class="grid">
+      <div class="card">
+        <h3>Real cross-machine inference</h3>
+        <p>Opt in a node's spare GPU/CPU and a request automatically splits across it via llama.cpp's own RPC backend — zero-config, no manual <code>--rpc</code> flags.</p>
+      </div>
+      <div class="card">
+        <h3>Hardware-aware placement</h3>
+        <p>Layer assignment across mixed compute environments (CPU, GPU, NPU), sized from each node's actually-detected VRAM and compute capability.</p>
+      </div>
+      <div class="card">
+        <h3>Sub-microsecond transport</h3>
+        <p>SPSC ring-buffer transport with spin-wait for in-process hand-off, plus TCP and Unix domain socket transport for multi-process pipelines.</p>
+      </div>
+      <div class="card">
+        <h3>Zero-config discovery</h3>
+        <p>UDP broadcast and mDNS cluster discovery find every Ghostlink instance on the LAN automatically — no manual peer configuration.</p>
+      </div>
+      <div class="card">
+        <h3>Production-grade auth</h3>
+        <p>Session-level authentication on transport frames, bearer-token API auth, optional PQC-hybrid TLS, and rate limiting on the control-plane gateway.</p>
+      </div>
+      <div class="card">
+        <h3>In-GUI code editor</h3>
+        <p>Monaco-based Editor tab with copilot-style Explain/Fix/Refactor, diff preview before anything is written, multi-file refactor, and repo-aware chat via local RAG indexing.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="compare">
+  <div class="wrap">
+    <h2>Where Ghostlink fits</h2>
+    <p class="lede">
+      See <a href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/COMPARISON.md" target="_blank" rel="noopener">docs/COMPARISON.md</a>
+      for the full breakdown and <a href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/BENCHMARKS.md" target="_blank" rel="noopener">docs/BENCHMARKS.md</a>
+      for real measured runs, not just prose.
+    </p>
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr><th>Platform</th><th>Best for</th><th>Weakness Ghostlink addresses</th></tr>
+        </thead>
+        <tbody>
+          <tr class="highlight">
+            <td>Ghostlink</td>
+            <td>Zero-config distributed inference across heterogeneous LAN hardware</td>
+            <td>Early-stage ecosystem; LAN only, no relay/WAN mode yet</td>
+          </tr>
+          <tr>
+            <td>vLLM / TensorRT-LLM</td>
+            <td>Datacenter-grade single/multi-GPU serving</td>
+            <td>Assumes homogeneous, co-located GPUs; no zero-config LAN clustering</td>
+          </tr>
+          <tr>
+            <td>Ollama</td>
+            <td>Single-node local model serving</td>
+            <td>No real multi-node distribution; no cluster discovery</td>
+          </tr>
+          <tr>
+            <td>LM Studio</td>
+            <td>Desktop-first local chat/inference</td>
+            <td>Single machine only, closed-source, not API-extensible</td>
+          </tr>
+          <tr>
+            <td>llama.cpp server</td>
+            <td>Lightweight single-binary inference</td>
+            <td>No orchestration, discovery, or cluster layer — Ghostlink wraps this as a backend</td>
+          </tr>
+          <tr>
+            <td>Kubernetes-based (KServe, Triton)</td>
+            <td>Large fleets, org-wide model serving</td>
+            <td>Needs a cluster and an ops team — overkill for a household/small-team LAN</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section id="quickstart">
+  <div class="wrap">
+    <h2>Quick Start</h2>
+    <p class="lede">Three commands, one launcher, no manual service wiring.</p>
+
+    <div class="tabs">
+      <button class="tab-btn active" data-tab="windows">Windows</button>
+      <button class="tab-btn" data-tab="unix">Linux / macOS</button>
+    </div>
+
+    <div class="tab-panel active" id="tab-windows">
+      <pre class="code-block"><code><span class="code-comment"># Requires: Rust, Node.js, CMake, Git</span>
+git clone https://github.com/rwilliamspbg-ops/Ghostlink.git
+cd Ghostlink
+
+<span class="code-comment"># One-time backend build</span>
+cargo build --release -p ghost-link
+
+<span class="code-comment"># Single launcher for the full stack</span>
+.\launch.bat</code></pre>
+    </div>
+    <div class="tab-panel" id="tab-unix">
+      <pre class="code-block"><code><span class="code-comment"># Requires: Rust, Node.js, curl (cmake optional)</span>
+git clone https://github.com/rwilliamspbg-ops/Ghostlink.git
+cd Ghostlink
+
+cargo build --release -p ghost-link
+./launch.sh</code></pre>
+    </div>
+
+    <p class="lede" style="margin-top: 20px;">
+      This starts llama-server (inference), the Ghostlink API, a Go control-plane gateway,
+      and the React frontend at <code>http://127.0.0.1:5173</code> — opened automatically.
+      Then: <strong>Models</strong> → load a model → <strong>Chat</strong>.
+      Full walkthrough in the <a href="https://github.com/rwilliamspbg-ops/Ghostlink#quick-start" target="_blank" rel="noopener">README</a>.
+    </p>
+  </div>
+</section>
+
+<section id="hardware">
+  <div class="wrap">
+    <h2>Hardware detection</h2>
+    <p class="lede">
+      Auto-detects available accelerators at startup — grounded in
+      <a href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/crates/ghostlink-core/src/system_profile.rs" target="_blank" rel="noopener"><code>system_profile.rs</code></a>.
+    </p>
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr><th>Accelerator</th><th>Windows</th><th>Linux</th><th>macOS</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>CUDA (NVIDIA)</td><td class="accel-yes">✓</td><td class="accel-yes">✓</td><td class="accel-partial">partial</td></tr>
+          <tr><td>DirectML (AMD iGPU, Intel ARC, any DX12)</td><td class="accel-yes">✓</td><td class="accel-no">—</td><td class="accel-no">—</td></tr>
+          <tr><td>ROCm (AMD discrete)</td><td class="accel-no">—</td><td class="accel-yes">✓ (feature flag)</td><td class="accel-no">—</td></tr>
+          <tr><td>Vulkan (generic fallback)</td><td class="accel-yes">✓</td><td class="accel-yes">✓</td><td class="accel-yes">✓</td></tr>
+          <tr><td>Metal (Apple Silicon)</td><td class="accel-no">—</td><td class="accel-no">—</td><td class="accel-yes">✓</td></tr>
+          <tr><td>NPU (AMD XDNA, Intel, Qualcomm)</td><td class="accel-yes">✓</td><td class="accel-yes">✓</td><td class="accel-partial">Neural Engine</td></tr>
+          <tr><td>CPU</td><td class="accel-yes">✓</td><td class="accel-yes">✓</td><td class="accel-yes">✓</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<section id="docs">
+  <div class="wrap">
+    <h2>Documentation</h2>
+    <p class="lede">Rendered on GitHub for the best reading experience.</p>
+    <div class="docs-grid">
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/ARCHITECTURE.md" target="_blank" rel="noopener">
+        <div class="name">Architecture</div>
+        <div class="desc">Request/cluster-flow diagram</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/QUICKSTART.md" target="_blank" rel="noopener">
+        <div class="name">Quickstart</div>
+        <div class="desc">Guided setup walkthrough</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/API_REFERENCE.md" target="_blank" rel="noopener">
+        <div class="name">API Reference</div>
+        <div class="desc">Request/response examples</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/openapi.yaml" target="_blank" rel="noopener">
+        <div class="name">OpenAPI Spec</div>
+        <div class="desc">Machine-readable API spec</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/BENCHMARKS.md" target="_blank" rel="noopener">
+        <div class="name">Benchmarks</div>
+        <div class="desc">Real, reproducible numbers</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/COMPARISON.md" target="_blank" rel="noopener">
+        <div class="name">Comparison</div>
+        <div class="desc">vs. vLLM, Ollama, LM Studio, K8s</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/SECURITY_MODEL.md" target="_blank" rel="noopener">
+        <div class="name">Security Model</div>
+        <div class="desc">Auth, PQC-hybrid TLS, trust boundaries</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/DEPLOYMENT.md" target="_blank" rel="noopener">
+        <div class="name">Deployment</div>
+        <div class="desc">Production deployment guide</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/TROUBLESHOOTING.md" target="_blank" rel="noopener">
+        <div class="name">Troubleshooting</div>
+        <div class="desc">Common issues and fixes</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/ROADMAP.md" target="_blank" rel="noopener">
+        <div class="name">Roadmap</div>
+        <div class="desc">Competitive strategy & what's next</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/CHANGELOG.md" target="_blank" rel="noopener">
+        <div class="name">Changelog</div>
+        <div class="desc">Release history</div>
+      </a>
+      <a class="doc-link" href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">
+        <div class="name">Contributing</div>
+        <div class="desc">Setup, PR expectations, release rubric</div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-links">
+      <a href="https://github.com/rwilliamspbg-ops/Ghostlink" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+      <a href="https://github.com/rwilliamspbg-ops/Ghostlink/issues" target="_blank" rel="noopener">Issues</a>
+      <a href="https://github.com/sponsors/rwilliamspbg-ops" target="_blank" rel="noopener">Sponsor</a>
+    </div>
+    <div>Ghostlink is an open-source distributed inference fabric, self-hosted and MIT licensed.</div>
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll('.tab-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      document.querySelectorAll('.tab-btn').forEach(function (b) { b.classList.remove('active'); });
+      document.querySelectorAll('.tab-panel').forEach(function (p) { p.classList.remove('active'); });
+      btn.classList.add('active');
+      document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/ghostlink_gui_modern/package-lock.json
+++ b/ghostlink_gui_modern/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostlink-studio-gui",
-  "version": "1.3.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostlink-studio-gui",
-      "version": "1.3.0",
+      "version": "1.16.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "axios": "^1.6.0",

--- a/ghostlink_gui_modern/package.json
+++ b/ghostlink_gui_modern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostlink-studio-gui",
-  "version": "1.3.0",
+  "version": "1.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ghostlink_gui_modern/vite.config.ts
+++ b/ghostlink_gui_modern/vite.config.ts
@@ -11,7 +11,34 @@ export default defineConfig({
   // node_modules/.monaco) instead of the CDN @monaco-editor/react defaults
   // to — Ghostlink is local-first everywhere else, so the Editor tab's code
   // editor shouldn't be the one piece that silently needs internet access.
-  plugins: [react(), monacoEditorEsmPlugin()],
+  //
+  // vite-plugin-monaco-editor-esm's built-in worker list hardcodes each
+  // entry with a "monaco-editor/esm/vs/..." path (languageWork.js) and feeds
+  // it straight to esbuild. monaco-editor >=0.53 ships a package.json
+  // "exports" map — "./*": "./esm/vs/*.js" — so esbuild now resolves
+  // subpaths strictly through that map instead of probing the filesystem;
+  // requesting the already-prefixed "esm/vs/editor/editor.worker" subpath
+  // re-applies the map's own "esm/vs/" prefix, doubling it to
+  // "esm/vs/esm/vs/editor/editor.worker.js", which doesn't exist ("Could
+  // not resolve" at both build and dev time). The plugin has had no release
+  // since (2.0.2 is latest) and there's no option to fix individual built-in
+  // entries, only to replace the whole worker list — so disable the broken
+  // defaults (`languageWorkers: []`) and resupply the same 5 workers via
+  // `customWorkers` with the "esm/vs/" prefix stripped, which the exports
+  // map re-adds itself and resolves to the real on-disk file.
+  plugins: [
+    react(),
+    monacoEditorEsmPlugin({
+      languageWorkers: [],
+      customWorkers: [
+        { label: 'editorWorkerService', entry: 'monaco-editor/editor/editor.worker' },
+        { label: 'css', entry: 'monaco-editor/language/css/css.worker' },
+        { label: 'html', entry: 'monaco-editor/language/html/html.worker' },
+        { label: 'json', entry: 'monaco-editor/language/json/json.worker' },
+        { label: 'typescript', entry: 'monaco-editor/language/typescript/ts.worker' },
+      ],
+    }),
+  ],
   resolve: {
     alias: [
       // vite-plugin-monaco-editor-esm hardcodes worker entry points as


### PR DESCRIPTION
## Summary

A prior work session left the repo with a broken `README.md`, several unwired "performance" modules carrying unverified/fabricated claims, a real GPU-probe timeout regression, and 18 root-level session-artifact docs that violated the repo's own `.gitignore` convention ("never commit session artifacts"). This PR reviews, fixes, and cleans that up into an honest `v1.16.0` release.

### Fixed
- **GPU-probe timeout regression** (`system_profile.rs`): the `probe_*_with_timeout` wrappers unconditionally slept the full 5-10s before checking if the probe had already finished — guaranteed minimum latency instead of an actual timeout. Replaced with a real bounded wait (detached thread + `mpsc::recv_timeout`). Full detection now completes in ~1.5s typical (verified) instead of a hard floor.
- **GUI production build was broken**: `vite-plugin-monaco-editor-esm`'s hardcoded worker paths double-prefix against `monaco-editor`'s package.json `"exports"` map ("Could not resolve"). This is the exact `npm run build` step `release-artifacts.yml` runs as a hard CI gate — a tag push would have failed CI outright. Fixed in `vite.config.ts` by resupplying the same 5 workers via `customWorkers` with the broken prefix stripped.

### Added — wired into real call sites, not left as dead code
- `circuit_breaker`: 3-state (Closed/Open/Half-Open) breaker with jittered backoff, wired into the TCP transport bridge's reconnect loop (`runtime::spawn_tcp_bridge`) via a new per-node registry on `ClusterState`. Also fixed a real thundering-herd race in `should_attempt()` (every concurrent caller got probe-approved in `HalfOpen`) — verified with a 16-thread concurrency test.
- `api_response_cache`: TTL+ETag cache wired into `GET /api/models`, which previously ran a real `fs::read_dir`/`fs::metadata` disk scan on every request. Explicitly invalidated on model download/delete, not just TTL-bound.
- `LayerKvCache::write_kv_batch`: single-lock-acquisition batched writes, validated atomically upfront (restored 6 tests this session's diff had deleted, including the only concurrency test).

### Removed
- Three modules from the same prior session didn't hold up under review and were cut: a churn coalescer duplicating `ClusterState`'s existing lock-free snapshot cache, an MCP "server pool" solving a subprocess-spawn cost the real MCP client (`mcp/registry.rs`, persistent connections) doesn't have, and a protocol buffer pool targeting `DiscoveryFrame::encode()`, which already encodes into a stack buffer on a low-frequency path. Plus an orphaned test file and bench file that never compiled/ran, and 18 root-level docs with inflated/fabricated claims (one cited a `discovery.rs` feature that was never actually written — zero diff on that file).
- Restored `README.md`, which had been completely overwritten with an internal report index.

### Version
Bumped `ghost-link`, `ghostlink-core`, and the GUI package to `1.16.0` — brings the crate versions back in sync with the actual last published release (`v1.15.1`); they'd drifted to `1.3.0`.

### GitHub Pages
Added `docs/index.html` — the live Pages site had no index page and 404'd at root (`deploy-pages.yml` uploads `docs/` raw, no Jekyll). Browser-verified: renders correctly, responsive on mobile, no console errors.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (172 ghostlink-core + 139 ghost-link + all integration tests)
- [x] `cd control-plane && go test ./...`
- [x] `cd ghostlink_gui_modern && npm run test` (142 tests)
- [x] `cd ghostlink_gui_modern && npm run build`
- [x] `docs/index.html` browser-verified (desktop + mobile, tab interactivity, no console errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)