### PR TITLE
🎨 Palette: Enhance MetricsTab keyboard focus visible styles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal
 
+## 2026-08-07 - [Metrics Tab Header Accessibility]
+**Learning:** Live monitoring headers often contain specialized quick-action buttons (like Export CSV and Manual Refresh) that lack text labels to keep the dashboard visual design minimal. While they have correct `aria-label` and `title` attributes, they must also be styled with customized, high-contrast focus rings (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) to preserve keyboard navigation. Without explicit indicators, users tabbing through live performance monitors will lose their selection completely, severely degrading the accessibility of critical dashboard features.
+**Action:** Always complement icon-only action triggers in live monitors and charts with explicit focus rings to guarantee seamless, visual keyboard tracking.
+
 ## 2026-08-06 - [Workspace & Editor Tab Keyboard Navigation]
 **Learning:** Development environments and files workspaces (such as the Editor tab with its file tree checkbox selectors, expandable folders, workspace-level toggles, and edit actions) need high-visibility focus indicator rings (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`). Relying on default browser focus states in dark-themed, nested pane designs leaves keyboard-only navigators or assistive technology users completely lost, unable to determine which button, input, or checkbox is currently active.
 **Action:** Ensure all workspace file checkboxes, file/folder tree nodes, editor action triggers, and diff confirmation buttons are styled with explicit, high-contrast focus visible styles to maintain continuous keyboard-accessible visual feedback.

--- a/ghostlink_gui_modern/src/components/MetricsTab.tsx
+++ b/ghostlink_gui_modern/src/components/MetricsTab.tsx
@@ -165,7 +165,7 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
           <button
             onClick={exportMetricsCsv}
             disabled={metricsHistory.length === 0}
-            className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition disabled:opacity-30 disabled:hover:bg-transparent"
+            className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition disabled:opacity-30 disabled:hover:bg-transparent focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             title="Export metrics history as CSV"
             aria-label="Export metrics history as CSV"
           >
@@ -173,7 +173,7 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
           </button>
           <button
             onClick={refreshMetrics}
-            className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition"
+            className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             title="Refresh metrics"
             aria-label="Refresh metrics"
           >


### PR DESCRIPTION
### 🎨 Palette: Enhance MetricsTab keyboard focus visible styles

#### 💡 What
Added explicit custom focus-visible styling (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) to the Export CSV and Refresh Metrics action buttons in the header of `MetricsTab.tsx`.

#### 🎯 Why
Icon-only actions in the System Performance dashboard lacked high-contrast focus indicators under default styles, rendering them invisible to keyboard-only and assistive technology users tabbing through the interface. This resolves the visual accessibility gap completely.

#### ♿ Accessibility
Ensures visual focus states are prominent and compliant with standard keyboard-navigation accessibility guidelines on the live monitors.

#### 📝 Documentation
Documented the learning and action item in `.jules/palette.md`.

---
*PR created automatically by Jules for task [9292078647934953331](https://jules.google.com/task/9292078647934953331) started by @rwilliamspbg-ops*