### PR TITLE
🎨 Palette: Improved Command Palette discoverability & correct New Chat shortcut badge

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal
 
+## 2026-08-05 - [Sidebar Search Button & Shortcut Badges]
+**Learning:** Displaying incorrect hotkey badges in primary UI controls (such as labeling "New Chat" with "Ctrl+K" instead of "Ctrl+Shift+O") confuses power users and misrepresents keyboard capability. Additionally, hidden features (like a global Command Palette) are significantly more accessible and discoverable when represented by a clear, dedicated visual trigger button in main navigation menus. Custom programmatic event systems with active focus restoration allow seamless visual triggers without losing screen-reader context.
+**Action:** Always provide dedicated visual trigger buttons for hidden features like command palettes, label shortcut badges precisely, and use custom window events with focus restoration to trigger them smoothly.
+
 ## 2026-08-04 - [Settings Safety and Accessibility Controls]
 **Learning:** Destructive utility actions in complex dashboards (like resetting runtime configurations) that are positioned directly adjacent to primary actions (like Save) must be guarded with descriptive titles and modal confirmation dialogs (`window.confirm`) to prevent catastrophic data loss. Furthermore, inputs, sliders, and buttons must utilize explicit high-contrast focus rings (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) to ensure keyboard navigatees have complete visual tracking on dark-theme UI layers.
 **Action:** Always secure configuration reset triggers with clear, modal confirmation prompts, native informational tooltips, and high-visibility keyboard focus state rings.

--- a/ghostlink_gui_modern/src/App.tsx
+++ b/ghostlink_gui_modern/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Plus, ChevronRight, Menu, Cpu, Zap, Wifi } from 'lucide-react';
+import { Plus, ChevronRight, Menu, Cpu, Zap, Wifi, Search } from 'lucide-react';
 import { useAppStore } from './store';
 import { GhostlinkAPI } from './api';
 import { ChatTab } from './components/ChatTab';
@@ -263,13 +263,30 @@ function App() {
                 closeSidebarOnMobile();
               }
             }}
-            className="flex items-center justify-between w-full p-3 bg-slate-800 hover:bg-slate-700 rounded-xl transition mb-6 group"
+            title="Start a new chat session (Ctrl+Shift+O)"
+            aria-label="Start a new chat"
+            className="flex items-center justify-between w-full p-3 bg-slate-800 hover:bg-slate-700 rounded-xl transition mb-2 group focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
           >
             <div className="flex items-center gap-3">
               <Plus size={18} className="text-slate-400 group-hover:text-white" aria-hidden="true" />
               <span className="text-sm font-medium">New Chat</span>
             </div>
-            <div className="text-[10px] text-slate-500 bg-slate-950 px-1.5 py-0.5 rounded border border-slate-700" title="Open the command palette">Ctrl K</div>
+            <div className="text-[10px] text-slate-500 bg-slate-950 px-1.5 py-0.5 rounded border border-slate-700" title="Shortcut for New Chat">Ctrl⇧O</div>
+          </button>
+
+          <button
+            onClick={() => {
+              window.dispatchEvent(new CustomEvent('open-command-palette'));
+            }}
+            title="Search commands (Ctrl+K)"
+            aria-label="Search and run commands"
+            className="flex items-center justify-between w-full p-3 bg-slate-800/40 hover:bg-slate-800 border border-slate-800/60 rounded-xl transition mb-6 group focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+          >
+            <div className="flex items-center gap-3">
+              <Search size={18} className="text-slate-500 group-hover:text-slate-300" aria-hidden="true" />
+              <span className="text-sm font-medium text-slate-400 group-hover:text-slate-200">Search commands...</span>
+            </div>
+            <div className="text-[10px] text-slate-500 bg-slate-950 px-1.5 py-0.5 rounded border border-slate-700" title="Shortcut for Command Palette">Ctrl K</div>
           </button>
 
           <nav className="flex-1 space-y-1" aria-label="Primary">

--- a/ghostlink_gui_modern/src/components/CommandPalette.tsx
+++ b/ghostlink_gui_modern/src/components/CommandPalette.tsx
@@ -87,7 +87,7 @@ export const CommandPalette: React.FC = () => {
     setHighlight(0);
   }, [query, open]);
 
-  // Global keyboard shortcuts — the only place any of these are wired up.
+  // Global keyboard shortcuts & custom trigger events — the only place any of these are wired up.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
@@ -114,8 +114,18 @@ export const CommandPalette: React.FC = () => {
         }
       }
     };
+    const handleOpenPalette = () => {
+      setOpen((o) => {
+        if (!o) triggerRef.current = document.activeElement as HTMLElement;
+        return true;
+      });
+    };
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    window.addEventListener('open-command-palette', handleOpenPalette);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('open-command-palette', handleOpenPalette);
+    };
   }, [setActiveTab, setChatMessages]);
 
   useEffect(() => {


### PR DESCRIPTION
### 🎨 Palette: Dedicated Command Palette Search Button & Correct New Chat Shortcut Badge

#### 💡 What
- Introduced a highly-accessible 'Search commands...' button in the primary sidebar navigation. This provides a visible entry point for the Command Palette, which was previously discoverable only via the `Ctrl+K` key binding.
- Corrected the 'New Chat' button's shortcut label/badge from `Ctrl K` to the actual hotkey `Ctrl⇧O` (`Ctrl+Shift+O`), as designated in `CommandPalette.tsx`.
- Implemented a custom programmatic event listener (`'open-command-palette'`) within `CommandPalette.tsx` to handle the sidebar click triggers and cleanly manage focus restoration.

#### 🎯 Why
- **Discoverability**: Power features like global command palettes shouldn't be entirely invisible to users who don't know the exact keyboard shortcuts. A visual trigger in the navigation menu promotes easy feature onboarding.
- **Accuracy**: Labeling the New Chat button with `Ctrl K` misled users since pressing `Ctrl K` actually triggered the Command Palette. Correcting it to `Ctrl⇧O` (and labeling the new Search button as `Ctrl K`) ensures absolute clarity.
- **Accessibility**: All buttons use explicit, high-contrast custom focus-visible classes (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`), descriptive tooltips (`title`), and proper semantic `aria-label` tags.

#### ♿ Accessibility
- Added `aria-label="Start a new chat"` to the New Chat button.
- Added `aria-label="Search and run commands"` to the Search button.
- Explicitly styled elements with `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none` so keyboard navigators have high visual feedback.

---
*PR created automatically by Jules for task [3610210795894597316](https://jules.google.com/task/3610210795894597316) started by @rwilliamspbg-ops*