### PR TITLE
fix(ci): install Go toolchain in release-artifacts.yml before go test

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -22,6 +22,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-go@v7
+        with:
+          go-version: stable
       - uses: actions/setup-node@v7
         with:
           node-version: '20'


### PR DESCRIPTION
## Summary

`release-artifacts.yml`'s "Run release validation gates" step runs `cd control-plane && go test ./...` but never sets up a Go toolchain — unlike `ci.yml`'s Go job, which does (`actions/setup-go@v7`). This only surfaced now because `release-artifacts.yml` only triggers on `push: tags: v*`, so no PR check ever exercised it — the `v1.16.0` tag push was the first real run.

Both matrix legs failed at the same step, two different symptoms of the same missing-toolchain root cause:
- **macos-latest**: `go: command not found` (exit 127) — no Go available on that runner image at all.
- **windows-latest**: got further (Go must be preinstalled there) but hit a transient TLS handshake timeout fetching a module from `proxy.golang.org` — plausible on any runner without Go's module cache warmed by a real `setup-go` step.

(Note: PR #237, merged just before this one, was titled "Fix macOS release artifact build failure in CI workflow" but only contains Copilot's empty "Initial plan" placeholder commit — no actual diff. This PR is the real fix.)

## Fix

Added `actions/setup-go@v7` with `go-version: stable` right after the Rust toolchain setup, matching the already-working pattern in `ci.yml`'s Go job exactly.

## Test plan

- [x] Diff reviewed against `ci.yml`'s working Go job for pattern consistency
- [ ] Next `release-artifacts.yml` run (re-tagging, since the `v1.16.0` tag's binaries never published) should pass the Go test step on all three OSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)