### PR TITLE
style(ring): fix rustfmt violation from SPSC batching optimization

### DIFF
--- a/crates/ghostlink-core/src/ring.rs
+++ b/crates/ghostlink-core/src/ring.rs
@@ -373,7 +373,11 @@ impl<T> SpscRingBuffer<T> {
             let second_chunk = count - first_chunk;
             unsafe {
                 std::ptr::copy_nonoverlapping(slice.as_ptr(), buf_ptr.add(start), first_chunk);
-                std::ptr::copy_nonoverlapping(slice.as_ptr().add(first_chunk), buf_ptr, second_chunk);
+                std::ptr::copy_nonoverlapping(
+                    slice.as_ptr().add(first_chunk),
+                    buf_ptr,
+                    second_chunk,
+                );
             }
         }
         let new_tail = tail.wrapping_add(count) & mask;


### PR DESCRIPTION
## Summary

Main is currently red on **Production Gate** since PR #253 (SPSC ring buffer `copy_nonoverlapping` batching optimization) merged without running through `rustfmt` first.

## Root cause

`push_batch`'s new split-write path in `crates/ghostlink-core/src/ring.rs:373` — the second `copy_nonoverlapping` call for the wrap-around case — exceeds rustfmt's line width and needs to be broken across multiple lines. Production Gate's "Rust Source Parse Check" step runs `rustfmt --check` directly against the diff and fails on it:

```
Diff in .../crates/ghostlink-core/src/ring.rs:373:
-                std::ptr::copy_nonoverlapping(slice.as_ptr().add(first_chunk), buf_ptr, second_chunk);
+                std::ptr::copy_nonoverlapping(
+                    slice.as_ptr().add(first_chunk),
+                    buf_ptr,
+                    second_chunk,
+                );
```

## Fix

`cargo fmt --all` on the affected file. **Pure formatting, zero logic change.**

## Verification

- `cargo fmt --all --check` — clean.
- `cargo build --release -p ghostlink-core` — clean.
- `cargo test -p ghostlink-core ring::` — all 13 tests pass, including `handles_wrap_around_correctly` and `push_pop_batch_round_trip_spsc`, which exercise this exact two-chunk copy path introduced by #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)