### PR TITLE
feat: control-plane serves the built GUI standalone; bundle it into releases

### DIFF
--- a/control-plane/main.go
+++ b/control-plane/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -115,7 +116,7 @@ func envInt(key string, def int) int {
 // against a fake backend instead of a hand-rolled subset of it. apiKey may
 // be empty (see auth.Middleware) — auth still applies via the proxy
 // forwarding Authorization through to ghost-link either way.
-func buildHandler(backendURL string, rateLimit int, rateWindow time.Duration, apiKey string) http.Handler {
+func buildHandler(backendURL string, rateLimit int, rateWindow time.Duration, apiKey string, guiDistDir string) http.Handler {
 	chatProxy := proxy.NewChatProxy(backendURL)
 	authToken := controlPlaneAuthToken()
 	withAuth := func(next http.HandlerFunc) http.HandlerFunc {
@@ -151,12 +152,39 @@ func buildHandler(backendURL string, rateLimit int, rateWindow time.Duration, ap
 	// MCP, metrics — proxies straight through to ghost-link's real backend.
 	mux.HandleFunc("/api/", withAuth(chatProxy.HandleBackendProxy))
 
+	// Serve the built GUI (ghostlink_gui_modern's `npm run build` output) for
+	// everything else, so a release binary can run standalone without `npm
+	// run dev` (which needs Node at runtime, not just at build time). Only
+	// registered when the directory is actually present — the normal dev
+	// flow (Vite serving the GUI on its own port) has no gui/dist at all, and
+	// must keep 404ing "/" exactly as before rather than serving a stale or
+	// nonexistent tree. The GUI has no client-side router (no react-router
+	// dependency), so a plain file server with no SPA fallback is correct —
+	// every route the GUI shows is client-state, not a distinct URL.
+	if guiDistDir != "" {
+		if info, err := os.Stat(guiDistDir); err == nil && info.IsDir() {
+			mux.Handle("/", http.FileServer(http.Dir(guiDistDir)))
+		}
+	}
+
 	// auth runs inside cors (cors already fully short-circuits OPTIONS
 	// preflight before reaching anything wrapped inside it, so ordering
 	// relative to preflight isn't in question here) and outside the rate
 	// limiter, so an unauthenticated request gets rejected before it
 	// consumes any of a client's rate-limit budget.
 	return loggingMiddleware(corsMiddleware(auth.Middleware(apiKey)(limiter.Middleware(mux))))
+}
+
+// defaultGuiDistDir resolves gui/dist next to the running binary — matching
+// scripts/release_bundle.sh's layout ($OUT_DIR/control-plane(.exe) sitting
+// beside $OUT_DIR/gui/dist) — rather than relative to the process's cwd,
+// which varies depending on how the binary is launched.
+func defaultGuiDistDir() string {
+	exePath, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(exePath), "gui", "dist")
 }
 
 func main() {
@@ -183,11 +211,21 @@ func main() {
 		apiKey = ""
 	}
 
-	handler := buildHandler(backendURL, rateLimit, time.Duration(rateWindowSec)*time.Second, apiKey)
+	guiDistDir := os.Getenv("GHOSTLINK_GUI_DIST_DIR")
+	if guiDistDir == "" {
+		guiDistDir = defaultGuiDistDir()
+	}
+
+	handler := buildHandler(backendURL, rateLimit, time.Duration(rateWindowSec)*time.Second, apiKey, guiDistDir)
 
 	log.Printf("Ghostlink Control Plane starting on :%s", port)
 	log.Printf("Proxying GUI/API routes to backend: %s", backendURL)
 	log.Printf("Rate limit: %d requests / %ds per client", rateLimit, rateWindowSec)
+	if info, err := os.Stat(guiDistDir); err == nil && info.IsDir() {
+		log.Printf("Serving built GUI from: %s", guiDistDir)
+	} else {
+		log.Printf("No built GUI found at %s — run the Vite dev server for the GUI, or `npm run build` + set GHOSTLINK_GUI_DIST_DIR for a standalone binary", guiDistDir)
+	}
 	if err := http.ListenAndServe(":"+port, handler); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}

--- a/control-plane/main_test.go
+++ b/control-plane/main_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHealthEndpoint(t *testing.T) {
-	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "")
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "", "")
 
 	req := httptest.NewRequest("GET", "/health", nil)
 	w := httptest.NewRecorder()
@@ -37,7 +37,7 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestHealthRejectsPost(t *testing.T) {
-	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "")
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "", "")
 
 	req := httptest.NewRequest("POST", "/health", nil)
 	w := httptest.NewRecorder()
@@ -58,7 +58,7 @@ func TestWorkersProxiesToBackend(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	handler := buildHandler(backend.URL, 1000, time.Second, "")
+	handler := buildHandler(backend.URL, 1000, time.Second, "", "")
 
 	req := httptest.NewRequest("GET", "/api/workers", nil)
 	w := httptest.NewRecorder()
@@ -78,7 +78,7 @@ func TestWorkersProxiesToBackend(t *testing.T) {
 }
 
 func TestCORSHeaders(t *testing.T) {
-	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "")
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "", "")
 
 	req := httptest.NewRequest("OPTIONS", "/api/models", nil)
 	w := httptest.NewRecorder()
@@ -98,7 +98,7 @@ func TestRateLimitingBlocksExcessRequests(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	handler := buildHandler(backend.URL, 2, time.Minute, "")
+	handler := buildHandler(backend.URL, 2, time.Minute, "", "")
 
 	makeReq := func() int {
 		req := httptest.NewRequest("GET", "/health", nil)
@@ -120,7 +120,7 @@ func TestRateLimitingBlocksExcessRequests(t *testing.T) {
 }
 
 func TestRateLimitingIsolatesByClient(t *testing.T) {
-	handler := buildHandler("http://127.0.0.1:19999", 1, time.Minute, "")
+	handler := buildHandler("http://127.0.0.1:19999", 1, time.Minute, "", "")
 
 	req1 := httptest.NewRequest("GET", "/health", nil)
 	req1.RemoteAddr = "10.0.0.1:1111"
@@ -152,7 +152,7 @@ func TestStreamingResponsesAreFlushed(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	handler := buildHandler(backend.URL, 1000, time.Second, "")
+	handler := buildHandler(backend.URL, 1000, time.Second, "", "")
 
 	req := httptest.NewRequest("POST", "/api/inference/chat", nil)
 	w := httptest.NewRecorder()
@@ -184,7 +184,7 @@ func TestControlPlaneMutationsRequireBearerToken(t *testing.T) {
 	}))
 	defer backend.Close()
 
-	handler := buildHandler(backend.URL, 1000, time.Second, "")
+	handler := buildHandler(backend.URL, 1000, time.Second, "", "")
 
 	body := []byte(`{"id":"secured-node"}`)
 	createReq := httptest.NewRequest("POST", "/api/workers", bytes.NewReader(body))
@@ -243,5 +243,37 @@ func TestControlPlaneTokenFallbackUsesDiscoveryToken(t *testing.T) {
 
 	if got := controlPlaneAuthToken(); got != token {
 		t.Fatalf("expected discovery token fallback, got %q", got)
+	}
+}
+
+func TestServesBuiltGUIWhenDistDirPresent(t *testing.T) {
+	distDir := t.TempDir()
+	if err := os.WriteFile(distDir+"/index.html", []byte("<html>ghostlink studio</html>"), 0o644); err != nil {
+		t.Fatalf("write fixture index.html: %v", err)
+	}
+
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "", distDir)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 serving built GUI, got %d", w.Code)
+	}
+	if w.Body.String() != "<html>ghostlink studio</html>" {
+		t.Fatalf("expected fixture index.html content, got %q", w.Body.String())
+	}
+}
+
+func TestNoStaticServingWhenDistDirAbsent(t *testing.T) {
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "", "/nonexistent/gui/dist")
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when no built GUI is present (dev flow unaffected), got %d", w.Code)
 	}
 }

--- a/scripts/release_bundle.sh
+++ b/scripts/release_bundle.sh
@@ -41,13 +41,26 @@ fi
 
 if [[ -n "$PLATFORM_SUFFIX" ]]; then
   BIN_NAME="ghost-link-${PLATFORM_SUFFIX}${SRC_EXT}"
+  CP_BIN_NAME="control-plane-${PLATFORM_SUFFIX}${SRC_EXT}"
   SUMS_NAME="SHA256SUMS-${PLATFORM_SUFFIX}"
 else
   BIN_NAME="ghost-link${SRC_EXT}"
+  CP_BIN_NAME="control-plane${SRC_EXT}"
   SUMS_NAME="SHA256SUMS"
 fi
 
 cp "$SRC_BIN" "$OUT_DIR/$BIN_NAME"
+
+GO_BIN="$(command -v go || true)"
+if [[ -z "$GO_BIN" ]]; then
+  echo "go is required to build the control-plane release binary" >&2
+  exit 1
+fi
+
+echo "[release] build control-plane release binary"
+pushd "$ROOT_DIR/control-plane" >/dev/null
+"$GO_BIN" build -o "$OUT_DIR/$CP_BIN_NAME" .
+popd >/dev/null
 
 echo "[release] build ghostlink_gui_modern frontend"
 pushd "$ROOT_DIR/ghostlink_gui_modern" >/dev/null
@@ -57,6 +70,11 @@ fi
 "$NPM_BIN" run build
 popd >/dev/null
 
+# gui/dist sits next to both binaries above — control-plane's
+# defaultGuiDistDir() (control-plane/main.go) resolves it relative to its own
+# executable's directory, so this layout is what lets a standalone release
+# binary serve the built GUI without Node at runtime (see that file's
+# comments for why nothing served this before).
 mkdir -p "$OUT_DIR/gui"
 cp -R "$ROOT_DIR/ghostlink_gui_modern/dist" "$OUT_DIR/gui/"
 


### PR DESCRIPTION
## Summary

Found this while scoping a real one-click installer: **nothing in the stack actually serves `ghostlink_gui_modern`'s production build.** The GUI only works today via `npm run dev` (needs Node at runtime). `scripts/release_bundle.sh` already bundles `gui/dist` into every GitHub Release, but ghost-link only serves the API, and control-plane (the Go gateway fronting everything) had no static-file route — it only ever proxied. The release binaries were already inert on arrival for anyone who doesn't also have Node installed.

This is the actual blocker underneath "no one-click installer" — a perfectly packaged installer still couldn't show you a GUI without also shipping Node.

## Changes

- **`control-plane/main.go`**: `buildHandler` now takes a `guiDistDir` and serves it on `/` via `http.FileServer` when that directory exists — guarded by `os.Stat` so the dev flow (Vite owns the GUI, no `gui/dist` present) is byte-for-byte unaffected. No SPA fallback needed: the GUI has no `react-router` dependency, it's tab/state-driven. Default path resolves next to `control-plane`'s own executable (`os.Executable()`, not cwd) — override with `GHOSTLINK_GUI_DIST_DIR` for dev.
- **`control-plane/main_test.go`**: updated the 8 existing `buildHandler(...)` call sites for the new param, added 2 tests (serves real `index.html` when present; still 404s when absent).
- **`scripts/release_bundle.sh`**: now also builds and bundles `control-plane(.exe)` next to `ghost-link(.exe)` and the same `gui/dist` it already copied.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all clean.
- Ran `release_bundle.sh` end-to-end locally (unsigned mode), then actually started the produced `control-plane` binary against a fake backend:
  - `GET /health` → 200
  - `GET /` → 200, real built `index.html`
  - `GET /assets/<real-chunk>.js` → 200
  - Log line confirms it auto-found `gui/dist` next to itself, zero config.

## What this doesn't do yet

Still no real `.msi`/`.dmg`/`.AppImage`. That needs `llama-server` bundled too — which GPU backend(s) to ship per platform (Vulkan/CUDA/Metal/CPU) is a product decision, not just plumbing — plus an actual installer/launcher wrapper. This PR closes the piece that made an installer pointless until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)