### PR TITLE
release: v1.16.1 — CI fix only (release-artifacts.yml), no feature bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.16.1] - 2026-08-05 (CI fix: release-artifacts.yml release build)
+
+### Fixed
+
+- `release-artifacts.yml`'s "Run release validation gates" step runs `cd control-plane && go test ./...` but never installed a Go toolchain first (unlike `ci.yml`'s Go job, which does). This only surfaced when the `v1.16.0` tag push exercised the workflow for real for the first time — it only triggers on `push: tags: v*`, so no PR check had ever run it. Both matrix legs failed: `macos-latest` with `go: command not found` (no Go on that runner image at all), `windows-latest` with a transient TLS handshake timeout fetching a Go module (plausible without a real `setup-go` step warming the module cache). Fixed by adding `actions/setup-go@v7` with `go-version: stable`, matching the already-working pattern in `ci.yml`.
+- No functional code changes — this release exists solely to get `v1.16.0`'s actual content (see below) published with working release binaries. `v1.16.0` itself published successfully to crates.io; it just never got a GitHub Release with binaries attached.
+
+This patch is cut from the commit immediately after the CI fix landed on `main`, before later unrelated work (an LLM-shaped benchmarking suite) merged — it carries `v1.16.0`'s code unchanged plus only this workflow fix, not that follow-on feature work.
+
+---
+
 ## [1.16.0] - 2026-08-05 (Reliability fixes: GPU probe timeout, TCP circuit breaker, model-list caching)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-link"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "ghostlink-core"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
 [![MSRV](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/msrv.yml/badge.svg)](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/msrv.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/Docs-GitHub%20Pages-0ea5e9)](https://rwilliamspbg-ops.github.io/Ghostlink/)
-[![Version](https://img.shields.io/badge/version-1.16.0-blueviolet)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.16.1-blueviolet)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust)](Cargo.toml)
 [![Platforms](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-lightgrey)](#quick-start)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghost-link"
-version = "1.16.0"
+version = "1.16.1"
 edition = "2021"
 authors = ["Ryan K Williams"]
 description = "CLI and API runtime for Ghostlink, a distributed inference fabric for routing and scheduling custom LLM workloads across heterogeneous hardware."
@@ -21,7 +21,7 @@ cuda = []
 rocm = ["ghostlink-core/rocm"]
 
 [dependencies]
-ghostlink-core = { path = "../ghostlink-core", version = "1.16.0" }
+ghostlink-core = { path = "../ghostlink-core", version = "1.16.1" }
 
 # Local date/time for the assistant system prompt
 chrono = "0.4"

--- a/crates/ghostlink-core/Cargo.toml
+++ b/crates/ghostlink-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghostlink-core"
-version = "1.16.0"
+version = "1.16.1"
 edition = "2021"
 authors = ["Ryan K Williams"]
 description = "Core runtime primitives for Ghostlink, including planning, routing, health monitoring, and transport logic for distributed inference workloads."

--- a/ghostlink_gui_modern/package-lock.json
+++ b/ghostlink_gui_modern/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostlink-studio-gui",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostlink-studio-gui",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "axios": "^1.6.0",

--- a/ghostlink_gui_modern/package.json
+++ b/ghostlink_gui_modern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostlink-studio-gui",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

`v1.16.0`'s tag push revealed `release-artifacts.yml` never installed a Go toolchain before running `go test`, so **no GitHub Release with binaries was ever published** for that tag (crates.io publish succeeded independently via `publish-crates.yml` and needs no changes). The fix (adding `actions/setup-go@v7`) already merged to `main` via #238.

This PR bumps the version to `v1.16.1` and is **intentionally based on the commit right after #238 merged** (`505ec7a`), *before* the separately-scoped LLM-shaped benchmarking suite (#239) merged on top of it. That means:
- `v1.16.1`'s code is `v1.16.0` unchanged, plus only the CI workflow fix.
- The benchmark suite (new `TcpTransportConfig`/`ExecutionResult` fields, `ray_transfer_baseline.py`, etc.) is **not** bundled into this release — it's already on `main` and will ship in a future version when that's decided separately, not folded in here as a side effect of fixing CI.

Diff here is just the version bump (`Cargo.toml` x2, `package.json`, `README.md` badge, `CHANGELOG.md` entry) — the workflow fix itself is already on `main`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] `cd control-plane && go test ./...`
- [x] `cd ghostlink_gui_modern && npm run test`

After merge: tag `v1.16.1` on this merge commit and push, which triggers `release-artifacts.yml` (now fixed) and `publish-crates.yml` for real this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)