### PR TITLE
v1.17.0: real distributed-inference testing, three bug fixes, RPC allowlist, install script, JS SDK

### DIFF
--- a/.github/workflows/distributed-e2e.yml
+++ b/.github/workflows/distributed-e2e.yml
@@ -1,0 +1,104 @@
+name: Distributed E2E (RPC Fabric)
+
+# Regression gate for Ghostlink's real distributed-inference feature
+# (llama.cpp's ggml-rpc backend — crates/ghost-link/src/rpc_cluster.rs).
+# Builds docker-compose.rpc-fabric.yml (a contributor node + a coordinator
+# node on an isolated bridge network), then runs
+# scripts/rpc_fabric_assert.py, which proves — not just asserts node
+# count — that a real chat completion executed across both containers:
+# UDP discovery found the peer, the coordinator built --rpc/-ts flags with
+# zero manual input, a real chat completion came back with
+# real_inference: true, and the contributor's own ggml-rpc-server log shows
+# it actually accepted a connection. See docs/ROADMAP.md's Horizon 1 #1 —
+# this is the CI test that section calls for.
+#
+# Path-filtered like production-gate.yml: this does a from-source llama.cpp
+# build (several minutes) so it only runs when something that could plausibly
+# break the distributed path actually changed, plus on every push to main
+# and on manual dispatch.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/ghost-link/src/rpc_cluster.rs'
+      - 'crates/ghost-link/src/native_engine.rs'
+      - 'crates/ghost-link/src/main.rs'
+      - 'crates/ghostlink-core/src/discovery.rs'
+      - 'crates/ghostlink-core/src/cluster.rs'
+      - 'crates/ghostlink-core/src/mdns.rs'
+      - 'crates/ghostlink-core/src/protocol.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile.rpc-fabric'
+      - 'docker-compose.rpc-fabric.yml'
+      - 'scripts/rpc_fabric_entrypoint.sh'
+      - 'scripts/rpc_fabric_assert.py'
+      - '.github/workflows/distributed-e2e.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/ghost-link/src/rpc_cluster.rs'
+      - 'crates/ghost-link/src/native_engine.rs'
+      - 'crates/ghost-link/src/main.rs'
+      - 'crates/ghostlink-core/src/discovery.rs'
+      - 'crates/ghostlink-core/src/cluster.rs'
+      - 'crates/ghostlink-core/src/mdns.rs'
+      - 'crates/ghostlink-core/src/protocol.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile.rpc-fabric'
+      - 'docker-compose.rpc-fabric.yml'
+      - 'scripts/rpc_fabric_entrypoint.sh'
+      - 'scripts/rpc_fabric_assert.py'
+      - '.github/workflows/distributed-e2e.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: distributed-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  distributed-e2e:
+    name: Distributed E2E (RPC Fabric)
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install assertion script dependencies
+        run: pip install requests urllib3
+
+      - name: Build fabric images
+        run: docker compose -f docker-compose.rpc-fabric.yml build
+
+      - name: Start fabric
+        run: |
+          docker compose -f docker-compose.rpc-fabric.yml up -d --wait --wait-timeout 300
+
+      - name: Run distributed-inference assertion
+        run: python3 scripts/rpc_fabric_assert.py
+
+      - name: Dump container logs
+        if: always()
+        run: |
+          mkdir -p ./tmp
+          docker compose -f docker-compose.rpc-fabric.yml logs --no-color rpc-contributor > ./tmp/rpc-contributor.log 2>&1 || true
+          docker compose -f docker-compose.rpc-fabric.yml logs --no-color rpc-coordinator > ./tmp/rpc-coordinator.log 2>&1 || true
+          docker exec ghostlink-rpc-contributor cat /tmp/ggml-rpc-server.log > ./tmp/ggml-rpc-server.log 2>&1 || true
+
+      - name: Upload fabric logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: distributed-e2e-logs
+          path: ./tmp/*.log
+          retention-days: 14
+
+      - name: Tear down fabric
+        if: always()
+        run: docker compose -f docker-compose.rpc-fabric.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,12 @@ opencode.json
 launch-fast.sh
 models/*.gguf
 models/
+# Downloaded by scripts/rpc_fabric_benchmark.py's own instructions / manual
+# curl (see docs/BENCHMARKS.md's 2026-08-08 Multi-Node Performance entry) —
+# same reasoning as models/*.gguf above, just a different directory name
+# since docker-compose.rpc-fabric-benchmark.yml bind-mounts it in without
+# touching the CI-gate's Dockerfile.rpc-fabric image.
+models-bench/*.gguf
 models.json
 sessions.json
 # Generated on first run — a real per-install secret / self-signed cert,

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ api_key.txt
 tls_cert.pem
 tls_key.pem
 ghostlink_gui_modern/dist/
+sdks/js/node_modules/
+sdks/js/dist/
 
 # mcp_servers.toml is a per-install copy of mcp_servers.example.toml (same
 # pattern as ghostlink.toml/ghostlink.example.toml) — the GUI's MCP tab writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [1.17.0] - 2026-08-08 (Real distributed-inference testing, three bug fixes, RPC allowlist, install script, JS SDK)
+
+### Added
+
+- **Real E2E CI gate for distributed inference** (`.github/workflows/distributed-e2e.yml`, `Dockerfile.rpc-fabric`, `docker-compose.rpc-fabric.yml`, `scripts/rpc_fabric_assert.py`): a two-container Docker fabric proving Ghostlink's `ggml-rpc`-backed distributed inference actually executes across containers (`real_inference: true`, live RPC connection log evidence), not just that peer discovery found a node count.
+- **Real multi-node benchmark harness** (`docker-compose.rpc-fabric-benchmark.yml`, `scripts/rpc_fabric_benchmark.py`), plus extensive real findings from testing on genuinely separate physical hardware documented in `docs/BENCHMARKS.md`: real single-node-vs-distributed throughput comparisons, and — the actual proof this project's roadmap has been chasing — a real 30B-class model that cannot load on one machine alone (`ErrorOutOfDeviceMemory`) loading and serving correctly once split across two real machines.
+- **RPC contributor IP allowlist** (`rpc_allowed_peers` setting, `crates/ghost-link/src/rpc_cluster.rs`): `ggml-rpc-server` has no authentication of its own (an upstream llama.cpp limitation); Ghostlink now optionally fronts it with a Ghostlink-controlled TCP proxy that only forwards connections from allowlisted IPs/CIDR ranges. Empty allowlist (the default) is byte-for-byte the old direct-bind behavior — zero overhead, zero change, for anyone not using the feature.
+- **Version-mismatch detection for RPC peers** (`rpc_build_id` field on `NodeResources`, carried through all three discovery wire paths — the shared binary encoder, `DiscoveryFrame`'s UDP encoder, and mDNS TXT records): a coordinator now refuses to route distributed inference through a peer running a different `llama.cpp` build, closing a real bug found this session where mismatched builds silently corrupted output on larger models while the API reported healthy throughout. Only excludes on a *confirmed* mismatch — a peer that predates this field is still used, so this rolls out without breaking anyone mid-upgrade.
+- **One-line install script** (`scripts/install.sh`, `scripts/install.ps1`): `curl -fsSL .../install.sh | sh` downloads, SHA256-verifies, and installs the real published `ghost-link` release binary — no sudo, no package manager, no Rust toolchain required.
+- **JS/TS client SDK** (`sdks/js/`, package `ghostlink-client`): mirrors `sdks/python`'s shape (`chat.completions.create`, real SSE streaming via `/api/inference/chat`, typed error hierarchy), built on native `fetch`/`ReadableStream`, ships ESM + CJS + `.d.ts`.
+- **Full per-crate READMEs** for all five workspace crates (`ghost-link`, `ghostlink-core`, `mcp-calculator`, `mcp-rag`, `mcp-vision`) — each `Cargo.toml`'s `readme` field now points at its own crate's README instead of the repo-wide root README.
+
+### Fixed
+
+- **Silent output corruption from version-mismatched `ggml-rpc` peers** — see "Added" above; this is the fix, `rpc_build_id` detection is the mechanism.
+- **Unsupervised RPC contributor child process**: `rpc_cluster::ensure_contributing()` already had working respawn logic but was only ever called once at server startup — if the spawned `ggml-rpc-server` child later crashed (e.g. the quantized-KV-cache/RPC-CPU-backend crash found this session), the node kept advertising RPC capability via discovery while actually unreachable. Now called every 30s on a background thread for the process lifetime whenever `contribute_compute` is on.
+- **90-second model-ready timeout too short for real distributed loads**: `native_engine.rs` used a flat 90s health-check budget for both single-node and distributed loads. Real distributed loads measured this session took anywhere from 168s to over 900s depending on model size, all previously aborted as false failures. Now scales to 600s specifically when a load attempt's args include `--rpc`, stays at 90s for single-node; `GHOSTLINK_MODEL_READY_TIMEOUT_SECS` env override for further tuning.
+
+### Changed
+
+- `ghost-link` and `ghostlink-core` bumped `1.16.1` → `1.17.0` (new backward-compatible settings/protocol fields, no breaking changes — a minor bump per semver). `ghostlink_gui_modern`'s `package.json` bumped to match, keeping the whole repo on one coordinated version number.
+
+### Documentation
+
+- `docs/ROADMAP.md` and `docs/BENCHMARKS.md` updated extensively with the real findings above — hardware tables, methodology, honest caveats about what wasn't yet proven (e.g. "usable speed" for the 30B distributed result is not yet there, even though the capacity proof is real).
+
+### Validation
+
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all clean (164 ghost-link + 183 ghostlink-core tests, 0 failures).
+- Real Docker E2E fabric rebuilt and rerun after the allowlist change, confirming zero regression to the existing passing gate.
+- JS SDK: `tsc --noEmit` clean, real `tsup` build (ESM + CJS + `.d.ts`), 17/17 `vitest` tests passing.
+- Install scripts: both actually run end-to-end against the real live `v1.16.1` release (not just syntax-checked) — real binary downloaded, checksum verified against the published `SHA256SUMS`, installed binary executed successfully.
+
 ## [1.16.1] - 2026-08-05 (CI fix: release-artifacts.yml release build)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "ghost-link"
-version = "1.16.1"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "ghostlink-core"
-version = "1.16.1"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Dockerfile.rpc-fabric
+++ b/Dockerfile.rpc-fabric
@@ -1,0 +1,89 @@
+# Docker image for the real distributed-inference RPC fabric test
+# (docker-compose.rpc-fabric.yml). Builds three things:
+#
+#   1. ghost-link / ghostlink-core (same as Dockerfile.ghostlink)
+#   2. llama.cpp's llama-server, built with -DGGML_RPC=ON
+#   3. llama.cpp's ggml-rpc-server (the RPC contributor binary), which only
+#      exists as a build target when GGML_RPC=ON
+#
+# This is a NEW file rather than a modification of Dockerfile.ghostlink,
+# which intentionally stays a plain `cargo build` image.
+
+# ---- Stage 1: Rust build (ghost-link + ghostlink-core) --------------------
+FROM rust:1.88-bookworm AS rust-builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+RUN cargo build --release -p ghost-link -p ghostlink-core
+
+# ---- Stage 2: llama.cpp build, GGML_RPC=ON ---------------------------------
+FROM debian:bookworm AS llama-builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+# Shallow clone: this test fabric only needs current upstream master, not
+# full history. Matches scripts/run_native_llama_server_stack.sh's source.
+RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp.git llama.cpp
+
+# -DGGML_RPC=ON is the flag scripts/run_native_llama_server_stack.sh's cmake
+# recipe does NOT pass (that script builds only llama-server for single-node
+# use). It also produces a second target, `ggml-rpc-server`
+# (third_party/llama.cpp/tools/rpc/CMakeLists.txt: `set(TARGET
+# ggml-rpc-server)`), which is what crates/ghost-link/src/rpc_cluster.rs's
+# get_rpc_server_bin() resolves by default.
+# -DGGML_NATIVE=OFF avoids baking in -march=native, which would tie the
+# resulting binary to this exact build machine's CPU.
+RUN cmake -S llama.cpp -B llama.cpp/build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DGGML_RPC=ON \
+      -DGGML_NATIVE=OFF \
+      -DLLAMA_BUILD_TESTS=OFF \
+      -DLLAMA_BUILD_EXAMPLES=OFF \
+    && cmake --build llama.cpp/build -j"$(nproc)" --target llama-server ggml-rpc-server
+
+# ---- Stage 3: runtime -------------------------------------------------------
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+RUN mkdir -p /app/bin /app/models
+
+COPY --from=rust-builder /build/target/release/ghost-link /app/bin/ghost-link
+# llama-server, ggml-rpc-server, and every ggml/llama shared lib CMake placed
+# alongside them (CMAKE_RUNTIME_OUTPUT_DIRECTORY == CMAKE_LIBRARY_OUTPUT_DIRECTORY
+# == build/bin for this project, see third_party/llama.cpp/CMakeLists.txt).
+COPY --from=llama-builder /src/llama.cpp/build/bin/ /app/bin/
+
+# Tiny, fast CPU-runnable GGUF model already used elsewhere in this repo
+# (scripts/run_native_llama_server_stack.sh) — keeps the build/test cycle
+# fast instead of reaching for a full-size model.
+RUN curl -L --fail -o /app/models/stories15M-q4_0.gguf \
+    https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories15M-q4_0.gguf
+
+COPY scripts/rpc_fabric_entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh /app/bin/ghost-link /app/bin/llama-server /app/bin/ggml-rpc-server
+
+ENV PATH="/app/bin:${PATH}"
+# The build-tree RPATH baked into llama-server/ggml-rpc-server points at the
+# llama-builder stage's absolute path, which doesn't exist in this image —
+# LD_LIBRARY_PATH is the fallback ld.so consults once RPATH resolution misses.
+ENV LD_LIBRARY_PATH="/app/bin"
+
+# GHOSTLINK_RPC_SERVER_BIN / GHOSTLINK_LLAMA_SERVER_BIN: explicit env-var
+# overrides are the first entry in both binaries' resolution order (see
+# rpc_cluster.rs::get_rpc_server_bin and native_engine.rs::get_llama_server_bin)
+# — set directly rather than relying on the relative-path fallback search.
+ENV GHOSTLINK_RPC_SERVER_BIN="/app/bin/ggml-rpc-server"
+ENV GHOSTLINK_LLAMA_SERVER_BIN="/app/bin/llama-server"
+ENV GHOSTLINK_MODEL_PATH="/app/models/stories15M-q4_0.gguf"
+ENV GHOSTLINK_MODELS_DIR="/app/models"
+ENV GHOSTLINK_SETTINGS_PATH="/app/settings.json"
+ENV GHOSTLINK_MODELS_PATH="/app/models.json"
+
+EXPOSE 8003 50052 45885/udp
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
 [![MSRV](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/msrv.yml/badge.svg)](https://github.com/rwilliamspbg-ops/Ghostlink/actions/workflows/msrv.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/Docs-GitHub%20Pages-0ea5e9)](https://rwilliamspbg-ops.github.io/Ghostlink/)
-[![Version](https://img.shields.io/badge/version-1.16.1-blueviolet)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.17.0-blueviolet)](CHANGELOG.md)
 [![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust)](Cargo.toml)
 [![Platforms](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-lightgrey)](#quick-start)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -92,6 +92,53 @@ Use Ghostlink when you need:
 ## Quick Start
 
 Three commands, one launcher, no manual service wiring — `launch.bat` / `launch.sh` builds what's missing, starts every process, and opens the GUI.
+
+### Fastest path: install the binary
+
+No Rust/Node/cmake toolchain needed — this downloads the prebuilt `ghost-link`
+binary from [GitHub Releases](https://github.com/rwilliamspbg-ops/Ghostlink/releases),
+verifies it against the release's published `SHA256SUMS`, and installs it to
+a user-writable directory (no `sudo`/admin required).
+
+**Linux / macOS:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/rwilliamspbg-ops/Ghostlink/main/scripts/install.sh | sh
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/rwilliamspbg-ops/Ghostlink/main/scripts/install.ps1 | iex
+```
+
+Then:
+```bash
+ghost-link --help
+ghost-link doctor --strict         # sanity-check your setup
+ghost-link serve 127.0.0.1 8003    # start the OpenAI-compatible API server
+```
+
+Both scripts accept `VERSION=v1.17.0` (env var) to pin a specific release
+instead of latest, and print PATH guidance if the install directory isn't
+already on it. Source for both lives at
+[`scripts/install.sh`](scripts/install.sh) and
+[`scripts/install.ps1`](scripts/install.ps1) — read them before piping to a
+shell if you'd rather not blind-trust a one-liner, that's a reasonable
+instinct.
+
+**What this does *not* give you**: the Go `control-plane` gateway or the
+built React GUI aren't published as standalone release assets today — only
+the `ghost-link` binary, its checksums, and an SBOM are (see
+[`scripts/release_bundle.sh`](scripts/release_bundle.sh)). The one-line
+install gets you the CLI and OpenAI-compatible API server; for the full
+browser GUI, use the build-from-source or Docker paths below. Release
+binaries are also **x86_64/amd64-only** — there's no arm64 build yet, and
+both scripts detect and refuse non-x86_64 hosts rather than silently
+handing you a binary that won't run.
+
+### Build from source (full stack, including the GUI)
+
+Needed for the browser GUI, local development, or platforms without a
+published release binary.
 
 ### Windows
 

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ghost-link"
-version = "1.16.1"
+version = "1.17.0"
 edition = "2021"
 authors = ["Ryan K Williams"]
 description = "CLI and API runtime for Ghostlink, a distributed inference fabric for routing and scheduling custom LLM workloads across heterogeneous hardware."
 homepage = "https://rwilliamspbg-ops.github.io/Ghostlink/"
 documentation = "https://rwilliamspbg-ops.github.io/Ghostlink/"
 repository = "https://github.com/rwilliamspbg-ops/Ghostlink"
-readme = "../../README.md"
+readme = "README.md"
 license = "MIT"
 keywords = ["networking", "zero-copy", "async", "distributed", "llm"]
 categories = ["asynchronous", "network-programming", "command-line-utilities"]
@@ -21,7 +21,7 @@ cuda = []
 rocm = ["ghostlink-core/rocm"]
 
 [dependencies]
-ghostlink-core = { path = "../ghostlink-core", version = "1.16.1" }
+ghostlink-core = { path = "../ghostlink-core", version = "1.17.0" }
 
 # Local date/time for the assistant system prompt
 chrono = "0.4"

--- a/crates/ghost-link/README.md
+++ b/crates/ghost-link/README.md
@@ -1,0 +1,89 @@
+# ghost-link
+
+CLI and API runtime for [Ghostlink](https://github.com/rwilliamspbg-ops/Ghostlink) — a
+distributed inference fabric that discovers heterogeneous consumer/prosumer hardware on a
+LAN (gaming GPU, old laptop, NPU-equipped ultrabook) and turns it into one inference
+cluster, with zero-config discovery and real cross-machine model sharding.
+
+This crate is the thing you actually run: `ghost-link serve` starts an OpenAI-compatible
+API server; other subcommands cover discovery, diagnostics, and the distributed-inference
+CLI surface. It depends on [`ghostlink-core`](../ghostlink-core) for the underlying
+protocol, planning, and transport primitives.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rwilliamspbg-ops/Ghostlink/main/scripts/install.sh | sh
+```
+
+Or from source: `cargo install --path .` from a checkout of the
+[full repository](https://github.com/rwilliamspbg-ops/Ghostlink) (this crate isn't
+useful installed standalone from crates.io without the rest of the repo's `models/`,
+`ghostlink.toml`, and `third_party/llama.cpp` layout — see the root README's Quick Start).
+
+## What it does
+
+- **`ghost-link serve <host> <port>`** — starts the API server: an OpenAI-compatible
+  surface (`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`)
+  plus Ghostlink's native `/api/*` surface (workers, sessions, settings, metrics, real
+  token-by-token streaming chat). Backed by either a local llama.cpp (`native`), a local
+  Ollama instance (`ollama`), or vLLM, selected via `inference_backend` in settings.
+- **Real distributed inference**, not a demo: when `distributed_inference: true` and
+  another node on the LAN has opted in via `contribute_compute: true`, this node
+  discovers it via UDP broadcast or mDNS (zero manual configuration), computes a
+  VRAM-proportional `--tensor-split`, and launches its local `llama-server` with
+  `--rpc host:port,...` — llama.cpp's own RPC backend (`ggml-rpc`) does the real
+  cross-process tensor execution. See [`rpc_cluster.rs`](src/rpc_cluster.rs) for the
+  implementation and its `SECURITY:` doc comment for what this does and doesn't protect
+  against (an IP allowlist restricts *who* can submit compute jobs; it isn't
+  protocol-level authentication — that's an upstream `ggml-rpc-server` limitation).
+- **`ghost-link probe <node-id> [--full]`** — real hardware detection (CPU, GPU/VRAM,
+  system RAM) for this machine or a named node.
+- **`ghost-link doctor [--strict] [--json <path>]`** — environment/config sanity check.
+- **`ghost-link flow` / `ghost-link stage-worker`** — the earlier synthetic pipeline
+  benchmark harness (ring buffer / TCP transport timing, not real model inference —
+  see `docs/BENCHMARKS.md` in the main repo for why this is a distinct thing from real
+  distributed inference).
+- **`ghost-link dashboard` / `ghost-link gui`** — the terminal dashboard and desktop GUI
+  entry points.
+
+## Settings
+
+Runtime settings live in `settings.json` (path overridable via `GHOSTLINK_SETTINGS_PATH`)
+and cover inference backend selection, model/context sizing, discovery, TLS, and the
+distributed-inference fields (`distributed_inference`, `contribute_compute`, `rpc_port`,
+`rpc_allowed_peers`). Most can also be read/changed live via `GET`/`POST /api/settings`.
+See the root repo's `ghostlink.example.toml` and `docs/QUICKSTART.md` for a worked
+example.
+
+## Feature flags
+
+- `cuda` — CUDA-specific paths.
+- `rocm` — enables `ghostlink-core`'s `rocm` feature (AMD ROCm device support).
+
+## Testing this crate specifically
+
+```bash
+cargo test -p ghost-link
+```
+
+For the real distributed-inference path specifically, see the root repo's
+`docker-compose.rpc-fabric.yml` + `scripts/rpc_fabric_assert.py` (also the CI gate in
+`.github/workflows/distributed-e2e.yml`) — a two-container fabric that proves real
+cross-container inference (`real_inference: true`, live RPC connection log evidence),
+not just that discovery found a peer.
+
+## More
+
+- [Main repository](https://github.com/rwilliamspbg-ops/Ghostlink) — full docs, GUI,
+  Docker Compose stacks, and the rest of the workspace.
+- [`docs/ARCHITECTURE.md`](https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/ARCHITECTURE.md),
+  [`docs/DEPLOYMENT.md`](https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/DEPLOYMENT.md),
+  [`docs/ROADMAP.md`](https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/docs/ROADMAP.md)
+  (competitive strategy + honest status of every distributed-inference claim, including
+  real bugs found via live multi-machine testing).
+
+## License
+
+MIT — see [`LICENSE`](https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/LICENSE) in
+the main repository.

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1783,6 +1783,18 @@ struct RuntimeSettings {
     /// before this field existed.
     #[serde(default = "default_rpc_port")]
     rpc_port: u16,
+    /// IP allowlist for who may submit compute jobs to this node's
+    /// `ggml-rpc-server` (see `rpc_cluster`'s module doc for the full
+    /// security rationale). Accepts plain IPv4 addresses ("10.0.0.29") and
+    /// IPv4 CIDR ranges ("10.0.0.0/24"). Empty (the default) means "allow
+    /// all" — the exact same default-open behavior as before this field
+    /// existed, matching how `contribute_compute` itself defaults to off:
+    /// this is opt-in hardening, not a behavior change for anyone who
+    /// hasn't configured it. `#[serde(default)]` so settings.json files
+    /// saved before this field existed still deserialize (to the
+    /// allow-all empty vec, not full-struct defaults).
+    #[serde(default)]
+    rpc_allowed_peers: Vec<String>,
 }
 
 fn default_rpc_port() -> u16 {
@@ -1853,6 +1865,7 @@ impl Default for RuntimeSettings {
             distributed_inference: false,
             contribute_compute: false,
             rpc_port: default_rpc_port(),
+            rpc_allowed_peers: Vec::new(),
         }
     }
 }
@@ -7933,6 +7946,18 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                             current.rpc_port = v as u16;
                         }
                     }
+                    "rpc_allowed_peers" => {
+                        if let Some(arr) = value.as_array() {
+                            // Same next-restart caveat as contribute_compute/
+                            // rpc_port: the allowlist proxy (if any) is only
+                            // stood up once, at startup, in `rpc_cluster::
+                            // ensure_contributing`.
+                            current.rpc_allowed_peers = arr
+                                .iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect();
+                        }
+                    }
                     "conversation_token_limit" => {
                         if let Some(v) = value.as_u64() {
                             current.conversation_token_limit = v as usize;
@@ -8117,6 +8142,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         .enable_all()
         .build()
         .map_err(|err| anyhow::anyhow!("failed to initialize runtime: {}", err))?;
+    // Cheap to clone (an `Arc`-backed handle into `rt`) and needed by
+    // `rpc_cluster::ensure_contributing` below to spawn its allowlist-proxy
+    // task from contexts that run before `rt.block_on` starts (this call
+    // site, and the periodic-respawn thread below) — `tokio::spawn` alone
+    // requires already being inside a runtime, which neither is.
+    let rt_handle = rt.handle().clone();
 
     // Loaded here (rather than at its previous spot further down) because
     // discovery advertisement below needs `contribute_compute`/`rpc_port`
@@ -8125,7 +8156,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     let mut settings = load_settings();
 
     if settings.contribute_compute {
-        rpc_cluster::ensure_contributing(host, settings.rpc_port);
+        rpc_cluster::ensure_contributing(
+            host,
+            settings.rpc_port,
+            &settings.rpc_allowed_peers,
+            &rt_handle,
+        );
 
         // `ensure_contributing` is already idempotent and already checks
         // child health (a no-op if the contributor is still alive, a
@@ -8140,9 +8176,16 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         // background thread's loop+sleep pattern just below.
         let contribute_host = host.to_string();
         let contribute_port = settings.rpc_port;
+        let contribute_allowed_peers = settings.rpc_allowed_peers.clone();
+        let contribute_rt_handle = rt_handle.clone();
         thread::spawn(move || loop {
             thread::sleep(Duration::from_secs(30));
-            rpc_cluster::ensure_contributing(&contribute_host, contribute_port);
+            rpc_cluster::ensure_contributing(
+                &contribute_host,
+                contribute_port,
+                &contribute_allowed_peers,
+                &contribute_rt_handle,
+            );
         });
     }
     let advertised_node = if settings.contribute_compute {

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -4971,8 +4971,12 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             // when disabled or no qualifying peers, which reproduces
             // single-node behavior exactly.
             let (rpc_servers, tensor_split) = if backend.settings.distributed_inference {
-                let peers =
-                    rpc_cluster::discover_rpc_peers(&backend.cluster, &backend.local_node_id);
+                let local_build_id = native_engine::NativeEngineClient::get_llama_build_id();
+                let peers = rpc_cluster::discover_rpc_peers(
+                    &backend.cluster,
+                    &backend.local_node_id,
+                    local_build_id.as_deref(),
+                );
                 if peers.is_empty() {
                     (None, None)
                 } else {
@@ -8122,12 +8126,41 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
 
     if settings.contribute_compute {
         rpc_cluster::ensure_contributing(host, settings.rpc_port);
+
+        // `ensure_contributing` is already idempotent and already checks
+        // child health (a no-op if the contributor is still alive, a
+        // respawn if it died) — but it was previously only ever called once,
+        // here, at startup. If the spawned `ggml-rpc-server` child later
+        // crashes (a real, confirmed failure mode: quantized KV cache on the
+        // RPC/CPU backend aborting on an unimplemented op — see
+        // `docs/BENCHMARKS.md`'s native two-machine entry), nothing called
+        // `ensure_contributing` again, so it never respawned despite the
+        // function itself already knowing how. Poll it periodically for the
+        // lifetime of the process instead, mirroring the UDP-broadcast
+        // background thread's loop+sleep pattern just below.
+        let contribute_host = host.to_string();
+        let contribute_port = settings.rpc_port;
+        thread::spawn(move || loop {
+            thread::sleep(Duration::from_secs(30));
+            rpc_cluster::ensure_contributing(&contribute_host, contribute_port);
+        });
     }
     let advertised_node = if settings.contribute_compute {
-        profile
+        let mut node = profile
             .node_resources
             .clone()
-            .with_rpc_port(settings.rpc_port)
+            .with_rpc_port(settings.rpc_port);
+        // Advertise this node's llama.cpp build fingerprint alongside its RPC
+        // port so peers can refuse to route distributed inference through a
+        // version-mismatched contributor instead of silently corrupting
+        // output (see `rpc_cluster::discover_rpc_peers` and
+        // `docs/BENCHMARKS.md`'s native two-machine entry). Best-effort:
+        // `None` when the binary is missing or unversioned, same as today's
+        // behavior for any peer that predates this field.
+        if let Some(build_id) = native_engine::NativeEngineClient::get_llama_build_id() {
+            node = node.with_rpc_build_id(build_id);
+        }
+        node
     } else {
         profile.node_resources.clone()
     };

--- a/crates/ghost-link/src/native_engine.rs
+++ b/crates/ghost-link/src/native_engine.rs
@@ -55,6 +55,13 @@ pub struct NativeEngineClient {
 // Static variable to track the llama-server process
 static LLAMA_SERVER_PROCESS: OnceLock<Arc<Mutex<Option<Child>>>> = OnceLock::new();
 
+// Cached local llama.cpp build fingerprint (short commit hash from
+// `llama-server --version`). Never changes during a process's lifetime, so
+// shelling out on every discovery/advertisement cycle would be wasteful.
+// `None` means the binary is missing or `--version` failed/was unparsable —
+// see `NativeEngineClient::get_llama_build_id`.
+static LLAMA_BUILD_ID: OnceLock<Option<String>> = OnceLock::new();
+
 impl NativeEngineClient {
     pub fn new() -> Self {
         Self {
@@ -167,6 +174,73 @@ impl NativeEngineClient {
         } else {
             "llama-server".to_string()
         }
+    }
+
+    /// Parse the short commit hash out of `llama-server --version`'s first
+    /// line, e.g. `"version: 1 (da296d6)\nbuilt with MSVC ..."` -> `da296d6`.
+    fn parse_llama_build_id(version_output: &str) -> Option<String> {
+        let first_line = version_output.lines().next()?;
+        let open = first_line.find('(')?;
+        let close = first_line[open..].find(')')? + open;
+        let hash = first_line[open + 1..close].trim();
+        if hash.is_empty() {
+            None
+        } else {
+            Some(hash.to_string())
+        }
+    }
+
+    /// This node's local `llama.cpp` build fingerprint (the short commit hash
+    /// `llama-server --version` prints in parens on its first line), cached
+    /// for the process's lifetime since it never changes at runtime.
+    ///
+    /// Used to detect version-mismatched `ggml-rpc` peers before routing
+    /// distributed inference through them — mismatched builds connect and
+    /// exchange data over `ggml-rpc-server` without complaint, but can
+    /// silently corrupt output for larger models while reporting healthy
+    /// status the whole time (confirmed on real hardware; see
+    /// `docs/BENCHMARKS.md`'s native two-machine entry and
+    /// `rpc_cluster::discover_rpc_peers`).
+    ///
+    /// Best-effort: a missing binary or an unparsable `--version` output
+    /// returns `None` rather than panicking or blocking startup, matching
+    /// this codebase's established pattern for hardware/binary detection.
+    pub fn get_llama_build_id() -> Option<String> {
+        LLAMA_BUILD_ID
+            .get_or_init(|| {
+                let bin = Self::get_llama_server_bin();
+                let output = match Command::new(&bin).arg("--version").output() {
+                    Ok(output) => output,
+                    Err(err) => {
+                        eprintln!(
+                            "[llama-build] Could not run '{bin} --version' to determine build \
+                             fingerprint ({err}); version-mismatch detection for distributed \
+                             inference will be skipped for this node."
+                        );
+                        return None;
+                    }
+                };
+                let combined = format!(
+                    "{}\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                match Self::parse_llama_build_id(&combined) {
+                    Some(build_id) => {
+                        eprintln!("[llama-build] Detected local llama.cpp build: {build_id}");
+                        Some(build_id)
+                    }
+                    None => {
+                        eprintln!(
+                            "[llama-build] '{bin} --version' output didn't contain a \
+                             recognizable build hash; version-mismatch detection for \
+                             distributed inference will be skipped for this node."
+                        );
+                        None
+                    }
+                }
+            })
+            .clone()
     }
 
     /// Raw URL from env/settings (may include `/completion` suffix from launchers).
@@ -376,6 +450,39 @@ impl NativeEngineClient {
             .await
             .map(|r| r.status().is_success())
             .unwrap_or(false)
+    }
+
+    /// Model-ready timeout, in seconds, for a specific `llama-server` launch
+    /// arg set. Real distributed (`--rpc`) loads take far longer than
+    /// single-node loads of the same-sized file — confirmed this session:
+    /// real cross-machine RPC loads took anywhere from 168s to over 900s
+    /// depending on model size, while single-node loads of the same files
+    /// completed comfortably within 90s (see `docs/BENCHMARKS.md`'s native
+    /// two-machine entry). Raising the single-node timeout to match would
+    /// make every single-node failure (e.g. a genuinely broken model file)
+    /// take much longer to report, so the two cases get different defaults
+    /// based on whether `--rpc` is actually present in `args` — the launch's
+    /// own arg set, not a single global flag (this is checked per arg-set
+    /// variant in `load_model_into_slot`'s staging loop, which tries
+    /// multiple variants with/without quantized KV cache).
+    ///
+    /// `GHOSTLINK_MODEL_READY_TIMEOUT_SECS`, when set to a valid positive
+    /// integer, overrides either default so an operator can tune this
+    /// further without a rebuild.
+    fn model_ready_timeout_secs(args: &[String]) -> u64 {
+        if let Ok(val) = std::env::var("GHOSTLINK_MODEL_READY_TIMEOUT_SECS") {
+            if let Ok(n) = val.trim().parse::<u64>() {
+                if n > 0 {
+                    return n;
+                }
+            }
+        }
+        let is_distributed = args.iter().any(|a| a == "--rpc");
+        if is_distributed {
+            600
+        } else {
+            90
+        }
     }
 
     /// Wait for llama-server to become ready. Polls `child`'s exit status
@@ -672,9 +779,10 @@ impl NativeEngineClient {
                 staging_child.id()
             );
 
+            let staging_timeout_secs = Self::model_ready_timeout_secs(args);
             let staged_ready = rt.block_on(Self::wait_for_llama_server_ready(
                 &staging_url,
-                90,
+                staging_timeout_secs,
                 &mut staging_child,
             ));
             let _ = staging_child.kill();
@@ -718,7 +826,12 @@ impl NativeEngineClient {
         let pid = child.id();
         eprintln!("[model-load] Started llama-server with PID: {pid}");
 
-        let ready = rt.block_on(Self::wait_for_llama_server_ready(&base_url, 90, &mut child));
+        let final_timeout_secs = Self::model_ready_timeout_secs(winning_args);
+        let ready = rt.block_on(Self::wait_for_llama_server_ready(
+            &base_url,
+            final_timeout_secs,
+            &mut child,
+        ));
         if let Err(e) = ready {
             let _ = child.kill();
             let _ = child.wait();
@@ -1440,6 +1553,113 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn parse_llama_build_id_extracts_short_hash_from_first_line() {
+        let output = "version: 1 (da296d6)\nbuilt with MSVC 19.50.35725.0 for x64";
+        assert_eq!(
+            NativeEngineClient::parse_llama_build_id(output),
+            Some("da296d6".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_llama_build_id_handles_single_line_output() {
+        assert_eq!(
+            NativeEngineClient::parse_llama_build_id("version: 1 (e920c523e)"),
+            Some("e920c523e".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_llama_build_id_returns_none_without_parens() {
+        assert_eq!(
+            NativeEngineClient::parse_llama_build_id("no version info here"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_llama_build_id_returns_none_on_empty_parens() {
+        assert_eq!(
+            NativeEngineClient::parse_llama_build_id("version: 1 ()"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_llama_build_id_returns_none_on_empty_input() {
+        assert_eq!(NativeEngineClient::parse_llama_build_id(""), None);
+    }
+
+    #[test]
+    fn get_llama_build_id_does_not_panic_when_binary_is_missing() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        // Best-effort: should gracefully return None (or a cached Some from
+        // an earlier test run in this process) rather than panic, even when
+        // no llama-server binary is resolvable in this test environment.
+        let _ = NativeEngineClient::get_llama_build_id();
+    }
+
+    #[test]
+    fn model_ready_timeout_uses_90s_for_single_node_args() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        std::env::remove_var("GHOSTLINK_MODEL_READY_TIMEOUT_SECS");
+        let args = vec!["-fa".to_string()];
+        assert_eq!(NativeEngineClient::model_ready_timeout_secs(&args), 90);
+    }
+
+    #[test]
+    fn model_ready_timeout_uses_600s_when_rpc_flag_present() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        std::env::remove_var("GHOSTLINK_MODEL_READY_TIMEOUT_SECS");
+        let args = vec![
+            "--rpc".to_string(),
+            "10.0.0.29:50052".to_string(),
+            "-ts".to_string(),
+            "3.9990,0.1000".to_string(),
+        ];
+        assert_eq!(NativeEngineClient::model_ready_timeout_secs(&args), 600);
+    }
+
+    #[test]
+    fn model_ready_timeout_env_override_applies_regardless_of_rpc() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        std::env::set_var("GHOSTLINK_MODEL_READY_TIMEOUT_SECS", "45");
+
+        let single_node_args: Vec<String> = vec![];
+        assert_eq!(
+            NativeEngineClient::model_ready_timeout_secs(&single_node_args),
+            45
+        );
+
+        let distributed_args = vec!["--rpc".to_string(), "host:1".to_string()];
+        assert_eq!(
+            NativeEngineClient::model_ready_timeout_secs(&distributed_args),
+            45
+        );
+
+        std::env::remove_var("GHOSTLINK_MODEL_READY_TIMEOUT_SECS");
+    }
+
+    #[test]
+    fn model_ready_timeout_ignores_invalid_or_zero_env_override() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        std::env::set_var("GHOSTLINK_MODEL_READY_TIMEOUT_SECS", "not-a-number");
+        let single_node_args: Vec<String> = vec![];
+        assert_eq!(
+            NativeEngineClient::model_ready_timeout_secs(&single_node_args),
+            90
+        );
+
+        std::env::set_var("GHOSTLINK_MODEL_READY_TIMEOUT_SECS", "0");
+        assert_eq!(
+            NativeEngineClient::model_ready_timeout_secs(&single_node_args),
+            90
+        );
+
+        std::env::remove_var("GHOSTLINK_MODEL_READY_TIMEOUT_SECS");
     }
 
     #[test]

--- a/crates/ghost-link/src/rpc_cluster.rs
+++ b/crates/ghost-link/src/rpc_cluster.rs
@@ -15,16 +15,56 @@
 //!
 //! SECURITY: `ggml-rpc-server` has no built-in authentication — this is
 //! upstream llama.cpp behavior, not a Ghostlink limitation. Anyone who can
-//! reach the port can submit compute to it. Only enable contribution
-//! (`contribute_compute` in settings) on a network you trust, same
+//! reach the port can submit compute to it. `contribute_compute` is off by
+//! default for exactly this reason.
+//!
+//! When it is on, `rpc_allowed_peers` (settings.json) closes the biggest gap
+//! in that: an IP allowlist (plain IPv4 addresses or IPv4 CIDR ranges)
+//! enforced by Ghostlink itself, since the vendored `ggml-rpc-server` binary
+//! has no concept of authentication to patch in. The mechanism is a TCP
+//! proxy (`run_rpc_allowlist_proxy`): `ggml-rpc-server` binds loopback-only
+//! (unreachable from the network directly) and this process listens on the
+//! publicly-advertised `bind_host:port` instead, splicing through only
+//! connections whose source IP passes the allowlist and closing everything
+//! else immediately. Left empty (the default), no proxy is started at all —
+//! `ggml-rpc-server` binds the public address directly, identical to the
+//! behavior before this allowlist existed.
+//!
+//! Be clear-eyed about what this does and doesn't buy: it is real,
+//! meaningful access control — "only these hosts/subnets," not "anyone on
+//! the LAN." It is **not** authentication of the RPC protocol itself. A
+//! device that is itself inside an allowlisted range, or one that can spoof
+//! a source IP on the local network, is not stopped by this. Only enable
+//! `contribute_compute` (allowlisted or not) on a network you trust, same
 //! assumption the existing UDP/mDNS discovery already makes.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
 
+use tokio::io::copy_bidirectional;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::runtime::Handle;
+
 use ghostlink_core::cluster::{ClusterState, NodeStatus};
+
+/// Offset added to the publicly-advertised `rpc_port` to derive the
+/// loopback-only port `ggml-rpc-server` actually binds to when the
+/// allowlist proxy is active. Arbitrary but fixed, so the proxy and
+/// `ggml-rpc-server` agree on it across the periodic respawn-supervision
+/// calls without needing to thread extra state between them.
+/// `saturating_add`ed against the configured port, so a `rpc_port` already
+/// close to `u16::MAX` degrades (a possible port reuse) rather than
+/// overflowing/panicking.
+const RPC_INTERNAL_PORT_OFFSET: u16 = 1000;
+
+/// True once this process has spawned its (single, process-lifetime)
+/// allowlist proxy task. Guards `maybe_start_allowlist_proxy` so the
+/// periodic respawn-supervision loop in `main.rs` (which calls
+/// `ensure_contributing` every 30s) doesn't try to bind the public port a
+/// second time.
+static RPC_ALLOWLIST_PROXY_STARTED: OnceLock<()> = OnceLock::new();
 
 static RPC_CONTRIBUTOR_PROCESS: OnceLock<Arc<Mutex<Option<Child>>>> = OnceLock::new();
 
@@ -87,7 +127,21 @@ pub fn get_rpc_server_bin() -> String {
 /// it. Idempotent — safe to call on every settings load/update. Best-effort:
 /// a failure to start is logged, not fatal, mirroring how UDP/mDNS discovery
 /// failures never block server startup elsewhere in this codebase.
-pub fn ensure_contributing(bind_host: &str, port: u16) {
+///
+/// When `allowed_peers` is non-empty, `ggml-rpc-server` is bound
+/// loopback-only and an allowlist proxy (spawned onto `rt_handle`, since
+/// this function itself isn't async and may be called before the tokio
+/// runtime's `block_on` starts) is stood up on the publicly-advertised
+/// `bind_host:port` in front of it — see this module's top-of-file SECURITY
+/// doc. When `allowed_peers` is empty, `ggml-rpc-server` binds
+/// `bind_host:port` directly, exactly as before this allowlist existed: no
+/// proxy, no extra hop, no behavior change for the default case.
+pub fn ensure_contributing(
+    bind_host: &str,
+    port: u16,
+    allowed_peers: &[String],
+    rt_handle: &Handle,
+) {
     let handle = contributor_handle();
     let mut guard = handle.lock().unwrap_or_else(|p| p.into_inner());
     if let Some(child) = guard.as_mut() {
@@ -96,13 +150,35 @@ pub fn ensure_contributing(bind_host: &str, port: u16) {
         }
     }
 
+    let (spawn_host, spawn_port): (String, u16) = if allowed_peers.is_empty() {
+        (bind_host.to_string(), port)
+    } else {
+        let internal_port = port.saturating_add(RPC_INTERNAL_PORT_OFFSET);
+        maybe_start_allowlist_proxy(bind_host, port, internal_port, allowed_peers, rt_handle);
+        ("127.0.0.1".to_string(), internal_port)
+    };
+
     let bin = get_rpc_server_bin();
-    tracing::warn!(
-        "rpc_cluster: starting ggml-rpc-server on {bind_host}:{port} \u{2014} this exposes local \
-         compute (GPU/CPU) to the network with NO AUTHENTICATION (an upstream llama.cpp \
-         limitation, not Ghostlink's). Only enable contribute_compute on a network you trust, \
-         the same assumption UDP/mDNS discovery already makes."
-    );
+    if allowed_peers.is_empty() {
+        tracing::warn!(
+            "rpc_cluster: starting ggml-rpc-server on {spawn_host}:{spawn_port} \u{2014} this \
+             exposes local compute (GPU/CPU) to the network with NO AUTHENTICATION (an upstream \
+             llama.cpp limitation, not Ghostlink's) and NO IP ALLOWLIST (rpc_allowed_peers is \
+             empty). Only enable contribute_compute on a network you trust, the same assumption \
+             UDP/mDNS discovery already makes. Set rpc_allowed_peers in settings to restrict \
+             which hosts may submit compute jobs."
+        );
+    } else {
+        tracing::warn!(
+            "rpc_cluster: starting ggml-rpc-server on loopback ({spawn_host}:{spawn_port}), \
+             fronted by an allowlist proxy on {bind_host}:{port} restricted to {} \
+             rpc_allowed_peers entries \u{2014} ggml-rpc-server itself still has NO \
+             AUTHENTICATION (an upstream llama.cpp limitation), so this is access control, not \
+             protocol-level auth. A device already inside an allowlisted range isn't stopped by \
+             this.",
+            allowed_peers.len()
+        );
+    }
 
     // ggml-rpc-server's own stdout/stderr (connection/tensor-transfer activity
     // logged by upstream llama.cpp) is discarded by default — matches every
@@ -146,9 +222,9 @@ pub fn ensure_contributing(bind_host: &str, port: u16) {
 
     match Command::new(&bin)
         .arg("-H")
-        .arg(bind_host)
+        .arg(&spawn_host)
         .arg("-p")
-        .arg(port.to_string())
+        .arg(spawn_port.to_string())
         .stdout(stdout_cfg)
         .stderr(stderr_cfg)
         .stdin(Stdio::null())
@@ -178,6 +254,203 @@ pub fn stop_contributing() {
             let _ = child.wait();
         }
     };
+}
+
+/// Spawns the allowlist proxy exactly once per process, the first time
+/// `ensure_contributing` sees a non-empty `allowed_peers`. Guarded by
+/// `RPC_ALLOWLIST_PROXY_STARTED` (only the caller whose `set()` call wins
+/// the race actually spawns) so the periodic respawn-supervision loop's
+/// repeated `ensure_contributing` calls don't try to rebind the public port
+/// every 30s.
+fn maybe_start_allowlist_proxy(
+    bind_host: &str,
+    public_port: u16,
+    internal_port: u16,
+    allowed_peers: &[String],
+    rt_handle: &Handle,
+) {
+    if RPC_ALLOWLIST_PROXY_STARTED.get().is_some() {
+        return;
+    }
+
+    let public_addr_str = format!("{bind_host}:{public_port}");
+    let public_addr: SocketAddr = match public_addr_str.parse() {
+        Ok(addr) => addr,
+        Err(err) => {
+            tracing::warn!(
+                "rpc_cluster: cannot start rpc_allowed_peers proxy \u{2014} invalid bind address \
+                 '{public_addr_str}': {err}. ggml-rpc-server will stay loopback-only and \
+                 unreachable from the network until this is fixed."
+            );
+            return;
+        }
+    };
+    let backend_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), internal_port);
+    let allowed = allowed_peers.to_vec();
+
+    // Only the thread whose `set()` succeeds spawns — race-free without an
+    // extra Mutex, and cheap even under the (practically impossible, given
+    // `ensure_contributing` already serializes callers through its own
+    // `contributor_handle()` lock) case of concurrent first calls.
+    if RPC_ALLOWLIST_PROXY_STARTED.set(()).is_ok() {
+        rt_handle.spawn(async move {
+            if let Err(err) = run_rpc_allowlist_proxy(public_addr, backend_addr, allowed).await {
+                tracing::warn!(
+                    "rpc_cluster: rpc_allowed_peers proxy on {public_addr} exited with error: \
+                     {err} \u{2014} the node will stop accepting distributed-inference compute \
+                     jobs from any peer until this process restarts."
+                );
+            }
+        });
+    }
+}
+
+/// Binds `public_addr` and runs the allowlist proxy forever (see this
+/// module's top-of-file SECURITY doc for the mechanism). Returns only on a
+/// bind failure; a running proxy never returns on its own. Intended to be
+/// spawned as a background task, not awaited to completion.
+async fn run_rpc_allowlist_proxy(
+    public_addr: SocketAddr,
+    backend_addr: SocketAddr,
+    allowed_peers: Vec<String>,
+) -> std::io::Result<()> {
+    let listener = TcpListener::bind(public_addr).await?;
+    tracing::info!(
+        "rpc_cluster: rpc_allowed_peers proxy listening on {public_addr}, forwarding allowed \
+         peers to ggml-rpc-server at {backend_addr} ({} allowlist entries)",
+        allowed_peers.len()
+    );
+    serve_rpc_allowlist_proxy(listener, backend_addr, allowed_peers).await
+}
+
+/// Accept loop shared by `run_rpc_allowlist_proxy` and its tests: for each
+/// inbound connection, checks the peer's source IP against `allowed_peers`
+/// (`ip_allowed`) and either splices it through to `backend_addr` via
+/// `tokio::io::copy_bidirectional`, or drops it immediately with a
+/// `tracing::warn!` naming the rejected IP. Split out from
+/// `run_rpc_allowlist_proxy` so tests can bind an ephemeral loopback port
+/// themselves (avoiding a bind/rebind race) instead of going through a
+/// fixed `SocketAddr`.
+async fn serve_rpc_allowlist_proxy(
+    listener: TcpListener,
+    backend_addr: SocketAddr,
+    allowed_peers: Vec<String>,
+) -> std::io::Result<()> {
+    loop {
+        let (inbound, peer_addr) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(err) => {
+                tracing::warn!("rpc_cluster: rpc_allowed_peers proxy accept() failed: {err}");
+                continue;
+            }
+        };
+
+        if !ip_allowed(&peer_addr.ip(), &allowed_peers) {
+            tracing::warn!(
+                "rpc_cluster: rejected ggml-rpc-server connection from {} \u{2014} not in \
+                 rpc_allowed_peers",
+                peer_addr.ip()
+            );
+            continue; // dropping `inbound` closes the connection
+        }
+
+        tokio::spawn(async move {
+            let mut inbound = inbound;
+            match TcpStream::connect(backend_addr).await {
+                Ok(mut outbound) => {
+                    if let Err(err) = copy_bidirectional(&mut inbound, &mut outbound).await {
+                        tracing::debug!(
+                            "rpc_cluster: proxied connection from {peer_addr} ended: {err}"
+                        );
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "rpc_cluster: rpc_allowed_peers proxy could not reach ggml-rpc-server at \
+                         {backend_addr}: {err} \u{2014} closing connection from {peer_addr}"
+                    );
+                }
+            }
+        });
+    }
+}
+
+/// Checks `ip` against `allowlist` (settings.json's `rpc_allowed_peers`).
+/// Empty allowlist means "allow all" — the default-open behavior. Each
+/// entry is either an exact IPv4 address ("10.0.0.29") or IPv4 CIDR
+/// ("10.0.0.0/24"); no CIDR-matching crate (e.g. `ipnet`, which appears in
+/// `Cargo.lock` only as a transitive dependency of unrelated crates, not a
+/// direct one) was already a dependency of this workspace, so this is a
+/// small hand-written IPv4-only matcher rather than a new direct
+/// dependency for a narrowly-scoped need.
+///
+/// IPv6 is not supported: an IPv6 `ip` is rejected (logged, not matched
+/// against anything) rather than silently mismatched against IPv4 entries,
+/// and a malformed or IPv6 allowlist entry is logged and skipped rather
+/// than panicking or being silently ignored without a trace.
+pub fn ip_allowed(ip: &IpAddr, allowlist: &[String]) -> bool {
+    if allowlist.is_empty() {
+        return true;
+    }
+
+    let ip_v4 = match ip {
+        IpAddr::V4(v4) => *v4,
+        IpAddr::V6(_) => {
+            tracing::warn!(
+                "rpc_cluster: rejecting connection from {ip} \u{2014} rpc_allowed_peers only \
+                 supports IPv4 addresses/CIDR ranges today, so an IPv6 peer can never match"
+            );
+            return false;
+        }
+    };
+
+    allowlist
+        .iter()
+        .any(|entry| ipv4_entry_matches(entry, ip_v4))
+}
+
+/// Matches a single `rpc_allowed_peers` entry (exact IPv4 address or IPv4
+/// CIDR) against `ip`. Malformed entries are logged and treated as
+/// non-matching rather than panicking — a typo in one allowlist entry
+/// should not take down the whole allowlist check.
+fn ipv4_entry_matches(entry: &str, ip: Ipv4Addr) -> bool {
+    let entry = entry.trim();
+
+    let Some((network_str, prefix_str)) = entry.split_once('/') else {
+        return match entry.parse::<Ipv4Addr>() {
+            Ok(addr) => addr == ip,
+            Err(_) => {
+                tracing::warn!(
+                    "rpc_cluster: rpc_allowed_peers entry '{entry}' is not a valid IPv4 address \
+                     \u{2014} ignoring it"
+                );
+                false
+            }
+        };
+    };
+
+    let (Ok(network), Ok(prefix)) = (network_str.parse::<Ipv4Addr>(), prefix_str.parse::<u32>())
+    else {
+        tracing::warn!(
+            "rpc_cluster: rpc_allowed_peers entry '{entry}' is not a valid IPv4 CIDR range \
+             \u{2014} ignoring it"
+        );
+        return false;
+    };
+    if prefix > 32 {
+        tracing::warn!(
+            "rpc_cluster: rpc_allowed_peers entry '{entry}' has an invalid CIDR prefix length \
+             (must be 0-32) \u{2014} ignoring it"
+        );
+        return false;
+    }
+
+    let mask: u32 = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    (u32::from(network) & mask) == (u32::from(ip) & mask)
 }
 
 /// A cluster peer known to be contributing compute over `ggml-rpc-server`.
@@ -615,5 +888,162 @@ mod tests {
     #[test]
     fn rpc_flag_value_empty_for_no_peers() {
         assert_eq!(rpc_flag_value(&[]), "");
+    }
+
+    // --- ip_allowed / CIDR matching ---
+
+    fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    #[test]
+    fn ip_allowed_empty_allowlist_allows_everything() {
+        // Empty rpc_allowed_peers means "allow all" -- the default-open
+        // behavior that must be unchanged from before this field existed.
+        assert!(ip_allowed(&v4(10, 0, 0, 29), &[]));
+        assert!(ip_allowed(&v4(203, 0, 113, 5), &[]));
+    }
+
+    #[test]
+    fn ip_allowed_exact_ipv4_match() {
+        let allowlist = vec!["10.0.0.29".to_string()];
+        assert!(ip_allowed(&v4(10, 0, 0, 29), &allowlist));
+        assert!(!ip_allowed(&v4(10, 0, 0, 30), &allowlist));
+    }
+
+    #[test]
+    fn ip_allowed_cidr_range_match() {
+        let allowlist = vec!["10.0.0.0/24".to_string()];
+        assert!(ip_allowed(&v4(10, 0, 0, 1), &allowlist));
+        assert!(ip_allowed(&v4(10, 0, 0, 254), &allowlist));
+        assert!(!ip_allowed(&v4(10, 0, 1, 1), &allowlist));
+        assert!(!ip_allowed(&v4(11, 0, 0, 1), &allowlist));
+    }
+
+    #[test]
+    fn ip_allowed_cidr_slash_32_is_exact_match() {
+        let allowlist = vec!["192.168.1.5/32".to_string()];
+        assert!(ip_allowed(&v4(192, 168, 1, 5), &allowlist));
+        assert!(!ip_allowed(&v4(192, 168, 1, 6), &allowlist));
+    }
+
+    #[test]
+    fn ip_allowed_cidr_slash_0_matches_everything() {
+        let allowlist = vec!["0.0.0.0/0".to_string()];
+        assert!(ip_allowed(&v4(1, 2, 3, 4), &allowlist));
+        assert!(ip_allowed(&v4(255, 255, 255, 255), &allowlist));
+    }
+
+    #[test]
+    fn ip_allowed_multiple_entries_any_match_wins() {
+        let allowlist = vec!["10.0.0.29".to_string(), "192.168.0.0/16".to_string()];
+        assert!(ip_allowed(&v4(10, 0, 0, 29), &allowlist));
+        assert!(ip_allowed(&v4(192, 168, 50, 7), &allowlist));
+        assert!(!ip_allowed(&v4(172, 16, 0, 1), &allowlist));
+    }
+
+    #[test]
+    fn ip_allowed_ipv6_input_rejected_not_panicking() {
+        let allowlist = vec!["10.0.0.0/24".to_string()];
+        let ipv6 = IpAddr::V6(std::net::Ipv6Addr::LOCALHOST);
+        // Must not panic, and must not silently "match" -- an IPv6 peer is
+        // always rejected against an IPv4-only allowlist.
+        assert!(!ip_allowed(&ipv6, &allowlist));
+    }
+
+    #[test]
+    fn ip_allowed_malformed_entry_is_skipped_not_panicking() {
+        let allowlist = vec![
+            "not-an-ip".to_string(),
+            "10.0.0.0/99".to_string(), // invalid prefix length
+            "10.0.0.29".to_string(),   // still valid, still matches
+        ];
+        assert!(ip_allowed(&v4(10, 0, 0, 29), &allowlist));
+        assert!(!ip_allowed(&v4(10, 0, 0, 30), &allowlist));
+    }
+
+    // --- allowlist proxy (integration-style, real loopback sockets) ---
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Spawns a trivial echo server on an ephemeral loopback port and
+    /// returns its address, standing in for the loopback `ggml-rpc-server`
+    /// the proxy would normally forward to.
+    async fn spawn_echo_backend() -> SocketAddr {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(pair) => pair,
+                    Err(_) => return,
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 1024];
+                    loop {
+                        match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => {
+                                if sock.write_all(&buf[..n]).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn allowlist_proxy_forwards_allowed_source() {
+        let backend_addr = spawn_echo_backend().await;
+
+        // Bind the proxy's public-facing listener on an ephemeral loopback
+        // port ourselves (rather than a fixed SocketAddr) so there's no
+        // bind/rebind race with `run_rpc_allowlist_proxy`.
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        let allowed_peers = vec!["127.0.0.1".to_string()];
+        tokio::spawn(serve_rpc_allowlist_proxy(
+            listener,
+            backend_addr,
+            allowed_peers,
+        ));
+
+        let mut client = TcpStream::connect(proxy_addr).await.unwrap();
+        client.write_all(b"hello").await.unwrap();
+        let mut resp = [0u8; 5];
+        client.read_exact(&mut resp).await.unwrap();
+        assert_eq!(
+            &resp, b"hello",
+            "allowed peer's traffic must be spliced through"
+        );
+    }
+
+    #[tokio::test]
+    async fn allowlist_proxy_rejects_disallowed_source() {
+        let backend_addr = spawn_echo_backend().await;
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        // 127.0.0.1 (what this test connects from) is deliberately NOT in
+        // this allowlist.
+        let allowed_peers = vec!["10.0.0.1".to_string()];
+        tokio::spawn(serve_rpc_allowlist_proxy(
+            listener,
+            backend_addr,
+            allowed_peers,
+        ));
+
+        let mut client = TcpStream::connect(proxy_addr).await.unwrap();
+        let _ = client.write_all(b"hello").await; // may or may not land before close
+        let mut resp = [0u8; 1];
+        let n = client.read(&mut resp).await.unwrap_or(0);
+        assert_eq!(
+            n, 0,
+            "disallowed peer's connection must be closed with no data forwarded"
+        );
     }
 }

--- a/crates/ghost-link/src/rpc_cluster.rs
+++ b/crates/ghost-link/src/rpc_cluster.rs
@@ -104,13 +104,53 @@ pub fn ensure_contributing(bind_host: &str, port: u16) {
          the same assumption UDP/mDNS discovery already makes."
     );
 
+    // ggml-rpc-server's own stdout/stderr (connection/tensor-transfer activity
+    // logged by upstream llama.cpp) is discarded by default — matches every
+    // other best-effort child process in this codebase. Opt-in redirection to
+    // a file via GHOSTLINK_RPC_SERVER_LOG exists specifically so its activity
+    // can be inspected/proven from outside the process (e.g. in a container
+    // where the contributor's own log is the only evidence a peer actually
+    // reached it), without changing default behavior for anyone who hasn't
+    // set it.
+    let log_file = std::env::var("GHOSTLINK_RPC_SERVER_LOG")
+        .ok()
+        .filter(|p| !p.trim().is_empty())
+        .and_then(|path| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .map_err(|err| {
+                    tracing::warn!(
+                        "rpc_cluster: failed to open GHOSTLINK_RPC_SERVER_LOG at '{path}': {err}. \
+                         Falling back to discarding ggml-rpc-server output."
+                    );
+                    err
+                })
+                .ok()
+        });
+
+    // try_clone() only fails on rare OS-level fd duplication errors; on
+    // failure that stream just falls back to null rather than aborting this
+    // best-effort startup path.
+    let stdout_cfg = log_file
+        .as_ref()
+        .and_then(|f| f.try_clone().ok())
+        .map(Stdio::from)
+        .unwrap_or_else(Stdio::null);
+    let stderr_cfg = log_file
+        .as_ref()
+        .and_then(|f| f.try_clone().ok())
+        .map(Stdio::from)
+        .unwrap_or_else(Stdio::null);
+
     match Command::new(&bin)
         .arg("-H")
         .arg(bind_host)
         .arg("-p")
         .arg(port.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(stdout_cfg)
+        .stderr(stderr_cfg)
         .stdin(Stdio::null())
         .spawn()
     {

--- a/crates/ghost-link/src/rpc_cluster.rs
+++ b/crates/ghost-link/src/rpc_cluster.rs
@@ -190,10 +190,37 @@ pub struct RpcPeer {
 
 /// Finds healthy, RPC-contributing peers (excluding `local_node_id`) from
 /// `cluster`'s live node list. A peer only qualifies if it advertised an
-/// `rpc_port` (opted in to contributing), is `NodeStatus::Active`, and has a
-/// known reachable IP (from discovery or `/api/workers/connect`). Sorted by
-/// node id for a stable `--rpc`/`--tensor-split` ordering across a session.
-pub fn discover_rpc_peers(cluster: &ClusterState, local_node_id: &str) -> Vec<RpcPeer> {
+/// `rpc_port` (opted in to contributing), is `NodeStatus::Active`, has a
+/// known reachable IP (from discovery or `/api/workers/connect`), and
+/// doesn't have a *confirmed* `llama.cpp` build mismatch against
+/// `local_rpc_build_id`. Sorted by node id for a stable
+/// `--rpc`/`--tensor-split` ordering across a session.
+///
+/// # Version-compatibility check
+///
+/// `ggml-rpc-server` has no version-compatibility check of its own — an
+/// upstream llama.cpp limitation. Confirmed on real, genuinely separate
+/// hardware (`docs/BENCHMARKS.md`'s native two-machine entry): two machines
+/// running `llama.cpp` builds 10 days apart connected and exchanged RPC
+/// traffic without complaint, but larger-model inference through the real
+/// distributed path came back as reproducible garbage while the API
+/// reported `healthy`/HTTP 200 throughout. Rebuilding both sides at the
+/// identical commit fixed it.
+///
+/// A peer is only excluded on an *actual confirmed* mismatch — both this
+/// node and the peer report a `rpc_build_id` and they differ. A peer
+/// reporting `None` (it predates this field, or couldn't determine its own
+/// build id) is deliberately **not** treated as a mismatch: that would make
+/// every not-yet-updated peer on a LAN unroutable the moment one node
+/// upgrades, an unnecessarily disruptive rollout behavior. Instead this
+/// ships additively: unknown-version peers are still used, with a lower-
+/// urgency warning that their safety can't be verified — matching today's
+/// actual (pre-this-field) behavior exactly.
+pub fn discover_rpc_peers(
+    cluster: &ClusterState,
+    local_node_id: &str,
+    local_rpc_build_id: Option<&str>,
+) -> Vec<RpcPeer> {
     let nodes = cluster.nodes_snapshot();
     let mut peers: Vec<RpcPeer> = nodes
         .iter()
@@ -204,6 +231,35 @@ pub fn discover_rpc_peers(cluster: &ClusterState, local_node_id: &str) -> Vec<Rp
             if metrics.status != NodeStatus::Active {
                 return None;
             }
+
+            match (local_rpc_build_id, node.rpc_build_id.as_deref()) {
+                (Some(local), Some(peer)) if local != peer => {
+                    tracing::warn!(
+                        "rpc_cluster: excluding peer '{}' ({peer_addr:?}) \u{2014} llama.cpp \
+                         build mismatch (local: '{local}', peer: '{peer}'). Distributed \
+                         inference is skipping this peer because version-mismatched ggml-rpc \
+                         peers have been confirmed to silently corrupt output for larger models \
+                         while reporting healthy status throughout. Rebuild both nodes at the \
+                         same llama.cpp commit to re-enable this peer.",
+                        node.id,
+                        peer_addr = metrics.ip_address,
+                    );
+                    return None;
+                }
+                (Some(local), Some(peer)) => {
+                    debug_assert_eq!(local, peer);
+                }
+                _ => {
+                    tracing::warn!(
+                        "rpc_cluster: peer '{}' did not report a verifiable llama.cpp build \
+                         fingerprint (predates version-compatibility checking, or couldn't \
+                         determine its own build id) \u{2014} cannot verify it matches this \
+                         node's build; proceeding anyway.",
+                        node.id
+                    );
+                }
+            }
+
             let mut addr = metrics.ip_address?;
             addr.set_port(rpc_port);
             Some(RpcPeer {
@@ -261,9 +317,25 @@ mod tests {
         addr: Option<SocketAddr>,
         status: NodeStatus,
     ) {
+        register_peer_with_build_id(cluster, id, vram_gb, rpc_port, None, addr, status);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_peer_with_build_id(
+        cluster: &ClusterState,
+        id: &str,
+        vram_gb: f32,
+        rpc_port: Option<u16>,
+        rpc_build_id: Option<&str>,
+        addr: Option<SocketAddr>,
+        status: NodeStatus,
+    ) {
         let mut node = NodeResources::new(id, vram_gb, 32.0, "8.6", None);
         if let Some(port) = rpc_port {
             node = node.with_rpc_port(port);
+        }
+        if let Some(build_id) = rpc_build_id {
+            node = node.with_rpc_build_id(build_id);
         }
         cluster.register_with_addr(node, addr);
         cluster.get_metrics_mut(id, |m| m.status = status);
@@ -317,7 +389,7 @@ mod tests {
             NodeStatus::Active,
         );
 
-        let peers = discover_rpc_peers(&cluster, "local");
+        let peers = discover_rpc_peers(&cluster, "local", None);
 
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].node_id, "contributor");
@@ -337,7 +409,7 @@ mod tests {
             NodeStatus::Active,
         );
 
-        assert!(discover_rpc_peers(&cluster, "local").is_empty());
+        assert!(discover_rpc_peers(&cluster, "local", None).is_empty());
     }
 
     #[test]
@@ -360,10 +432,135 @@ mod tests {
             NodeStatus::Active,
         );
 
-        let peers = discover_rpc_peers(&cluster, "local");
+        let peers = discover_rpc_peers(&cluster, "local", None);
         assert_eq!(peers.len(), 2);
         assert_eq!(peers[0].node_id, "alpha");
         assert_eq!(peers[1].node_id, "zeta");
+    }
+
+    #[test]
+    fn excludes_peer_with_confirmed_mismatched_rpc_build_id() {
+        let cluster = ClusterState::new();
+        register_peer_with_build_id(
+            &cluster,
+            "local",
+            16.0,
+            None,
+            None,
+            Some(loopback(9000)),
+            NodeStatus::Active,
+        );
+        register_peer_with_build_id(
+            &cluster,
+            "contributor",
+            12.0,
+            Some(50052),
+            Some("e920c523e"),
+            Some(loopback(9001)),
+            NodeStatus::Active,
+        );
+
+        let peers = discover_rpc_peers(&cluster, "local", Some("da296d6"));
+
+        assert!(
+            peers.is_empty(),
+            "peer with a confirmed different llama.cpp build id must be excluded"
+        );
+    }
+
+    #[test]
+    fn does_not_exclude_peer_with_matching_rpc_build_id() {
+        let cluster = ClusterState::new();
+        register_peer_with_build_id(
+            &cluster,
+            "local",
+            16.0,
+            None,
+            None,
+            Some(loopback(9000)),
+            NodeStatus::Active,
+        );
+        register_peer_with_build_id(
+            &cluster,
+            "contributor",
+            12.0,
+            Some(50052),
+            Some("da296d6"),
+            Some(loopback(9001)),
+            NodeStatus::Active,
+        );
+
+        let peers = discover_rpc_peers(&cluster, "local", Some("da296d6"));
+
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].node_id, "contributor");
+    }
+
+    #[test]
+    fn does_not_exclude_peer_with_unknown_rpc_build_id() {
+        // Asymmetry from bug 1's fix: a peer reporting `None` (predates this
+        // field, or couldn't determine its own build) must NOT be treated as
+        // a mismatch and excluded -- only an *actual confirmed* mismatch
+        // (Some(a) != Some(b)) should exclude a peer. Otherwise every
+        // not-yet-updated peer on a LAN becomes unroutable the moment one
+        // node upgrades.
+        let cluster = ClusterState::new();
+        register_peer_with_build_id(
+            &cluster,
+            "local",
+            16.0,
+            None,
+            None,
+            Some(loopback(9000)),
+            NodeStatus::Active,
+        );
+        register_peer(
+            &cluster,
+            "contributor",
+            12.0,
+            Some(50052),
+            Some(loopback(9001)),
+            NodeStatus::Active,
+        );
+
+        let peers = discover_rpc_peers(&cluster, "local", Some("da296d6"));
+
+        assert_eq!(
+            peers.len(),
+            1,
+            "a peer with no rpc_build_id must still be used, not excluded"
+        );
+        assert_eq!(peers[0].node_id, "contributor");
+    }
+
+    #[test]
+    fn does_not_exclude_peer_when_local_build_id_is_unknown() {
+        // Mirror case: if this node itself couldn't determine its own build
+        // id, it also can't confirm a mismatch, so peers should still be used.
+        let cluster = ClusterState::new();
+        register_peer_with_build_id(
+            &cluster,
+            "local",
+            16.0,
+            None,
+            None,
+            Some(loopback(9000)),
+            NodeStatus::Active,
+        );
+        register_peer_with_build_id(
+            &cluster,
+            "contributor",
+            12.0,
+            Some(50052),
+            Some("e920c523e"),
+            Some(loopback(9001)),
+            NodeStatus::Active,
+        );
+
+        let peers = discover_rpc_peers(&cluster, "local", None);
+
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].node_id, "contributor");
     }
 
     #[test]

--- a/crates/ghostlink-core/Cargo.toml
+++ b/crates/ghostlink-core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ghostlink-core"
-version = "1.16.1"
+version = "1.17.0"
 edition = "2021"
 authors = ["Ryan K Williams"]
 description = "Core runtime primitives for Ghostlink, including planning, routing, health monitoring, and transport logic for distributed inference workloads."
 homepage = "https://rwilliamspbg-ops.github.io/Ghostlink/"
 documentation = "https://rwilliamspbg-ops.github.io/Ghostlink/"
 repository = "https://github.com/rwilliamspbg-ops/Ghostlink"
-readme = "../../README.md"
+readme = "README.md"
 license = "MIT"
 keywords = ["networking", "zero-copy", "async", "llm", "inference"]
 categories = ["asynchronous", "network-programming"]

--- a/crates/ghostlink-core/README.md
+++ b/crates/ghostlink-core/README.md
@@ -1,0 +1,70 @@
+# ghostlink-core
+
+Core runtime primitives for [Ghostlink](https://github.com/rwilliamspbg-ops/Ghostlink):
+discovery, cluster state, planning, load balancing, health monitoring, and transport
+logic for distributed inference workloads across heterogeneous hardware. Depended on by
+[`ghost-link`](../ghost-link) (the CLI/API binary); this crate has no binary of its own.
+
+## What's in here
+
+- **`discovery.rs` / `mdns.rs` / `protocol.rs`** — zero-config peer discovery over UDP
+  broadcast and mDNS, and the wire format (`NodeResources`, `DiscoveryFrame`) nodes use to
+  advertise hardware (VRAM, system memory, GPU name), RPC contribution capability
+  (`rpc_port`), and — as of the version-mismatch-corruption fix this crate shipped —
+  an `rpc_build_id` fingerprint so a coordinator can detect (and refuse to route
+  distributed inference through) a peer running a different `llama.cpp` build than its
+  own, rather than silently getting corrupted output. Both the shared binary encoder and
+  the UDP-specific hand-duplicated one carry every field — a real historical bug here was
+  a field silently dropped by only one of the two encoders, so each field gets its own
+  round-trip regression test now, not just the shared helper.
+- **`cluster.rs` / `health.rs`** — live cluster membership and per-node health tracking.
+- **`planning.rs` / `load_balance.rs`** — placement planning and load distribution across
+  discovered nodes.
+- **`runtime.rs` / `ring.rs`** — the ring-buffer/TCP-bridge pipeline execution engine used
+  by the synthetic `ghost-link flow`/`stage-worker` benchmark harness. Worth being
+  explicit about what this is *not*: it moves synthetic `f32` timing payloads to prove out
+  transport latency, not real model tensors. Real distributed inference goes through
+  llama.cpp's own `ggml-rpc` backend instead (see `ghost-link`'s `rpc_cluster.rs`), which
+  this crate's runtime doesn't implement — the two are genuinely separate mechanisms and
+  conflating them was a real gap this project had to fix (see the main repo's
+  `docs/ROADMAP.md`, "Priority Zero").
+- **`system_profile.rs` / `accelerator.rs` / `host.rs`** — hardware detection (CPU, GPU,
+  VRAM, NPU where available).
+- **`circuit_breaker.rs`** — a 3-state (closed/open/half-open) circuit breaker with
+  jittered exponential backoff, used on the TCP transport bridge's reconnect path so a
+  chronically-unreachable node fails fast instead of repeating a full connect/backoff
+  cycle on every call.
+- **`api_response_cache.rs`** — TTL + ETag response caching (used for the model-list
+  endpoint, which otherwise re-scans disk on every request).
+- **`kv_cache.rs`** — KV-cache primitives (currently no caller in `runtime.rs`, since
+  model execution is delegated to an external inference engine — kept as a tested
+  primitive for future use).
+- **`watcher.rs` / `xdp.rs` / `dashboard.rs` / `models.rs` / `autotune.rs`** — config file
+  watching, optional AF_XDP kernel-bypass networking support, terminal dashboard data
+  model, model registry types, and TCP transport autotuning.
+
+## Feature flags
+
+- `rocm` — AMD ROCm device support in the hardware-detection/accelerator paths.
+
+## Testing
+
+```bash
+cargo test -p ghostlink-core
+```
+
+This crate's test suite is where most of the wire-protocol and cluster-logic regression
+coverage lives, including the discovery round-trip tests referenced above.
+
+## More
+
+- [Main repository](https://github.com/rwilliamspbg-ops/Ghostlink) for the full stack,
+  docs, and GUI.
+- [`ghost-link`](https://crates.io/crates/ghost-link) is the CLI/API binary that actually
+  uses this crate — most people want that, not this one, unless you're embedding
+  Ghostlink's discovery/planning logic in your own tool.
+
+## License
+
+MIT — see [`LICENSE`](https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/LICENSE) in
+the main repository.

--- a/crates/ghostlink-core/src/mdns.rs
+++ b/crates/ghostlink-core/src/mdns.rs
@@ -136,6 +136,9 @@ fn node_to_txt_properties(node: &NodeResources) -> Vec<(String, String)> {
     if let Some(rpc_port) = node.rpc_port {
         props.push(("rpc_port".to_string(), rpc_port.to_string()));
     }
+    if let Some(rpc_build_id) = &node.rpc_build_id {
+        props.push(("rpc_build_id".to_string(), rpc_build_id.clone()));
+    }
     props
 }
 
@@ -146,6 +149,7 @@ fn node_from_txt_lookup(lookup: impl Fn(&str) -> Option<String>) -> Option<NodeR
     let compute_capability = lookup("compute_capability").unwrap_or_default();
     let gpu_name = lookup("gpu_name");
     let rpc_port = lookup("rpc_port").and_then(|v| v.parse().ok());
+    let rpc_build_id = lookup("rpc_build_id");
     Some(NodeResources {
         id,
         vram_gb,
@@ -153,6 +157,7 @@ fn node_from_txt_lookup(lookup: impl Fn(&str) -> Option<String>) -> Option<NodeR
         compute_capability,
         gpu_name,
         rpc_port,
+        rpc_build_id,
     })
 }
 
@@ -209,6 +214,25 @@ mod tests {
         let decoded = node_from_txt_lookup(lookup_from(&props)).expect("decode");
 
         assert_eq!(decoded.rpc_port, None);
+    }
+
+    #[test]
+    fn txt_roundtrip_preserves_rpc_build_id() {
+        let node =
+            NodeResources::new("node-e", 12.0, 32.0, "8.6", None).with_rpc_build_id("da296d6");
+        let props = node_to_txt_properties(&node);
+        let decoded = node_from_txt_lookup(lookup_from(&props)).expect("decode");
+
+        assert_eq!(decoded.rpc_build_id, Some("da296d6".to_string()));
+    }
+
+    #[test]
+    fn txt_roundtrip_without_rpc_build_id() {
+        let node = NodeResources::new("node-f", 8.0, 16.0, "7.5", None);
+        let props = node_to_txt_properties(&node);
+        let decoded = node_from_txt_lookup(lookup_from(&props)).expect("decode");
+
+        assert_eq!(decoded.rpc_build_id, None);
     }
 
     #[test]

--- a/crates/ghostlink-core/src/protocol.rs
+++ b/crates/ghostlink-core/src/protocol.rs
@@ -154,6 +154,20 @@ pub struct NodeResources {
     /// both are indistinguishable and both correctly mean "don't route
     /// distributed inference through this node."
     pub rpc_port: Option<u16>,
+    /// Short commit-hash fingerprint of this node's local `llama.cpp` build
+    /// (see `ghost_link::native_engine::NativeEngineClient::get_llama_build_id`),
+    /// e.g. `"da296d6"`. `None` means this node either couldn't determine its
+    /// own build id or the peer that sent this frame predates this field —
+    /// both are indistinguishable, and both are treated as "unknown, can't
+    /// verify" rather than "mismatched" by `rpc_cluster::discover_rpc_peers`
+    /// (mismatched-but-unknown must not be treated the same as a confirmed
+    /// mismatch, or every not-yet-updated peer becomes unroutable overnight).
+    /// Used to refuse routing distributed inference through a peer whose
+    /// `llama.cpp` build doesn't match the local one — version-mismatched
+    /// `ggml-rpc` peers have been confirmed on real hardware to silently
+    /// corrupt output for larger models while reporting healthy status the
+    /// whole time (see `docs/BENCHMARKS.md`'s native two-machine entry).
+    pub rpc_build_id: Option<String>,
 }
 
 impl NodeResources {
@@ -172,6 +186,7 @@ impl NodeResources {
             compute_capability: compute_capability.into(),
             gpu_name,
             rpc_port: None,
+            rpc_build_id: None,
         }
     }
 
@@ -180,6 +195,12 @@ impl NodeResources {
     /// workspace's tests and CLI commands.
     pub fn with_rpc_port(mut self, port: u16) -> Self {
         self.rpc_port = Some(port);
+        self
+    }
+
+    /// Builder-style setter, same rationale as `with_rpc_port`.
+    pub fn with_rpc_build_id(mut self, build_id: impl Into<String>) -> Self {
+        self.rpc_build_id = Some(build_id.into());
         self
     }
 
@@ -195,6 +216,7 @@ impl NodeResources {
         let id_bytes = self.id.as_bytes();
         let cc_bytes = self.compute_capability.as_bytes();
         let gpu_bytes = self.gpu_name.as_ref().map(|name| name.as_bytes());
+        let build_id_bytes = self.rpc_build_id.as_ref().map(|id| id.as_bytes());
 
         if id_bytes.len() > u8::MAX as usize || cc_bytes.len() > u8::MAX as usize {
             return Err("field length exceeds u8::MAX");
@@ -202,6 +224,11 @@ impl NodeResources {
         if let Some(gpu_bytes) = gpu_bytes {
             if gpu_bytes.len() > u8::MAX as usize {
                 return Err("GPU name length exceeds u8::MAX");
+            }
+        }
+        if let Some(build_id_bytes) = build_id_bytes {
+            if build_id_bytes.len() > u8::MAX as usize {
+                return Err("rpc_build_id length exceeds u8::MAX");
             }
         }
 
@@ -214,8 +241,19 @@ impl NodeResources {
         // after this field existed, reading an older (shorter) payload from
         // a peer that predates it, just doesn't find the 2 extra bytes and
         // defaults to `None` — see `decode_payload`.
-        let payload_len =
-            11 + id_bytes.len() + cc_bytes.len() + gpu_bytes.map_or(0, |bytes| 1 + bytes.len()) + 2;
+        //
+        // Then a length-prefixed rpc_build_id string (u8 length + bytes,
+        // length 0 meaning "none"/unknown), appended *after* rpc_port for the
+        // same additive-compatibility reasoning: older decoders never read
+        // past what they know about, and this decoder defaults to `None` when
+        // an older/shorter payload doesn't have these trailing bytes at all.
+        let payload_len = 11
+            + id_bytes.len()
+            + cc_bytes.len()
+            + gpu_bytes.map_or(0, |bytes| 1 + bytes.len())
+            + 2
+            + 1
+            + build_id_bytes.map_or(0, |bytes| bytes.len());
         if payload_len > max_size {
             return Err("payload length exceeds max_size");
         }
@@ -237,6 +275,13 @@ impl NodeResources {
 
         buffer.extend_from_slice(&self.rpc_port.unwrap_or(0).to_le_bytes());
 
+        if let Some(build_id_bytes) = build_id_bytes {
+            buffer.push(build_id_bytes.len() as u8);
+            buffer.extend_from_slice(build_id_bytes);
+        } else {
+            buffer.push(0);
+        }
+
         Ok(payload_len)
     }
 
@@ -248,6 +293,7 @@ impl NodeResources {
         let id_bytes_len = self.id.len();
         let cc_bytes_len = self.compute_capability.len();
         let gpu_bytes_len = self.gpu_name.as_ref().map_or(0, |name| name.len());
+        let build_id_bytes_len = self.rpc_build_id.as_ref().map_or(0, |id| id.len());
         let est_len = 11
             + id_bytes_len
             + cc_bytes_len
@@ -256,7 +302,9 @@ impl NodeResources {
             } else {
                 0
             }
-            + 2;
+            + 2
+            + 1
+            + build_id_bytes_len;
 
         let mut payload = Vec::with_capacity(est_len);
         if self.encode_payload_into(&mut payload, max_size).is_ok() {
@@ -362,10 +410,34 @@ impl NodeResources {
                     .try_into()
                     .map_err(|_| "rpc_port parsing failed".to_string())?,
             );
+            cursor += 2;
             if port == 0 {
                 None
             } else {
                 Some(port)
+            }
+        } else {
+            None
+        };
+
+        // Trailing length-prefixed rpc_build_id field, added after rpc_port
+        // shipped — same additive-compatibility reasoning: a payload from a
+        // peer that predates this field simply won't have these bytes, which
+        // correctly decodes as "unknown build" rather than an error.
+        let rpc_build_id = if cursor < len {
+            let build_id_len = payload[cursor] as usize;
+            cursor += 1;
+            let build_id_end = cursor + build_id_len;
+            if build_id_end > len {
+                return Err("payload truncated".into());
+            }
+            if build_id_len == 0 {
+                None
+            } else {
+                let id = std::str::from_utf8(&payload[cursor..build_id_end])
+                    .map_err(|_| "invalid UTF-8 in rpc_build_id".to_string())?
+                    .to_string();
+                Some(id)
             }
         } else {
             None
@@ -378,6 +450,7 @@ impl NodeResources {
             compute_capability,
             gpu_name,
             rpc_port,
+            rpc_build_id,
         })
     }
 }
@@ -414,6 +487,12 @@ impl DiscoveryFrame {
                 return buf[..8].to_vec();
             }
         }
+        if let Some(ref build_id) = self.node.rpc_build_id {
+            if build_id.len() > u8::MAX as usize {
+                buf[4..8].copy_from_slice(&crc32(&[]).to_le_bytes());
+                return buf[..8].to_vec();
+            }
+        }
 
         // Guard against the combined fields overflowing the fixed-size stack
         // buffer: each field is individually bounded by u8::MAX above, but
@@ -427,8 +506,18 @@ impl DiscoveryFrame {
         // carried it correctly, so a UDP-discovered peer could never be
         // selected for distributed inference. See `decode_payload`, which
         // already tolerated this field being absent/present either way.
-        let payload_len =
-            11 + id_bytes.len() + cc_bytes.len() + gpu_len.map_or(0, |len| 1 + len) + 2;
+        //
+        // +1 (length prefix) + build_id bytes for rpc_build_id, appended
+        // after rpc_port for the same additive-compatibility reasoning —
+        // see `NodeResources::encode_payload_into`'s matching comment.
+        let build_id_len = self.node.rpc_build_id.as_ref().map(|id| id.len());
+        let payload_len = 11
+            + id_bytes.len()
+            + cc_bytes.len()
+            + gpu_len.map_or(0, |len| 1 + len)
+            + 2
+            + 1
+            + build_id_len.unwrap_or(0);
         if payload_len > MAX_PAYLOAD_SIZE {
             buf[4..8].copy_from_slice(&crc32(&[]).to_le_bytes());
             return buf[..8].to_vec();
@@ -468,6 +557,17 @@ impl DiscoveryFrame {
         let rpc_port_bytes = self.node.rpc_port.unwrap_or(0).to_le_bytes();
         buf[pos..pos + 2].copy_from_slice(&rpc_port_bytes);
         pos += 2;
+
+        if let Some(ref build_id) = self.node.rpc_build_id {
+            let build_id_bytes = build_id.as_bytes();
+            buf[pos] = build_id_bytes.len() as u8;
+            pos += 1;
+            buf[pos..pos + build_id_bytes.len()].copy_from_slice(build_id_bytes);
+            pos += build_id_bytes.len();
+        } else {
+            buf[pos] = 0;
+            pos += 1;
+        }
 
         let crc = crc32(&buf[8..pos]);
         buf[4..8].copy_from_slice(&crc.to_le_bytes());
@@ -603,6 +703,54 @@ mod tests {
     }
 
     #[test]
+    fn discovery_frame_encode_round_trips_rpc_build_id() {
+        // Same lesson as `discovery_frame_encode_round_trips_rpc_port` above:
+        // `DiscoveryFrame::encode()` is a hand-duplicated serializer from
+        // `NodeResources::encode_payload_into`, so a new trailing field has to
+        // be added to *both* independently or UDP discovery silently drops it
+        // while mDNS (which reuses the shared encoder) carries it correctly.
+        let frame = DiscoveryFrame {
+            kind: FrameKind::Join,
+            node: NodeResources::new("node-i", 12.0, 32.0, "8.6", None)
+                .with_rpc_build_id("da296d6"),
+        };
+
+        let encoded = frame.encode();
+        let decoded = DiscoveryFrame::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.node.rpc_build_id, Some("da296d6".to_string()));
+    }
+
+    #[test]
+    fn discovery_frame_encode_without_rpc_build_id_decodes_to_none() {
+        let frame = DiscoveryFrame {
+            kind: FrameKind::Join,
+            node: NodeResources::new("node-j", 8.0, 16.0, "7.5", None),
+        };
+
+        let encoded = frame.encode();
+        let decoded = DiscoveryFrame::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.node.rpc_build_id, None);
+    }
+
+    #[test]
+    fn discovery_frame_encode_round_trips_rpc_port_and_rpc_build_id_together() {
+        let frame = DiscoveryFrame {
+            kind: FrameKind::Join,
+            node: NodeResources::new("node-k", 12.0, 32.0, "8.6", None)
+                .with_rpc_port(50052)
+                .with_rpc_build_id("e920c523e"),
+        };
+
+        let encoded = frame.encode();
+        let decoded = DiscoveryFrame::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.node.rpc_port, Some(50052));
+        assert_eq!(decoded.node.rpc_build_id, Some("e920c523e".to_string()));
+    }
+
+    #[test]
     fn crc_verification_fails_on_modified_payload() {
         let frame = DiscoveryFrame {
             kind: FrameKind::Discovery,
@@ -636,12 +784,12 @@ mod tests {
         let node = NodeResources::new("a", 1.0, 1.0, "b", Some("c".to_string()));
         let mut buffer = Vec::new();
         // Actual encoded length: id_len(1)+id(1)+vram(4)+mem(4)+cc_len(1)+cc(1)
-        // +has_gpu(1)+gpu_len(1)+gpu(1)+rpc_port(2) = 17 bytes.
+        // +has_gpu(1)+gpu_len(1)+gpu(1)+rpc_port(2)+rpc_build_id_len(1) = 18 bytes.
         let written = node
-            .encode_payload_into(&mut buffer, 17)
-            .expect("payload of exactly 17 bytes must fit within max_size 17");
-        assert_eq!(written, 17);
-        assert_eq!(buffer.len(), 17);
+            .encode_payload_into(&mut buffer, 18)
+            .expect("payload of exactly 18 bytes must fit within max_size 18");
+        assert_eq!(written, 18);
+        assert_eq!(buffer.len(), 18);
     }
 
     #[test]
@@ -684,6 +832,65 @@ mod tests {
         encoded.truncate(encoded.len() - 2);
         let decoded = NodeResources::decode_payload(&encoded).expect("decode");
         assert_eq!(decoded.rpc_port, None);
+    }
+
+    #[test]
+    fn node_resources_round_trip_preserves_rpc_build_id() {
+        let node =
+            NodeResources::new("node-i", 12.0, 32.0, "8.6", None).with_rpc_build_id("da296d6");
+        let encoded = node.encode_payload(64);
+        let decoded = NodeResources::decode_payload(&encoded).expect("decode");
+        assert_eq!(decoded.rpc_build_id, Some("da296d6".to_string()));
+    }
+
+    #[test]
+    fn node_resources_round_trip_without_rpc_build_id_is_none() {
+        let node = NodeResources::new("node-j", 8.0, 16.0, "7.5", None);
+        let encoded = node.encode_payload(64);
+        let decoded = NodeResources::decode_payload(&encoded).expect("decode");
+        assert_eq!(decoded.rpc_build_id, None);
+    }
+
+    #[test]
+    fn node_resources_round_trip_with_gpu_name_rpc_port_and_rpc_build_id_together() {
+        // Regression test mirroring
+        // `node_resources_round_trip_with_gpu_name_and_rpc_port_together`:
+        // rpc_build_id is read *after* rpc_port, so both trailing fields must
+        // survive a payload that also has a GPU name in the middle.
+        let node = NodeResources::new("node-k", 24.0, 64.0, "8.9", Some("RTX 4090".to_string()))
+            .with_rpc_port(50053)
+            .with_rpc_build_id("e920c523e");
+        let encoded = node.encode_payload(128);
+        let decoded = NodeResources::decode_payload(&encoded).expect("decode");
+        assert_eq!(decoded.gpu_name, Some("RTX 4090".to_string()));
+        assert_eq!(decoded.rpc_port, Some(50053));
+        assert_eq!(decoded.rpc_build_id, Some("e920c523e".to_string()));
+    }
+
+    #[test]
+    fn decode_payload_from_before_rpc_build_id_existed_defaults_to_none() {
+        // Simulates a frame from a peer build that has rpc_port but predates
+        // rpc_build_id: same format, just without the trailing length-prefix
+        // byte (and any build-id bytes).
+        let node = NodeResources::new("node-l", 8.0, 16.0, "7.5", None).with_rpc_port(50054);
+        let mut encoded = node.encode_payload(64);
+        assert!(!encoded.is_empty());
+        encoded.truncate(encoded.len() - 1);
+        let decoded = NodeResources::decode_payload(&encoded).expect("decode");
+        assert_eq!(decoded.rpc_port, Some(50054));
+        assert_eq!(decoded.rpc_build_id, None);
+    }
+
+    #[test]
+    fn decode_payload_truncated_mid_rpc_build_id_string_is_an_error() {
+        // A length prefix claiming more build-id bytes than are actually
+        // present should error, not panic or silently truncate.
+        let node =
+            NodeResources::new("node-m", 8.0, 16.0, "7.5", None).with_rpc_build_id("da296d6");
+        let mut encoded = node.encode_payload(64);
+        encoded.truncate(encoded.len() - 2); // drop the last 2 bytes of the hash
+        let result = NodeResources::decode_payload(&encoded);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/mcp-calculator/Cargo.toml
+++ b/crates/mcp-calculator/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 description = "Local stdio MCP server exposing a safe expression-evaluator 'calculate' tool for Ghostlink chat's calculator tool slot."
+readme = "README.md"
 
 [dependencies]
 rmcp = { version = "2", features = ["transport-io", "schemars"] }

--- a/crates/mcp-calculator/README.md
+++ b/crates/mcp-calculator/README.md
@@ -1,0 +1,44 @@
+# mcp-calculator
+
+Local stdio [MCP](https://modelcontextprotocol.io/) server exposing a single `calculate`
+tool — a safe math-expression evaluator — for
+[Ghostlink](https://github.com/rwilliamspbg-ops/Ghostlink) chat's calculator tool slot.
+
+**Not published to crates.io** (`publish = false`) — this is an internal component of the
+main Ghostlink repository, spawned as a child process over stdio by the Ghostlink chat
+runtime, not a standalone library or service meant to be depended on externally.
+
+## What it does
+
+One tool, `calculate(expression: string) -> number`, backed by
+[`evalexpr`](https://docs.rs/evalexpr) for safe (no arbitrary code execution) numeric
+expression evaluation. Runs as a local subprocess speaking MCP over stdio
+(`rmcp`'s `transport-io`) — Ghostlink's chat tool-call loop spawns it, sends a tool call,
+gets a result back, same pattern as `mcp-rag` and `mcp-vision`.
+
+## Running standalone (for testing)
+
+```bash
+cargo run -p mcp-calculator
+```
+
+Speaks MCP over stdin/stdout — not meant to be run interactively; use an MCP-aware client
+or Ghostlink's own chat tool-call loop (`mcp_servers.toml` in the main repo registers it).
+
+## Testing
+
+```bash
+cargo test -p mcp-calculator
+```
+
+## More
+
+See the [main repository](https://github.com/rwilliamspbg-ops/Ghostlink) — this crate is
+one of three local MCP tool servers alongside
+[`mcp-rag`](https://github.com/rwilliamspbg-ops/Ghostlink/tree/main/crates/mcp-rag) and
+[`mcp-vision`](https://github.com/rwilliamspbg-ops/Ghostlink/tree/main/crates/mcp-vision).
+
+## License
+
+MIT — see [`LICENSE`](https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/LICENSE) in
+the main repository.

--- a/crates/mcp-rag/Cargo.toml
+++ b/crates/mcp-rag/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 description = "Local stdio MCP server exposing index_document/search retrieval tools backed by a local Ollama embedding model and an in-process cosine-similarity index, for Ghostlink chat's RAG tool."
+readme = "README.md"
 
 [dependencies]
 rmcp = { version = "2", features = ["transport-io", "schemars"] }

--- a/crates/mcp-rag/README.md
+++ b/crates/mcp-rag/README.md
@@ -1,0 +1,54 @@
+# mcp-rag
+
+Local stdio [MCP](https://modelcontextprotocol.io/) server exposing `index_document` and
+`search` retrieval tools for [Ghostlink](https://github.com/rwilliamspbg-ops/Ghostlink)
+chat's RAG (retrieval-augmented generation) tool — backed by a local Ollama embedding
+model and an in-process cosine-similarity index, no external vector database.
+
+**Not published to crates.io** (`publish = false`) — an internal component of the main
+Ghostlink repository, spawned as a child process over stdio by the Ghostlink chat runtime.
+
+## What it does
+
+- **`index_document(path, ...)`** — chunks a document (splitting on blank lines, then
+  breaking long paragraphs at word boundaries under a max-chars limit) and stores each
+  chunk's embedding (via a local Ollama embedding model over HTTP) in a persisted local
+  index.
+- **`search(query, top_k)`** — embeds the query the same way, ranks indexed chunks by
+  cosine similarity, and returns the top matches.
+
+The index is a flat in-process store with a real persist/load round-trip to disk (no
+external vector DB dependency) — appropriate for the scale of documents a single chat
+session's RAG tool actually needs, not a general-purpose retrieval system.
+
+## Running standalone (for testing)
+
+```bash
+cargo run -p mcp-rag
+```
+
+Requires a local Ollama instance running an embedding model. Speaks MCP over stdio — use
+an MCP-aware client or Ghostlink's own chat tool-call loop
+(`mcp_servers.toml` in the main repo registers it).
+
+## Testing
+
+```bash
+cargo test -p mcp-rag
+```
+
+Covers chunking behavior (blank-line splitting, word-boundary breaking, whitespace-only
+input) and the index persist/load round-trip without requiring a live Ollama instance.
+
+## More
+
+See the [main repository](https://github.com/rwilliamspbg-ops/Ghostlink) — this crate is
+one of three local MCP tool servers alongside
+[`mcp-calculator`](https://github.com/rwilliamspbg-ops/Ghostlink/tree/main/crates/mcp-calculator)
+and
+[`mcp-vision`](https://github.com/rwilliamspbg-ops/Ghostlink/tree/main/crates/mcp-vision).
+
+## License
+
+MIT — see [`LICENSE`](https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/LICENSE) in
+the main repository.

--- a/crates/mcp-vision/Cargo.toml
+++ b/crates/mcp-vision/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 description = "Local stdio MCP server exposing an analyze_image tool backed by a local Ollama vision model, for Ghostlink chat's vision tool."
+readme = "README.md"
 
 [dependencies]
 rmcp = { version = "2", features = ["transport-io", "schemars"] }

--- a/crates/mcp-vision/README.md
+++ b/crates/mcp-vision/README.md
@@ -1,0 +1,43 @@
+# mcp-vision
+
+Local stdio [MCP](https://modelcontextprotocol.io/) server exposing a single
+`analyze_image` tool for [Ghostlink](https://github.com/rwilliamspbg-ops/Ghostlink)
+chat's vision tool — backed by a local Ollama vision model, no external API calls.
+
+**Not published to crates.io** (`publish = false`) — an internal component of the main
+Ghostlink repository, spawned as a child process over stdio by the Ghostlink chat runtime.
+
+## What it does
+
+One tool, `analyze_image(image, prompt) -> string`: takes a base64-encoded image (and an
+optional prompt describing what to look for), forwards it to a local Ollama vision model
+over HTTP, and returns the model's description/analysis as text. Everything stays local —
+no image data leaves the machine running Ollama.
+
+## Running standalone (for testing)
+
+```bash
+cargo run -p mcp-vision
+```
+
+Requires a local Ollama instance running a vision-capable model. Speaks MCP over stdio —
+use an MCP-aware client or Ghostlink's own chat tool-call loop (`mcp_servers.toml` in the
+main repo registers it).
+
+## Testing
+
+```bash
+cargo test -p mcp-vision
+```
+
+## More
+
+See the [main repository](https://github.com/rwilliamspbg-ops/Ghostlink) — this crate is
+one of three local MCP tool servers alongside
+[`mcp-calculator`](https://github.com/rwilliamspbg-ops/Ghostlink/tree/main/crates/mcp-calculator)
+and [`mcp-rag`](https://github.com/rwilliamspbg-ops/Ghostlink/tree/main/crates/mcp-rag).
+
+## License
+
+MIT — see [`LICENSE`](https://github.com/rwilliamspbg-ops/Ghostlink/blob/main/LICENSE) in
+the main repository.

--- a/docker-compose.rpc-fabric-benchmark.yml
+++ b/docker-compose.rpc-fabric-benchmark.yml
@@ -1,0 +1,117 @@
+# Benchmark variant of docker-compose.rpc-fabric.yml — same two-container
+# ggml-rpc fabric (contributor + coordinator), same Dockerfile.rpc-fabric
+# image, but:
+#
+#   - mounts a real, larger GGUF model (models-bench/, downloaded by
+#     scripts/rpc_fabric_benchmark.py or manually — see docs/BENCHMARKS.md's
+#     2026-08-08 Multi-Node Performance entry for the exact source URL) into
+#     /app/models on the coordinator, alongside the tiny stories15M model
+#     already baked into the image.
+#   - separate container names, network subnet (172.31.0.0/24), and host
+#     port (8020) from docker-compose.rpc-fabric.yml, so this can run
+#     alongside (or without disturbing) the CI correctness gate
+#     (.github/workflows/distributed-e2e.yml), which must keep using the
+#     original compose file unmodified.
+#   - larger cpu/mem limits, sized for a ~1GB real model instead of the
+#     19MB smoke-test model (still well inside this machine's Docker
+#     Desktop VM allocation — see docs/BENCHMARKS.md for the measured
+#     `docker info` numbers).
+#
+# This file is NOT part of any CI gate — it's a manual benchmarking tool,
+# driven by scripts/rpc_fabric_benchmark.py.
+
+services:
+  rpc-bench-contributor:
+    build:
+      context: .
+      dockerfile: Dockerfile.rpc-fabric
+    container_name: ghostlink-rpc-bench-contributor
+    hostname: rpc-bench-contributor
+    networks:
+      ghostlink-rpc-fabric-bench:
+        ipv4_address: 172.31.0.11
+    environment:
+      GHOSTLINK_NODE_ID: "rpc-bench-contributor"
+      GHOSTLINK_API_HOST: "0.0.0.0"
+      GHOSTLINK_API_PORT: "8003"
+      GHOSTLINK_CONTRIBUTE_COMPUTE: "true"
+      GHOSTLINK_DISTRIBUTED_INFERENCE: "false"
+      GHOSTLINK_RPC_PORT: "50052"
+      GHOSTLINK_DISCOVERY_BROADCAST: "255.255.255.255:45885"
+      GHOSTLINK_RPC_SERVER_LOG: "/tmp/ggml-rpc-server.log"
+      GHOSTLINK_API_KEY: "ghostlink-rpc-fabric-bench-test-key-0123456789abcdef0123456789ab"
+      RUST_LOG: "info,ghost_link=debug"
+    expose:
+      - "50052"
+      - "8003"
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:8003/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    # Contributor's ggml-rpc-server has to hold whatever fraction of the
+    # model's tensors the coordinator's -ts split assigns it, in its own
+    # process memory (uploaded once at load time) — not just a thin proxy,
+    # so it gets the same real headroom as the coordinator.
+    cpus: '4'
+    mem_limit: 3g
+
+  rpc-bench-coordinator:
+    build:
+      context: .
+      dockerfile: Dockerfile.rpc-fabric
+    container_name: ghostlink-rpc-bench-coordinator
+    hostname: rpc-bench-coordinator
+    networks:
+      ghostlink-rpc-fabric-bench:
+        ipv4_address: 172.31.0.12
+    environment:
+      GHOSTLINK_NODE_ID: "rpc-bench-coordinator"
+      GHOSTLINK_API_HOST: "0.0.0.0"
+      GHOSTLINK_API_PORT: "8003"
+      GHOSTLINK_CONTRIBUTE_COMPUTE: "false"
+      # Left false here; scripts/rpc_fabric_benchmark.py PATCHes this live
+      # via /api/settings for the single-node phase, then flips it true for
+      # the distributed phase — same live-toggle-then-reload path
+      # scripts/rpc_fabric_assert.py already exercises.
+      GHOSTLINK_DISTRIBUTED_INFERENCE: "false"
+      GHOSTLINK_RPC_PORT: "50052"
+      GHOSTLINK_DISCOVERY_BROADCAST: "255.255.255.255:45885"
+      GHOSTLINK_API_KEY: "ghostlink-rpc-fabric-bench-test-key-0123456789abcdef0123456789ab"
+      # Defaults to the same "0" scripts/rpc_fabric_entrypoint.sh itself
+      # falls back to for CPU-only containers (`${GHOSTLINK_LLAMA_NGL:-0}`)
+      # — matches docker-compose.rpc-fabric.yml's (the CI gate's) real
+      # behavior. docs/BENCHMARKS.md's 2026-08-08 entry found this makes
+      # --rpc/-ts real-but-functionally-inert for compute placement: real
+      # RPC connections happen, but 0 layers get assigned to the remote
+      # device, so memory/throughput are indistinguishable from single-node.
+      # Reproduce that entry's control experiment (real layer offload) with:
+      #   GHOSTLINK_BENCH_NGL=-1 docker compose -f docker-compose.rpc-fabric-benchmark.yml up -d rpc-bench-coordinator
+      GHOSTLINK_LLAMA_NGL: "${GHOSTLINK_BENCH_NGL:-0}"
+      RUST_LOG: "info,ghost_link=debug"
+    depends_on:
+      rpc-bench-contributor:
+        condition: service_healthy
+    ports:
+      - "8020:8003"
+    volumes:
+      # Single-file bind mount into the image's existing /app/models dir —
+      # doesn't hide stories15M-q4_0.gguf (that's still baked in at the same
+      # path by Dockerfile.rpc-fabric), just adds this one alongside it.
+      - ./models-bench/qwen2.5-1.5b-instruct-q4_k_m.gguf:/app/models/qwen2.5-1.5b-instruct-q4_k_m.gguf:ro
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:8003/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    cpus: '4'
+    mem_limit: 3g
+
+networks:
+  ghostlink-rpc-fabric-bench:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.31.0.0/24

--- a/docker-compose.rpc-fabric.yml
+++ b/docker-compose.rpc-fabric.yml
@@ -1,0 +1,110 @@
+# Two-container proof that Ghostlink's real distributed-inference feature
+# (llama.cpp's ggml-rpc backend, see crates/ghost-link/src/rpc_cluster.rs)
+# works end to end across process/container boundaries, not just on one
+# machine. See scripts/rpc_fabric_assert.py for the verification sequence.
+#
+# rpc-contributor runs `ggml-rpc-server`, exposing its (CPU-only, in this
+# test) compute over TCP. rpc-coordinator discovers it via Ghostlink's UDP
+# broadcast discovery, and — once `distributed_inference` is on — launches
+# its own llama-server with `--rpc <contributor>:50052 -ts <split>` computed
+# entirely by Ghostlink itself.
+
+services:
+  rpc-contributor:
+    build:
+      context: .
+      dockerfile: Dockerfile.rpc-fabric
+    container_name: ghostlink-rpc-contributor
+    hostname: rpc-contributor
+    networks:
+      ghostlink-rpc-fabric:
+        ipv4_address: 172.30.0.11
+    environment:
+      GHOSTLINK_NODE_ID: "rpc-contributor"
+      GHOSTLINK_API_HOST: "0.0.0.0"
+      GHOSTLINK_API_PORT: "8003"
+      GHOSTLINK_CONTRIBUTE_COMPUTE: "true"
+      GHOSTLINK_DISTRIBUTED_INFERENCE: "false"
+      GHOSTLINK_RPC_PORT: "50052"
+      # 255.255.255.255 is RuntimeSettings::default()'s own value; Docker
+      # user-defined bridge networks are a single L2 broadcast domain so this
+      # is expected to cross the container boundary. If discovery doesn't
+      # come up, switch both containers to the bridge's directed broadcast
+      # address instead: "172.30.0.255:45885" (subnet is 172.30.0.0/24 below).
+      GHOSTLINK_DISCOVERY_BROADCAST: "255.255.255.255:45885"
+      # rpc_cluster::ensure_contributing() discards ggml-rpc-server's own
+      # stdout/stderr by default (Stdio::null(), best-effort like every other
+      # child process it launches). This opt-in env var (added specifically
+      # for this fabric's verification requirement) redirects it to a file
+      # instead, so scripts/rpc_fabric_assert.py can prove the contributor
+      # actually saw a real connection, not just that the chat request
+      # succeeded.
+      GHOSTLINK_RPC_SERVER_LOG: "/tmp/ggml-rpc-server.log"
+      # main.rs forces TLS on for any non-loopback bind host (0.0.0.0 here),
+      # regardless of enable_tls in settings.json — see
+      # scripts/rpc_fabric_entrypoint.sh's comment. Fixed test-only bearer
+      # token, seeded into api_key.txt by the entrypoint before ghost-link
+      # starts, so scripts/rpc_fabric_assert.py doesn't have to scrape a
+      # randomly-generated one out of container logs.
+      GHOSTLINK_API_KEY: "ghostlink-rpc-fabric-test-key-0123456789abcdef0123456789abcdef"
+      RUST_LOG: "info,ghost_link=debug"
+    # rpc_port only needs to be reachable on the bridge network — no host
+    # publish needed, matching the task's networking shape.
+    expose:
+      - "50052"
+      - "8003"
+    healthcheck:
+      # -k: self-signed cert (see the TLS note above) — this is a test
+      # fabric on an isolated bridge network, not a scenario where cert
+      # validation buys anything.
+      test: ["CMD", "curl", "-fk", "https://localhost:8003/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    cpus: '2'
+    mem_limit: 2g
+
+  rpc-coordinator:
+    build:
+      context: .
+      dockerfile: Dockerfile.rpc-fabric
+    container_name: ghostlink-rpc-coordinator
+    hostname: rpc-coordinator
+    networks:
+      ghostlink-rpc-fabric:
+        ipv4_address: 172.30.0.12
+    environment:
+      GHOSTLINK_NODE_ID: "rpc-coordinator"
+      GHOSTLINK_API_HOST: "0.0.0.0"
+      GHOSTLINK_API_PORT: "8003"
+      GHOSTLINK_CONTRIBUTE_COMPUTE: "false"
+      # Set statically here (in addition to the assertion script also
+      # PATCHing it live via /api/settings, which is idempotent) — mirrors
+      # both "off by default" single-node behavior and the original
+      # live-toggle verification described in commit 46a023c.
+      GHOSTLINK_DISTRIBUTED_INFERENCE: "true"
+      GHOSTLINK_RPC_PORT: "50052"
+      GHOSTLINK_DISCOVERY_BROADCAST: "255.255.255.255:45885"
+      GHOSTLINK_API_KEY: "ghostlink-rpc-fabric-test-key-0123456789abcdef0123456789abcdef"
+      RUST_LOG: "info,ghost_link=debug"
+    depends_on:
+      rpc-contributor:
+        condition: service_healthy
+    ports:
+      - "8010:8003"
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:8003/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    cpus: '2'
+    mem_limit: 2g
+
+networks:
+  ghostlink-rpc-fabric:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -355,13 +355,533 @@ signal is `remote_bridge_write_ms`: a genuine ~10-16ms round-trip write
 cost to a physically separate machine over Wi-Fi, in the same range as raw
 ICMP RTT to that host.
 
+### Real ggml-rpc distributed-inference run — 2026-08-08 (Docker fabric, CPU-only, single host)
+
+The 2026-08-03 entry above is explicit that it exercises the *synthetic*
+`stage-worker`/`flow` pipeline harness (fake `f32` payloads, a timing proxy
+for per-stage compute), not Ghostlink's real distributed-inference feature.
+This entry supersedes/complements it by exercising the actual production
+code path: llama.cpp's own `ggml-rpc` backend
+(`crates/ghost-link/src/rpc_cluster.rs`), via `docker-compose.rpc-fabric.yml`
+(a contributor container + a coordinator container on an isolated Docker
+bridge network) and its CI correctness gate,
+`.github/workflows/distributed-e2e.yml` /
+`scripts/rpc_fabric_assert.py` — the same evidence bar that gate uses
+(`real_inference: true` in the chat response, plus fresh "Accepted client
+connection" lines in the contributor's own `ggml-rpc-server` log) is what
+every run below is checked against, not just a settings flag.
+
+**Important framing**: both "nodes" here are containers on **one physical
+host**, not genuinely separate machines like the 2026-08-03 LAN entry above
+(real `stage-worker` on a second machine, real NIC hop). This entry can
+prove the real cross-process ggml-rpc code path works and measure its real
+local resource cost — it cannot show a real network-bandwidth or
+genuinely-separate-hardware benefit, and the results below should not be
+read as such.
+
+#### Hardware / resource limits
+
+| | |
+|---|---|
+| Host OS | Windows 11 (build 10.0.26200) |
+| Docker Desktop VM | 16 CPUs, 13.46 GiB RAM (`docker info --format 'NCPU={{.NCPU}} MemTotal={{.MemTotal}}'` → `NCPU=16 MemTotal=14451666944`), Linux 6.6.87.2-microsoft-standard-WSL2, Docker 29.6.2 |
+| GPU | None passed through — CPU-only for both containers, `-ngl` forced per below |
+| `rpc-bench-contributor` limit | `cpus: '4'`, `mem_limit: 3g` |
+| `rpc-bench-coordinator` limit | `cpus: '4'`, `mem_limit: 3g` |
+
+(Larger than the CI gate's `2 cpus`/`2g` per container — this benchmark's
+model is ~59x the CI gate's 19MB smoke-test model, and needed real headroom
+to run repeated timed trials rather than a single pass/fail check.)
+
+#### Model
+
+`Qwen2.5-1.5B-Instruct-Q4_K_M.gguf`, downloaded directly from Qwen's own
+official GGUF repo on Hugging Face (public, unauthenticated,
+`https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf`
+— same plain-HTTPS-GGUF-URL convention `Dockerfile.rpc-fabric` already uses
+for `stories15M-q4_0.gguf`). 1.5B parameters, Q4_K_M quantization, real
+downloaded file size **1,117,320,736 bytes (1.04 GiB)**,
+sha256 `6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e`.
+Chosen as a real step up from the trivial 19MB stories15M smoke-test model
+(which proves connectivity, not realistic throughput or memory behavior)
+while still being CPU-feasible for several timed trials on this hardware in
+a reasonable amount of time.
+
+#### Methodology
+
+New `scripts/rpc_fabric_benchmark.py` and `docker-compose.rpc-fabric-benchmark.yml`
+(the latter is a **separate** compose file — `docker-compose.rpc-fabric.yml`
+itself, the CI gate, is untouched). The benchmark model is bind-mounted
+into the existing image's `/app/models` directory rather than baked into
+`Dockerfile.rpc-fabric`, so the CI-gate image build is unaffected.
+
+For each of the two phases below, the script: PATCHes `distributed_inference`
+live via `/api/settings`, then calls `/api/models/load` — which always
+fully restarts `llama-server` (`native_engine.rs::load_model_into_slot`'s
+own doc comment: "restarting it with the new model... doesn't support
+runtime hot-swapping"), so the restart genuinely picks up the new
+`--rpc`/`-ts` flags — then runs **5** real chat completions
+(`POST /api/inference/chat`, which — unlike `/v1/chat/completions` — reports
+real per-call `tokens_generated` and server-measured `throughput`/`latency_ms`)
+against a fixed prompt, `max_tokens=128`. Every distributed-phase run is
+checked for `real_inference: true` *and* a nonzero increase in the
+contributor's `ggml-rpc-server` "Accepted client connection" log count
+since the phase started — a passing response alone doesn't prove real
+distributed work happened, same standard `rpc_fabric_assert.py` holds
+itself to. Memory is read directly from each container's cgroup
+(`/sys/fs/cgroup/memory.current` + `memory.stat`'s `anon`/`file` split),
+not `docker stats`' derived/cache-inclusive number — the anon/file
+distinction turned out to be the load-bearing one (see below).
+
+#### Result 1 — as-shipped default (`-ngl 0`, the same CPU-safety default `scripts/rpc_fabric_entrypoint.sh` forces for every container in this fabric, including the CI gate)
+
+| Mode | Runs | Throughput (avg) | Throughput (min-max) | Latency (avg) | Coordinator mem post-load | Coordinator anon/file split |
+|---|---|---|---|---|---|---|
+| single-node (`distributed_inference: false`) | 5 | 32.70 tok/s | 32.48-32.96 tok/s | 3754.2 ms | 1,940,283,392 B (1.807 GiB) | anon 811,155,456 B (773.5 MiB) / file 1,118,490,624 B (1.042 GiB) |
+| distributed (`distributed_inference: true`) | 5 | 32.53 tok/s | 32.40-32.70 tok/s | 3776.3 ms | 1,940,000,768 B (1.807 GiB) | anon 811,634,688 B (774.0 MiB) / file 1,118,543,872 B (1.042 GiB) |
+
+Throughput and memory are statistically indistinguishable between the two
+modes (0.5% throughput delta, well inside the ~0.1-0.2 tok/s run-to-run
+stdev measured within each mode). **But the distributed run is not a
+no-op**: the contributor's `ggml-rpc-server` log genuinely gained **462**
+new "Accepted client connection" lines over the 5 runs (0 in single-node,
+where `distributed_inference` was off) — real RPC traffic occurred. The
+explanation, found by reading `native_engine.rs::build_cmd`'s actual
+launched command line
+(`... -ngl 0 ... --rpc 172.31.0.11:50052 -ts 0.1000,0.1000`): with `-ngl 0`,
+llama.cpp assigns **zero** transformer layers to any non-CPU-primary
+backend device — GPU or RPC alike — so `--rpc`/`-ts` are real flags
+producing a real (but layer-empty) connection, not real tensor placement.
+`-ngl 0` is what `scripts/rpc_fabric_entrypoint.sh` forces by default for
+every container in this fabric (`export GHOSTLINK_LLAMA_NGL="${GHOSTLINK_LLAMA_NGL:-0}"`,
+a deliberate CPU-only safety default, not a bug) — meaning **the CI gate's
+own default configuration exercises the RPC wire protocol for real, but
+not real cross-process layer compute.**
+
+#### Result 2 — control experiment: real layer offload (`GHOSTLINK_BENCH_NGL=-1`)
+
+To confirm that diagnosis rather than assume it, the coordinator was
+recreated with `-ngl -1` (`native_engine.rs::get_ngl`'s own "auto/offload
+all" fallback) and 2 more real distributed runs collected
+(`max_tokens=96`; 2 runs rather than 5 — this was a confirmatory control,
+not the primary comparison, so it gets less statistical weight):
+
+| | as-shipped (`-ngl 0`, distributed) | control (`-ngl -1`, distributed) |
+|---|---|---|
+| Coordinator mem post-load | 1,940,000,768 B (1.807 GiB) | **1,195,409,408 B (1.113 GiB)** |
+| Coordinator anon (real committed memory) | 811,634,688 B (774.0 MiB) | **70,815,744 B (67.5 MiB)** |
+| Coordinator file (mmap'd GGUF, reclaimable cache) | 1,118,543,872 B (1.042 GiB) | 1,117,343,744 B (1.040 GiB) |
+| Contributor mem post-load | 7,139,328 B (6.8 MiB) | **1,129,553,920 B (1.052 GiB)** |
+| Contributor anon | 3,457,024 B (3.3 MiB) | **1,123,610,624 B (1.046 GiB)** |
+| New contributor RPC connections | +462 over 5 runs (~92/run) | +1084 over 2 runs (~542/run) |
+| Throughput (avg) | 32.53 tok/s | **17.01 tok/s** (16.86-17.17, 2 runs) |
+| Latency (avg) | 3776.3 ms | 5047.8 ms |
+
+This is the real answer to "does ggml-rpc's tensor split reduce the
+coordinator's own local memory footprint": **yes, on the metric that
+actually matters for avoiding an OOM — real anonymous (committed) memory —
+when layer offload is genuinely enabled.** The coordinator's anon memory
+dropped **~741 MB** (811.6 → 70.8 MiB) while the contributor's anon memory
+grew by almost exactly that much (3.3 → 1046 MiB), consistent with roughly
+half the model's real working weight buffers moving to the remote side
+under the `-ts 0.1000,0.1000` split (both nodes report equal declared VRAM
+— 0.0 GB, CPU-only — so `rpc_cluster::compute_tensor_split` floors both to
+an even split).
+
+**But it is not a proportional total-memory reduction**, and this is the
+honest, load-bearing caveat: the coordinator's `file` (mmap'd GGUF page
+cache) stayed at ~1.04 GiB — essentially the entire model file — in
+**both** configurations, single-node or distributed, `-ngl 0` or `-ngl -1`.
+`native_engine.rs::build_cmd` always passes `-m <full local model path>`
+and never passes `--no-mmap`; llama.cpp mmaps the whole GGUF locally
+regardless of how much of it actually executes remotely. Those mmap'd
+pages are reclaimable clean file-backed cache (the kernel can drop and
+re-read them under real memory pressure, unlike the anon pages above), but
+they still count toward `memory.current` and toward what a cgroup
+`mem_limit` would eventually reclaim-under-pressure or OOM-kill over,
+depending on how tight the limit is and how the reclaim path behaves —
+this was not stress-tested at a limit tight enough to force that decision
+(both configurations ran comfortably inside the 3g `mem_limit`, nowhere
+near triggering reclaim or OOM), so this document does **not** claim to
+have shown a "model too large for one node alone, only fits when split"
+capacity unlock. The honest, measured claim is narrower and still real:
+tensor-split genuinely redistributes committed working memory when layer
+offload is actually enabled, but the coordinator's local address space
+still has to mmap the full file either way.
+
+**And real distributed compute has a real cost here, not a benefit**:
+throughput dropped ~48% (32.53 → 17.01 tok/s) once compute was genuinely
+split across the RPC link. This is expected, not a regression to chase —
+both "nodes" are containers time-sharing **one physical host's CPU cores**
+with no additional hardware added by distributing, so every real
+cross-process tensor op pays real IPC/RPC round-trip and serialization
+overhead (~542 accepted connections per single 96-token generation call,
+vs. ~92/call when the split was compute-inert) for zero added compute
+capacity. This matches the same-host-no-real-benefit caveat the
+2026-08-03 LAN section above states from the transport side; here it's
+measured from the compute-distribution side instead.
+
+#### Caveats
+
+- CPU-only throughout — no GPU passthrough in this Docker setup. Not a
+  GPU-cluster performance claim.
+- Both containers ran on one physical host (Docker Desktop VM), not two
+  genuinely separate machines — unlike the 2026-08-03 LAN entry, this
+  cannot and does not measure real network bandwidth/latency between
+  separate hardware.
+- `tokens_estimated` (prompt-side count) is a word-count estimate
+  (`req.message.split_whitespace().count()`in `handle_gui_chat`), not an
+  exact tokenizer count — not relied on for the throughput numbers above,
+  which use the server's real `tokens_generated`/measured-latency
+  `throughput`.
+- The first run in each 5-run series generated fewer tokens (98 and 106 of
+  a requested 128) than the rest — the model hit a natural stop condition
+  early on that particular generation; throughput (tokens ÷ latency)
+  already accounts for this, but it's why per-run token counts in the raw
+  JSON aren't all identical.
+- The `-ngl -1` control used 2 runs, not 5, and a shorter `max_tokens` (96
+  vs. 128) — a real, deliberate, disclosed asymmetry with the primary
+  table above, not an oversight; it was a confirmatory experiment run
+  after the primary comparison, not the main result.
+- Only one model size/quantization was tested. Whether the anon-memory
+  split holds proportionally for larger models, or whether a genuine
+  OOM-vs-succeeds capacity unlock is reachable at a large-enough model /
+  tight-enough `mem_limit` combination, is real open follow-up work, not
+  something this entry measured.
+
+#### Reproduce this section
+
+```bash
+# One-time: download the benchmark model (public, unauthenticated HF repo)
+curl -L --fail -o models-bench/qwen2.5-1.5b-instruct-q4_k_m.gguf \
+  https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf
+
+docker compose -f docker-compose.rpc-fabric-benchmark.yml up -d --build --wait --wait-timeout 300
+python3 scripts/rpc_fabric_benchmark.py --runs 5 --max-tokens 128
+
+# Control experiment: real layer offload instead of the CPU-safe -ngl 0 default
+GHOSTLINK_BENCH_NGL=-1 docker compose -f docker-compose.rpc-fabric-benchmark.yml up -d rpc-bench-coordinator --wait
+python3 scripts/rpc_fabric_benchmark.py --skip-single-node --runs 2 --max-tokens 96 \
+  --output-dir tmp/rpc_fabric_benchmark_ngl_control
+
+docker compose -f docker-compose.rpc-fabric-benchmark.yml down -v
+```
+
+Raw per-run output: `tmp/rpc_fabric_benchmark/` (`summary.json` +
+`single-node-N.json`/`distributed-N.json`) and
+`tmp/rpc_fabric_benchmark_ngl_control/` — not committed (`tmp/` is
+gitignored), same convention as the 2026-08-03 LAN entry's raw output
+above.
+
+### Real ggml-rpc distributed-inference run — 2026-08-08 (native processes, two genuinely separate physical machines)
+
+The entry above proved the real `ggml-rpc` mechanism works but explicitly
+could not measure a genuine separate-hardware benefit, because both
+"nodes" were containers sharing one physical host's CPU. This entry closes
+that gap — real `ghost-link serve` processes (no Docker) on two actually
+separate machines on the same residential LAN — and in the process found
+four real, distinct bugs that the single-host Docker test structurally
+could not have surfaced. This is the most important entry in this
+document: it's the first genuinely separate-hardware run of the real
+(non-synthetic) distributed-inference path, and it found real correctness
+and resilience problems, not just a throughput number.
+
+**Hardware — two genuinely separate machines on the same residential LAN:**
+
+| | Coordinator (`10.0.0.87`) | Contributor "Iprada" (`10.0.0.29`) |
+|---|---|---|
+| OS | Windows 11 | Linux |
+| GPU / compute exposed to RPC | AMD Radeon(TM) 860M (integrated), Vulkan, 4.0 GB VRAM | Intel(R) N97 CPU only (15.2 GiB free) — the machine also has an Alder Lake-N iGPU, but only its CPU was exposed as an RPC device in this test |
+| Declared VRAM (drives tensor-split ratio) | 3.999 GB | 0.0 GB (floored to 0.1 GB by `compute_tensor_split`) |
+| Role | `distributed_inference: true` | `contribute_compute: true`, `rpc_port: 50052` |
+
+ICMP round-trip measured 8-14ms, consistent with the 2026-08-03 LAN
+entry's separate hardware pair (10-16ms) — a genuine second real-network
+data point, not a coincidence to read too much into with N=1 pairs.
+
+Both processes ran natively (`cargo build --release`, llama.cpp built with
+`-DGGML_RPC=ON` via the same cmake recipe as `Dockerfile.rpc-fabric`),
+deliberately avoiding Docker Desktop's Windows/WSL2 networking layer for
+this test — real UDP broadcast discovery (`GET /api/workers/discover` →
+`count: 2`) confirmed this works cleanly between genuinely separate
+physical machines with no manual IP configuration beyond the standard
+LAN.
+
+#### Result 1 — 1.5B model (`Qwen2.5-1.5B-Instruct-Q4_K_M`, the same file as the Docker entry above): real, small, honest cost
+
+`--rpc 10.0.0.29:50052 -ts 3.9990,0.1000` — built entirely by Ghostlink
+itself from live discovery, no manual flags. 5 runs each, `POST
+/api/inference/chat`, same prompt/`max_tokens=128` methodology as the
+Docker entry:
+
+| Mode | Runs | Throughput (avg) | Throughput (min-max) | Stdev |
+|---|---|---|---|---|
+| single-node | 5 | 55.11 tok/s | 54.27-56.23 tok/s | 0.70 |
+| distributed | 5 | 53.57 tok/s | 53.32-53.95 tok/s | 0.25 |
+
+A real ~2.8% cost — far smaller than the Docker same-host entry's 48%
+penalty, because real separate hardware means the coordinator isn't
+time-sharing its CPU with the remote side. But it's a cost, not a benefit,
+for a structural reason: `compute_tensor_split` is purely
+VRAM-proportional (`local_vram_gb.max(0.1)` per node — see
+`rpc_cluster.rs`), and Iprada declares `0.0 GB` VRAM (its iGPU wasn't
+exposed as an RPC device, only its CPU, which the split formula has no way
+to value in GB terms). That floors Iprada to a token ~2.4% share
+regardless of how much real, usable CPU/RAM capacity it actually has —
+real "old laptop with plenty of system RAM, no dedicated VRAM" hardware,
+exactly the profile the product pitch is built around, and the current
+split heuristic can't make meaningful use of it. **Worth carrying into any
+automatic-sharding work**: a VRAM-only split heuristic systematically
+under-uses non-GPU compute contributors.
+
+#### Bug 1 — quantized KV cache crashes the remote RPC-CPU backend (found, and already silently handled)
+
+The very first model load on this pairing crashed on both sides at once:
+the coordinator's own log recorded `llama-server exited before becoming
+ready (status: exit code: 0xc0000409)`, and Iprada's `ggml-rpc-server` log
+(via the opt-in `GHOSTLINK_RPC_SERVER_LOG`, same mechanism the CI gate
+uses) captured the other half of the same failure — a real GDB backtrace
+ending in `ggml_get_n_tasks: op not implemented: 100` inside
+`rpc_server::graph_compute`. Root cause: `-ctk q8_0 -ctv q8_0` (quantized
+KV cache, `native_engine.rs`'s default for declared-VRAM-under-4GB tiers)
+uses a ggml op the RPC/CPU backend combination doesn't implement.
+`native_engine.rs` already has a real, working fallback — retry without
+quantized KV cache — which is why every chat completion in Result 1 above
+still succeeded; the crash and recovery happened silently during the very
+first load and wasn't visible without reading the raw log.
+
+**A second, separate bug this surfaced**: after that crash, Iprada's `ghost-link
+serve` process stayed healthy (`/health` kept responding), but
+`ggml-rpc-server` — the actual contributor child process
+`rpc_cluster::ensure_contributing()` spawns once at startup — was dead
+(port 50052 went from accepting connections to `Connection refused`).
+Nothing in Ghostlink restarts it, and nothing stops the node from
+continuing to *advertise* `contribute_compute`/`rpc_port` via discovery
+(that's driven by settings, not live child-process health). A coordinator
+would discover this node as a usable peer, build a `--rpc` flag pointing
+at a dead port, and fail — a real resilience gap, not just a KV-cache
+edge case. Confirmed the API layer and the actual compute layer can
+silently diverge in health.
+
+#### Result 2 — bigger models (7B, then a different 5GB single-file model): a real, reproducible, silent correctness bug
+
+To test whether distribution could show a genuine capacity benefit (not
+just a cost), the same pairing was loaded with
+`Qwen2.5-7B-Instruct-Q4_K_M` (4.36 GiB, real 2-shard GGUF from Qwen's
+official HF repo, sha256-verified) — comfortably over the coordinator's
+declared 4.0 GB VRAM.
+
+- **The distributed load did not fail to fit — it just took longer than
+  Ghostlink's timeout allows.** `native_engine.rs`'s model-ready
+  health-check budget is a hardcoded 90 seconds (`wait_for_llama_server_ready(&url,
+  90, &mut child)`, no env override), identical for single-node and
+  distributed loads. Running the *exact* logged distributed command
+  manually (bypassing Ghostlink's timeout) showed the model **did** load
+  successfully — after **5 minutes 3 seconds**. `llama.cpp`'s own log
+  explained part of the slowdown: `failed to fit params to free device
+  memory: model_params::tensor_split already set by user, abort` — its
+  automatic memory-fit optimization disables itself whenever an explicit
+  `-ts` is passed, which Ghostlink always does. Single-node loading of the
+  *same* file completed within the 90s budget and served correct,
+  coherent real output (`real_inference: true`, 38.71 tok/s) — the model
+  fit and ran fine locally on this UMA (unified-memory) integrated GPU,
+  which can apparently overflow gracefully into system RAM past its
+  "declared" 4.0 GB. **A real, actionable bug**: the 90s readiness budget
+  doesn't account for the real extra time an RPC-distributed load takes,
+  and currently aborts loads that would have succeeded.
+
+- **Far more serious, found once the distributed load was allowed to
+  finish**: the response was **reproducibly corrupted garbage** —
+  `"The capital of France is"` → `"pérdida RencontreDBus并不是很 pérdida..."`
+  — while the server reported `healthy`/HTTP 200 throughout, and
+  throughput collapsed to 1.7 tok/s (vs 38.71 tok/s single-node, same
+  file). Reproduced on a **second, unrelated single-file model**
+  (`gemma-4-E4B-it-Q4_K_M.gguf`, 4.97 GiB, not sharded — ruling out
+  multi-part GGUF handling as the cause) with the same garbage pattern
+  (`"’’’’’’’’’’’’’’’’’’’’"`). The 1.5B model in Result 1 above worked
+  correctly through the identical distributed path on the identical
+  hardware pair, so this isn't a blanket "RPC is broken" finding — it's
+  specific to larger models on this pairing, and the trigger wasn't fully
+  characterized before the likely cause below was found and confirmed.
+
+- **Root cause, confirmed by a controlled before/after test**: the two
+  machines' `llama.cpp` builds were on different commits — coordinator at
+  `da296d6` (2026-07-23), Iprada at `e920c523e` (2026-07-13), a 10-day gap
+  in a very actively developed upstream project. `ggml-rpc-server` has no
+  version-compatibility check between peers (the same upstream limitation
+  already documented for its lack of authentication — see the Risks
+  section of `ROADMAP.md`) — mismatched builds connect and exchange data
+  without complaint instead of rejecting each other. After rebuilding
+  Iprada's `llama.cpp` at the exact matching commit (`da296d6`, confirmed
+  via the `ggml` version string bumping 0.16.0 → 0.17.0) and rerunning the
+  identical `gemma-4-E4B-it-Q4_K_M` distributed load — same model, same
+  tensor split, same real cross-machine RPC path, only the peer's
+  `llama.cpp` commit changed — the output was **correct**: `"The capital
+  of France is"` → `"Paris. Paris is a famous city known for its art,
+  fashion, and history. The Eiffel Tower"`. Load time also dropped from
+  312s to 168s on the matched build. This is a real, controlled A/B
+  result, not circumstantial: **version-mismatched `ggml-rpc` peers can
+  silently corrupt output for larger models while reporting healthy
+  status throughout, and this is currently undetectable from the API
+  surface alone.**
+
+#### Result 3 — the actual proof: a real 30B-class model, genuinely too large for the coordinator alone, working correctly when split
+
+With versions matched, the pairing was pushed with a real ~13.58 GiB
+model already on hand locally: `Qwen3-Coder-30B-A3B-Instruct-Q3_K_L.gguf`
+(30B-parameter MoE, ~3B active per token, Q3_K_L quant, sha256 not
+re-verified since it predates this session — a pre-existing local file).
+
+**Single-node genuinely cannot load this model** — not a timeout, a real,
+clean failure:
+```
+ggml_vulkan: Device memory allocation of size 964611072 failed.
+ggml_vulkan: vk::Device::allocateMemory: ErrorOutOfDeviceMemory
+```
+This is the first entry in this document where single-node isn't just
+slow or suboptimal — it hard-fails. Real coordinator hardware (4.0 GB
+declared VRAM, UMA integrated GPU) cannot hold this model alone.
+
+**The distributed attempt also initially failed**, and the debugging
+process (jointly diagnosed with the Claude session running on Iprada,
+which had direct log access this session's coordinator didn't) is worth
+recording because every intermediate hypothesis was real and ruled out in
+turn, not assumed:
+
+1. Three separate coordinator-side configurations — default settings,
+   `-c 2048` (down from 8192, ruling out KV-cache size), and an extreme
+   `-ts 39.9990,0.0100` split (~400x more lopsided than the automatic
+   ratio, ruling out the split ratio controlling per-buffer size) — all
+   failed identically: `failed to allocate RPC0[10.0.0.29:50052] buffer of
+   size 1043927040`, same byte count every time. This looked like a fixed
+   structural ceiling.
+2. Checked Iprada's Vulkan `maxMemoryAllocationSize`: 11.15 GiB — far
+   above the ~995 MB failing request, ruling out a hard per-allocation
+   cap.
+3. `GGML_RPC_DEBUG=1` on the contributor (upstream llama.cpp's own
+   per-command debug logging, `ggml-rpc.cpp:20`) gave real command-level
+   visibility and overturned the "fixed ceiling" read: the coordinator
+   was actually streaming buffers successfully in sequence — **11
+   buffers of ~947 MB–1.06 GB each, each properly `alloc_buffer` →
+   `set_tensor` (real weight data, up to ~138 MB per call) →
+   `free_buffer`, one per transformer layer — and only the 12th of the
+   same size failed.** Summed, 11 successful buffers ≈ 10.5 GiB, right up
+   against the 11.15 GiB heap. The real signature: not a per-allocation
+   cap, and not a leftover-process leak (a freshly-restarted contributor
+   failed identically) — **the Vulkan/Mesa driver on this iGPU wasn't
+   fully reclaiming freed device memory across repeated large alloc→free
+   cycles within one process**, so cumulative usage crept toward the heap
+   ceiling regardless of individual buffer size or split ratio.
+4. **The fix**: reduce `-ngl` from `-1` (offload all layers) to `20`,
+   cutting the total number of layers assigned across local+remote
+   devices — not the per-buffer size, the buffer *count*. This kept
+   Iprada's cumulative allocation comfortably under the reclaim ceiling.
+
+**Result: real success.** Loaded in 487s (~8 min — the largest model
+tested this session, expected to take longer). Two real completions,
+both coherent and correct — including a genuinely competent Python
+Fibonacci implementation with edge-case discussion, real evidence this is
+a working coding-capable model, not a lucky short answer:
+
+```
+"Write a Python function that returns the nth Fibonacci number."
+→ "The Fibonacci sequence starts with F(0) = 0, F(1) = 1, and each
+   subsequent number is the sum of the two preceding ones. ... 
+   def fibonacci_nth(n):
+       # Your implementation here
+       pass
+   def fibonacci_list(n): ..."
+```
+
+Real measured throughput: prompt eval 0.39–0.82 tok/s, generation
+1.47–2.52 tok/s — slow, and an honest caveat this document should not
+smooth over: at this speed, "usable" is a stretch for interactive chat.
+This is **not yet** the "usable speed" half of the roadmap's target
+claim, even though it is genuinely the "too large for one node, works
+when split" half. Both halves together are the actual target; this
+entry has one of them, on real hardware, for the first time.
+
+##### Finding the real `-ngl` boundary on this pairing
+
+`-ngl -1` (offload all layers) hits the reclaim ceiling above; `-ngl 20`
+(Result 3's working config) doesn't. A manual bisection above `-ngl 20`
+found the real boundary and a second, related failure mode:
+
+| `-ngl` | Result | Load time | Prompt eval | Generation |
+|---|---|---|---|---|
+| 20 | works | 487s | 0.39–0.82 tok/s (2 runs) | 1.47–2.52 tok/s (2 runs) |
+| 30 | works | 902s | 0.36 tok/s (1 run) | 1.56 tok/s (1 run) |
+| 40 | **fails** | 11m41s of successful weight loading, then fails | n/a | n/a |
+
+`-ngl 40`'s failure is instructive on its own: every weight buffer loaded
+successfully this time (no `alloc_tensor_range` weight failures, unlike
+Result 3's original `-ngl -1` failure) — it failed afterward, specifically
+allocating the **KV cache**, at a much smaller size (~312 MB, not the
+~995 MB weight-buffer chunks): `failed to allocate RPC0[...] buffer of
+size 327155712` → `failed to allocate buffer for kv cache`. This confirms
+the reclaim-ceiling bug isn't specific to weight-tensor transfers — it's
+cumulative across *any* large allocation on the contributor's device
+within one session, weights and KV cache competing for the same ~11 GiB
+budget. At `-ngl 40`, enough weight data landed on Iprada that no room
+was left for its share of the KV cache once inference was about to
+start.
+
+**Practical takeaway**: the real safe boundary for this exact
+model/hardware/quant combination sits between `-ngl 30` and `-ngl 40` —
+not further narrowed down (30 vs 40 bisection wasn't completed). Load
+time roughly doubled from `-ngl 20` to `-ngl 30` (487s → 902s, more
+layers now loading locally too, not just more risk on the RPC side).
+Generation throughput was flat across both working configs (~1.5–2.5
+tok/s) — not enough samples (2 runs, then 1 run) to call this a real
+trend either way. **This boundary is specific to this session's hardware
+pairing, model, and quantization** — it says nothing about where the
+ceiling sits for a different model size, a different contributor's real
+Vulkan heap budget, or (the actual fix) once the underlying Mesa/Vulkan
+reclaim behavior itself is addressed rather than worked around by
+tuning `-ngl` down.
+
+Four real findings came out of one afternoon of genuinely separate-
+hardware testing, none of which a same-host Docker fabric could have
+produced: a same-host setup has no meaningful network latency to expose
+the 90s-timeout gap, no reason to run mismatched `llama.cpp` builds on
+each side, and — most fundamentally — no way to show a real "too large
+for one node" capacity story, since the whole point of a single-host test
+is that one host's resources are shared, not genuinely partitioned.
+Three of the four findings (the dead-but-still-advertised contributor
+process, the timeout, and the version-mismatch silent-corruption bug) are
+correctness/resilience gaps, currently open and unfixed, worth
+prioritizing before any claim that the distributed path is
+production-ready beyond a single trusted operator running matched
+binaries. The fourth (Result 3 above) is the payoff this whole
+document-full of prior entries was building toward: real proof the
+mechanism delivers on half of its core promise, with the other half
+(usable speed, not just capacity) still open.
+
 ### Notes on Multi-Node Performance
 
-- The one real run above used exactly 2 nodes; scaling trends across 3+
-  nodes are still untested hypotheses, not measurements.
-- Bridge-write latency here tracks network RTT closely (10-16ms TCP vs.
-  8-14ms ICMP) — on this LAN, transport overhead is dominated by the
+- Two real cross-machine runs now exist: 2026-08-03 (synthetic
+  `stage-worker` transport harness) and 2026-08-08 (real `ggml-rpc` path,
+  native processes). Both used exactly 2 genuinely separate nodes. Scaling
+  trends across 3+ genuinely separate nodes are still untested hypotheses,
+  not measurements.
+- **The single most important finding across every entry in this
+  document**: version-mismatched `ggml-rpc` peers (2026-08-08's native
+  two-machine entry) can silently corrupt inference output for larger
+  models while the API reports healthy status throughout, and there is
+  currently no version-compatibility check to catch this. Confirmed via a
+  controlled before/after test on real hardware. Anyone running
+  `contribute_compute`/`distributed_inference` across machines that don't
+  share an exact `llama.cpp` build should treat output as unverified until
+  this is fixed upstream in Ghostlink's own peer-handshake layer.
+- Bridge-write latency (2026-08-03) tracks network RTT closely (10-16ms TCP
+  vs. 8-14ms ICMP) — on that LAN, transport overhead is dominated by the
   network hop itself, not Ghostlink's framing/serialization.
+- ggml-rpc's tensor split (2026-08-08) only moves real compute/memory off
+  the coordinator when `-ngl` is configured to allow non-CPU-primary layer
+  placement — a CPU-safety default of `-ngl 0` (as this repo's own Docker
+  fabric ships) makes `--rpc`/`-ts` real-connection-but-inert. Worth
+  checking deliberately, not assuming, on any new distributed-inference
+  deployment.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -193,7 +193,100 @@ make the Priority Zero fix land on solid ground.
    (should be roughly at parity — same llama.cpp core), and Ghostlink
    single-node vs. Ghostlink multi-node on a model too big for one node
    alone. Publish hardware specs, model, prompt set, concurrency — exactly
-   as CONTRIBUTING.md's release rubric already asks for.
+   as CONTRIBUTING.md's release rubric already asks for. **Status check
+   (2026-08-08, updated): the real-path benchmark now exists, and it found
+   something more important than a throughput number.** `BENCHMARKS.md`'s
+   2026-08-03 entry predates the ggml-rpc work above and only exercises the
+   old `stage-worker`/`flow` synthetic timing harness — that gap is now
+   closed. A new 2026-08-08 "Real ggml-rpc distributed-inference run" entry
+   (`docker-compose.rpc-fabric-benchmark.yml` + `scripts/rpc_fabric_benchmark.py`,
+   reusing the same fabric as Horizon 1 item 1's CI gate) drives the actual
+   `distributed_inference: true` / `rpc_cluster` path with a real 1.5B model
+   (Qwen2.5-1.5B-Instruct-Q4_K_M) and real, checked evidence
+   (`real_inference: true` plus contributor RPC-log connection counts), not
+   just a settings flag.
+
+   **What it found**: with `-ngl 0` — the CPU-safety default this Docker
+   fabric forces everywhere, including in the CI gate — `--rpc`/`-ts` are
+   real flags producing a real RPC connection (462 genuine "Accepted client
+   connection" log lines over 5 runs) that carries **zero compute**:
+   throughput (32.70 vs 32.53 tok/s) and memory were statistically
+   identical single-node vs. distributed, because `-ngl 0` assigns zero
+   transformer layers to any non-CPU-primary backend, GPU or RPC alike. A
+   control run with real layer offload (`-ngl -1`) confirmed the mechanism
+   works — the coordinator's real committed memory dropped ~741MB while the
+   contributor's grew by almost exactly that — but also that, on **one
+   physical host with two containers sharing its CPU**, real distributed
+   compute made throughput ~48% *worse* (32.53 → 17.01 tok/s), since
+   splitting adds real RPC round-trip cost without adding real hardware.
+
+   **Net effect on this roadmap item**: the "prove it, publicly" mechanism
+   now exists, is reproducible (`docs/BENCHMARKS.md`'s entry has full
+   repro commands), and is honestly documented rather than oversold — but
+   it does not yet deliver the "model too large for one node, running at
+   usable speed, split across ≥2 heterogeneous nodes" proof this item and
+   the roadmap's "How we'll know it's working" section actually call for.
+   That specifically requires genuinely separate hardware (like the
+   2026-08-03 LAN entry's real second machine, just exercising the real
+   `ggml-rpc` path instead of the synthetic one) — a single Docker host
+   cannot produce it, no matter how the benchmark is tuned. **Remaining
+   work, now much better scoped**: run this same fabric's benchmark script
+   against two real separate machines with `-ngl -1` (or a real GPU split),
+   on a model that's actually too large for either machine alone. A second,
+   equally real finding worth carrying into item 3 below (automatic
+   sharding) and any future default-tuning work: a CPU-safe `-ngl 0`
+   default silently makes `distributed_inference: true` a no-op rather than
+   an error or a warning — worth surfacing to the user explicitly, not just
+   documenting in a benchmark footnote.
+
+   **Status check (2026-08-08, second update — the real separate-hardware
+   test now exists.)** Two real machines, native processes (not Docker),
+   `ghost-link` on each — see `BENCHMARKS.md`'s "native processes, two
+   genuinely separate physical machines" entry for the full account. The
+   real-hardware result: single-node 55.11 tok/s avg vs. distributed 53.57
+   tok/s avg on the 1.5B model — a small real cost (~2.8%), not the
+   hoped-for benefit, because `compute_tensor_split`'s VRAM-only
+   proportionality floors any non-GPU contributor (Iprada declared 0GB
+   VRAM) to a token ~2.4% share regardless of its real CPU/RAM capacity.
+   Attempting to force a genuine capacity benefit with a bigger model (7B,
+   then a second 5GB model) did **not** produce the "too large for one
+   node, works when split" proof either — instead it surfaced four real,
+   distinct, previously-unknown bugs (a quantized-KV-cache crash on the
+   RPC/CPU backend, an unsupervised contributor child process, a
+   90-second readiness timeout too short for real cross-machine RPC loads,
+   and — the serious one — silent output corruption from unversioned
+   `ggml-rpc` peers, confirmed via a controlled test). See the Risks
+   section below and `BENCHMARKS.md` for full detail on each. **Net
+   effect**: this item is now blocked less by "we haven't tested real
+   hardware" and more by "real hardware testing found real bugs that
+   should be fixed before the compelling benchmark is published" —
+   publishing a flattering number before the version-mismatch corruption
+   bug is addressed would be actively misleading given how easy that
+   failure mode is to hit unknowingly (any two machines that haven't been
+   deliberately kept in version lockstep).
+
+   **Status check (2026-08-08, third update — the actual proof landed.)**
+   With `llama.cpp` versions matched (closing the corruption bug above),
+   the same two-machine pairing loaded and correctly served a real
+   30B-class model (`Qwen3-Coder-30B-A3B-Instruct-Q3_K_L`, 13.58 GiB) that
+   **genuinely cannot load on the coordinator alone** — confirmed via a
+   real `ErrorOutOfDeviceMemory` single-node failure, not a timeout or a
+   contrived constraint. The distributed path found and worked around a
+   real driver-level bug along the way (Vulkan/Mesa on the contributor's
+   iGPU not reclaiming freed device memory across repeated large
+   alloc→free cycles, diagnosed down to the exact command sequence via
+   upstream llama.cpp's own `GGML_RPC_DEBUG` logging — see
+   `BENCHMARKS.md`'s Result 3 for the full diagnostic trail) by reducing
+   `-ngl` to send fewer total layers to the constrained device. Real,
+   correct, coherent output followed, including working Python code
+   generation. **This is genuinely the "too large for one node, works
+   when split" proof this item has been chasing all along** — half of the
+   roadmap's target claim, confirmed on real hardware for the first time.
+   The other half, **usable speed**, is not yet there: 1.5-2.5 tok/s
+   generation is real and correct but slow, not the "usable speed"
+   language in "How we'll know it's working" below describes. Don't
+   publish this as the flagship benchmark number without that caveat
+   attached — it's the capacity proof, not the performance proof.
 3. **JS/TS client SDK**, mirroring `sdks/python`'s shape (nested
    `chat.completions`, real SSE streaming, typed errors). This is the
    difference between "has an API" and "has an ecosystem" — most people
@@ -225,7 +318,14 @@ Once Priority Zero is real and provable, these make it hard to copy.
    startup. This is the feature that turns "distributed" into "resilient,"
    and it's the kind of thing vLLM's static deployment model doesn't
    attempt and Kubernetes-based setups solve with a completely different
-   (much heavier) toolset.
+   (much heavier) toolset. **Status check (2026-08-08): more groundwork
+   than "not started."** `load_balance.rs` already has a `rebalance()`
+   function and real config (`max_concurrent_rebalances`,
+   `recommended_workers`-derived defaults, a load threshold). What's
+   unconfirmed is whether anything calls `rebalance()` in response to a
+   live node join/leave/health-degrade event today, or whether it's only
+   invoked from a static planning pass — worth a quick read of the call
+   sites before scoping this as greenfield.
 2. **Speculative decoding across heterogeneous nodes** — a small/fast node
    (or NPU) drafts, a large/slow node verifies. This is a genuinely novel
    angle: nobody targets *consumer heterogeneous* hardware for this pattern
@@ -235,14 +335,26 @@ Once Priority Zero is real and provable, these make it hard to copy.
    <hf-repo>`), auto-picking a GGUF quant that fits the *cluster's*
    aggregate VRAM, not just one node's. Ollama's model library is one of
    its biggest UX wins; Ghostlink should match it while adding the
-   cluster-aware sizing Ollama structurally can't do.
+   cluster-aware sizing Ollama structurally can't do. **Status check
+   (2026-08-08): partially shipped.** HF search/pull already exists
+   (`ModelsTab.tsx`, HF handling in `main.rs`, a nightly
+   `hf-model-verify.yml` CI job that checks downloads keep working). The
+   part that's genuinely still missing is narrower than the original
+   framing: *cluster-aggregate-VRAM-aware* quant selection specifically —
+   picking a quant sized to what the whole discovered cluster can hold,
+   not one node.
 4. **LoRA / adapter support** in the native engine path — increasingly
    table-stakes, currently absent.
-5. **RBAC + audit logging that's actually populated** (`/api/security/audit-log`
-   exists today but is permanently empty — closing that is cheap and
-   directly serves the "enterprise-adjacent trust" wedge; multi-user API
-   keys with scoped permissions is the natural next step for any
-   team/household deployment beyond a single operator).
+5. **RBAC + audit logging that's actually populated.** **Status check
+   (2026-08-08): audit logging is done, RBAC is not.**
+   `/api/security/audit-log` used to be hardcoded to always return empty;
+   it's now backed by a real in-memory, capped (`AUDIT_LOG_CAP`) log of
+   actual security events (failed auth, PQC/JWT actions, tool-call
+   approvals — see `audit_log`/`record_audit_event` in `main.rs`). It
+   resets on restart and isn't a persistent append-only trail, but "empty"
+   is no longer accurate. What's still genuinely missing: multi-user API
+   keys with scoped permissions (RBAC) — that's the remaining piece for
+   any team/household deployment beyond a single operator.
 6. **Plugin marketplace-lite**: a `plugins.toml`-style registry (mirroring
    the existing `mcp_servers.toml` pattern) so third-party
    `InferenceBackendPlugin`/MCP-tool implementations can be discovered and
@@ -295,7 +407,14 @@ Bigger, riskier, higher payoff if the moat above is already real.
 - A published, reproducible benchmark showing a model too large for any
   single owned machine running at usable speed across ≥2 heterogeneous
   nodes, with a one-command setup — becomes the canonical "why Ghostlink"
-  demo, replacing prose claims with a number.
+  demo, replacing prose claims with a number. **Status (2026-08-08): half
+  done, on real hardware.** `BENCHMARKS.md`'s native two-machine entry,
+  Result 3, has the "too large for any single owned machine" half —
+  confirmed with a real single-node `ErrorOutOfDeviceMemory` failure and a
+  real, correct distributed success on the same model. "Usable speed" is
+  not yet there (1.5-2.5 tok/s) and the setup was not one-command (manual
+  native builds on both machines, plus real debugging of a driver-level
+  bug to get there). Don't call this item done from that entry alone.
 - Time-to-first-distributed-chat-completion on fresh hardware: target
   under 5 minutes from `curl | sh` to a cluster-routed response.
 - GitHub stars/forks growth rate and PyPI/npm SDK download counts as
@@ -304,6 +423,39 @@ Bigger, riskier, higher payoff if the moat above is already real.
 
 ## Risks
 
+- **`ggml-rpc` has no version-compatibility check between peers, and
+  mismatched builds silently corrupt output rather than failing.**
+  Confirmed on real, genuinely separate hardware (2026-08-08,
+  `BENCHMARKS.md`'s native two-machine entry — read it in full, this is
+  the most important finding in that document): two machines running
+  `llama.cpp` builds 10 days apart connected and exchanged data without
+  complaint, and larger-model inference through the real distributed path
+  came back as reproducible garbage (`"pérdida RencontreDBus并不是很
+  pérdida..."`) while the API reported `healthy`/HTTP 200 the entire time.
+  A controlled before/after test (same hardware, same model, only the
+  peer's `llama.cpp` commit changed) confirmed this as the root cause —
+  rebuilding both sides at an identical commit produced correct output.
+  Smaller models (1.5B) worked correctly despite the same mismatch, so the
+  exact trigger threshold isn't fully characterized, but the core problem
+  is clear and severe: **there is currently no way for an operator to
+  detect this from the API surface alone.** This ranks above the
+  authentication gap below in severity — an unauthenticated-but-correct
+  compute contribution is a trust problem; a silently-wrong answer that
+  reports itself as healthy is a correctness problem, and a much easier
+  one to ship without noticing. Needs a real fix before any "production
+  trustworthy" claim: at minimum, a version/build-fingerprint handshake at
+  RPC-connect time that refuses (or loudly warns on) a mismatch, not a
+  documentation-only caveat.
+- **Two related resilience gaps found in the same session**, lower
+  severity but real: (1) the spawned `ggml-rpc-server` contributor child
+  process isn't supervised — if it crashes (a real, separate bug: quantized
+  KV cache combined with the RPC-CPU backend aborts on an unimplemented op,
+  see `BENCHMARKS.md`), the node keeps *advertising* itself as RPC-capable
+  via discovery while actually unreachable, and nothing restarts it. (2)
+  the hardcoded 90-second model-ready timeout in `native_engine.rs` doesn't
+  account for real cross-machine RPC transfer time — a real load that
+  would have succeeded at 5 minutes gets aborted and reported as a failure
+  well before that. Both are concrete, scoped fixes, not research problems.
 - **Priority Zero shipped as an additive, off-by-default change**
   (`distributed_inference` defaults false; a single node reproduces prior
   behavior exactly) — still needs the CI integration test from Horizon 1
@@ -329,3 +481,9 @@ Bigger, riskier, higher payoff if the moat above is already real.
   broadcasting hardware specs — a meaningfully bigger blast radius if a
   hostile device is already on the network. Worth an explicit allowlist or
   auth shim ahead of any "enable this on an untrusted network" claim.
+  **Status check (2026-08-08): still unaddressed** — no allowlist or auth
+  shim exists in `rpc_cluster.rs` today. Given `contribute_compute` is a
+  real security boundary once RBAC/multi-user work (Horizon 2 item 5)
+  starts inviting more than a single trusted operator, this is worth
+  pulling forward alongside the Horizon 2 plugin-marketplace work rather
+  than leaving it last in Horizon 1's list.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -474,16 +474,26 @@ Bigger, riskier, higher payoff if the moat above is already real.
   target, not a rearchitecture.
 - **`ggml-rpc-server` (the new distributed-inference contributor process)
   has no built-in authentication** — an upstream llama.cpp limitation, not
-  something Ghostlink's layer can currently paper over. `contribute_compute`
-  is off by default and the startup log carries an explicit warning, but
-  this is the same trust-the-LAN posture as UDP/mDNS discovery, now backing
-  a service that accepts arbitrary compute jobs rather than just
+  something Ghostlink's layer can patch directly. `contribute_compute` is
+  off by default and the startup log carries an explicit warning, and this
+  is still the same trust-the-LAN posture as UDP/mDNS discovery, now
+  backing a service that accepts arbitrary compute jobs rather than just
   broadcasting hardware specs — a meaningfully bigger blast radius if a
-  hostile device is already on the network. Worth an explicit allowlist or
-  auth shim ahead of any "enable this on an untrusted network" claim.
-  **Status check (2026-08-08): still unaddressed** — no allowlist or auth
-  shim exists in `rpc_cluster.rs` today. Given `contribute_compute` is a
-  real security boundary once RBAC/multi-user work (Horizon 2 item 5)
-  starts inviting more than a single trusted operator, this is worth
-  pulling forward alongside the Horizon 2 plugin-marketplace work rather
-  than leaving it last in Horizon 1's list.
+  hostile device is already on the network.
+  **Status check (2026-08-08): partially addressed.** An IP allowlist now
+  exists: `rpc_allowed_peers` in settings.json (plain IPv4 addresses or IPv4
+  CIDR ranges) is enforced by a Ghostlink-owned TCP proxy in
+  `rpc_cluster.rs` — when the allowlist is non-empty, `ggml-rpc-server`
+  binds loopback-only and the proxy fronts the publicly-advertised port,
+  splicing through only allowed source IPs and closing everything else.
+  Empty (the default) is unchanged: `ggml-rpc-server` binds the public
+  address directly, zero overhead, zero behavior change. This is real
+  access control — "only these hosts/subnets," not "anyone on the LAN" —
+  but it is **not** authentication of the RPC protocol itself: a device
+  already inside an allowlisted range, or one able to spoof a source IP on
+  the LAN, is not stopped by it. Given `contribute_compute` is a real
+  security boundary once RBAC/multi-user work (Horizon 2 item 5) starts
+  inviting more than a single trusted operator, genuine protocol-level
+  auth (not just IP allowlisting) is still worth pulling forward alongside
+  the Horizon 2 plugin-marketplace work rather than treating this as fully
+  closed.

--- a/ghostlink_gui_modern/package-lock.json
+++ b/ghostlink_gui_modern/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostlink-studio-gui",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostlink-studio-gui",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "axios": "^1.6.0",

--- a/ghostlink_gui_modern/package.json
+++ b/ghostlink_gui_modern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostlink-studio-gui",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,178 @@
+<#
+.SYNOPSIS
+    Ghostlink one-line installer for Windows.
+
+.DESCRIPTION
+    Downloads the prebuilt ghost-link.exe binary published on this repo's
+    GitHub Releases (built by .github/workflows/release-artifacts.yml),
+    verifies it against the release's published SHA256SUMS-windows-latest
+    file, and installs it to a user-writable directory. No admin rights
+    required, nothing is added to PATH automatically.
+
+    This installs the ghost-link.exe binary only (CLI + OpenAI-compatible
+    API server) -- it does NOT install the Go control-plane gateway or the
+    built React GUI, which are not published as standalone release assets
+    today (only ghost-link-<os>*, SHA256SUMS-<os>, and an SBOM are -- see
+    scripts/release_bundle.sh). For the full browser GUI on Windows, clone
+    the repo and use launch.bat or launch-native.ps1 -- see the README's
+    Quick Start section.
+
+    Honesty notes, read before filing a bug:
+      - Only x86_64/amd64 Windows binaries are published as of this writing
+        -- there is no separate ARM64 build (check the `os:` matrix in
+        .github/workflows/release-artifacts.yml in case that has since
+        changed). This script refuses to install on non-AMD64 hosts rather
+        than handing you a binary that won't run.
+      - There is currently no code-signing certificate for these binaries,
+        so Windows SmartScreen may warn on first run of the downloaded
+        ghost-link.exe -- that is expected, not a sign this script did
+        anything wrong.
+
+.PARAMETER Version
+    Release tag to install, e.g. "v1.16.1". Defaults to $env:VERSION, or
+    the latest release if neither is set.
+
+.PARAMETER InstallDir
+    Directory to install ghost-link.exe into. Defaults to
+    $env:GHOSTLINK_INSTALL_DIR, or "$env:LOCALAPPDATA\Ghostlink\bin".
+
+.EXAMPLE
+    irm https://raw.githubusercontent.com/rwilliamspbg-ops/Ghostlink/main/scripts/install.ps1 | iex
+
+.EXAMPLE
+    $env:VERSION = "v1.16.1"
+    irm https://raw.githubusercontent.com/rwilliamspbg-ops/Ghostlink/main/scripts/install.ps1 | iex
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = $(if ($env:VERSION) { $env:VERSION } else { "latest" }),
+    [string]$InstallDir = $(if ($env:GHOSTLINK_INSTALL_DIR) { $env:GHOSTLINK_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA "Ghostlink\bin" })
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo   = "rwilliamspbg-ops/Ghostlink"
+$GitHub = "https://github.com/$Repo"
+$Api    = "https://api.github.com/repos/$Repo"
+
+function Write-Info([string]$Message) { Write-Host $Message }
+function Write-InstallWarning([string]$Message) { Write-Host "warning: $Message" -ForegroundColor Yellow }
+function Fail([string]$Message) {
+    Write-Host "error: $Message" -ForegroundColor Red
+    exit 1
+}
+
+# --- Arch check --------------------------------------------------------
+# No ARM64 Windows build exists today (single-arch matrix, no
+# cross-compilation step) -- refuse rather than install a binary that will
+# not execute. PROCESSOR_ARCHITECTURE reflects the current process's
+# architecture, so this is best-effort under x64 emulation on ARM64 Windows.
+$Arch = $env:PROCESSOR_ARCHITECTURE
+if ($Arch -ne "AMD64") {
+    Fail "unsupported architecture '$Arch'. Ghostlink release binaries are x86_64/amd64-only as of this writing -- there is no ARM64 build for Windows (check .github/workflows/release-artifacts.yml's build matrix in case this has changed since). Refusing to install a binary that won't run on this machine. Build from source instead: $GitHub#quick-start"
+}
+
+$BinAsset  = "ghost-link-windows-latest.exe"
+$SumsAsset = "SHA256SUMS-windows-latest"
+
+# --- Resolve version -----------------------------------------------------
+if ($Version -eq "latest") {
+    Write-Info "Looking up the latest Ghostlink release..."
+    try {
+        $Release = Invoke-RestMethod -UseBasicParsing -Uri "$Api/releases/latest" -Headers @{ "User-Agent" = "ghostlink-install.ps1" }
+    } catch {
+        Fail "failed to query $Api/releases/latest -- check your network connection ($($_.Exception.Message))"
+    }
+    $Tag = $Release.tag_name
+    if (-not $Tag) { Fail "could not determine the latest release tag from the GitHub API response" }
+} else {
+    $Tag = $Version
+}
+Write-Info "Installing Ghostlink $Tag (windows-latest, $Arch)"
+
+$DownloadBase = "$GitHub/releases/download/$Tag"
+$BinUrl  = "$DownloadBase/$BinAsset"
+$SumsUrl = "$DownloadBase/$SumsAsset"
+
+# --- Download --------------------------------------------------------------
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ghostlink-install-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
+
+try {
+    $TmpBin  = Join-Path $TmpDir $BinAsset
+    $TmpSums = Join-Path $TmpDir $SumsAsset
+
+    Write-Info "Downloading $BinAsset..."
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri $BinUrl -OutFile $TmpBin
+    } catch {
+        Fail "failed to download $BinUrl -- does release $Tag exist and include a windows-latest build? ($($_.Exception.Message))"
+    }
+
+    Write-Info "Downloading $SumsAsset for verification..."
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri $SumsUrl -OutFile $TmpSums
+    } catch {
+        Fail "failed to download $SumsUrl ($($_.Exception.Message))"
+    }
+
+    # --- Verify checksum -----------------------------------------------
+    # SHA256SUMS-windows-latest lines look like
+    # "<hash> *./ghost-link-windows-latest.exe" (binary mode -- what the
+    # windows-latest runner's sha256sum actually emits) but handle the
+    # "<hash>  ./name" text-mode format too (seen on ubuntu-latest /
+    # macos-latest) in case a future runner image changes this.
+    $ExpectedHash = $null
+    foreach ($line in Get-Content -Path $TmpSums) {
+        if ($line -match '^([0-9a-fA-F]{64})\s+\*?\.\/?(.+)$') {
+            if ($Matches[2] -eq $BinAsset) {
+                $ExpectedHash = $Matches[1].ToLowerInvariant()
+                break
+            }
+        }
+    }
+    if (-not $ExpectedHash) {
+        Fail "could not find a checksum entry for $BinAsset in $SumsAsset -- refusing to install an unverified binary"
+    }
+
+    $ActualHash = (Get-FileHash -Path $TmpBin -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($ActualHash -ne $ExpectedHash) {
+        Fail "checksum mismatch for ${BinAsset}: expected $ExpectedHash, got $ActualHash. The download may be corrupted or tampered with -- not installing."
+    }
+    Write-Info "Checksum verified (sha256:$ActualHash)"
+
+    # --- Install ---------------------------------------------------------
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    $Dest = Join-Path $InstallDir "ghost-link.exe"
+    Move-Item -Path $TmpBin -Destination $Dest -Force
+
+    Write-Host ""
+    Write-Host "Ghostlink $Tag installed to $Dest"
+    Write-Host ""
+
+    $PathDirs = $env:PATH -split ";"
+    $OnPath = $PathDirs | Where-Object { $_.TrimEnd("\") -eq $InstallDir.TrimEnd("\") }
+    if (-not $OnPath) {
+        Write-InstallWarning "$InstallDir is not on your PATH."
+        Write-Host "Add it permanently (current-user scope, no admin required), then open a new terminal:"
+        Write-Host "  [Environment]::SetEnvironmentVariable('Path', `$env:Path + ';$InstallDir', 'User')"
+        Write-Host ""
+    }
+
+    Write-Host "Next steps:"
+    Write-Host "  & `"$Dest`" --help"
+    Write-Host "  & `"$Dest`" doctor --strict         # sanity-check your setup"
+    Write-Host "  & `"$Dest`" serve 127.0.0.1 8003    # start the OpenAI-compatible API server"
+    Write-Host ""
+    Write-Host "This installs the ghost-link.exe binary only (CLI + OpenAI-compatible"
+    Write-Host "API server) -- it does not include the Go control-plane gateway or the"
+    Write-Host "React GUI, which aren't published as standalone release assets. For the"
+    Write-Host "full browser GUI, clone the repo and run 'launch.bat' or 'docker compose"
+    Write-Host "up': $GitHub#quick-start"
+    Write-Host ""
+    Write-Host "Models load from a 'models\' directory relative to wherever you run"
+    Write-Host "ghost-link.exe from. More: $GitHub/blob/main/docs/QUICKSTART.md"
+}
+finally {
+    Remove-Item -Path $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+# Ghostlink one-line installer (Linux / macOS)
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/rwilliamspbg-ops/Ghostlink/main/scripts/install.sh | sh
+#   VERSION=v1.16.1 sh install.sh          # install a specific release instead of latest
+#   GHOSTLINK_INSTALL_DIR=/opt/bin sh install.sh   # install somewhere other than ~/.local/bin
+#
+# This downloads the prebuilt `ghost-link` binary from this repo's GitHub
+# Releases (published by .github/workflows/release-artifacts.yml), verifies
+# it against the release's published SHA256SUMS file, and installs it to a
+# user-writable directory. No sudo, no package manager.
+#
+# What this does NOT install: the Go `control-plane` gateway or the built
+# React GUI. Only the `ghost-link` binary itself (plus SHA256SUMS and an
+# SBOM) is published as a release asset today -- see scripts/release_bundle.sh
+# and .github/workflows/release-artifacts.yml if you want to check. For the
+# full browser GUI, clone the repo and run `docker compose up` or
+# `./launch.sh` (see the README's Quick Start section instead).
+#
+# Honesty notes, read before filing a bug:
+#   - "Linux" here really means "the binary was built and tested on the
+#     ubuntu-latest GitHub Actions runner." There is no distro-specific
+#     testing or guarantee beyond that (e.g. it may not run on musl-based
+#     distros like Alpine).
+#   - Only x86_64/amd64 binaries are published as of this writing -- there is
+#     no separate arm64 build for any OS (check the `os:` matrix in
+#     .github/workflows/release-artifacts.yml if that has since changed).
+#     This script refuses to install on non-x86_64 hosts rather than
+#     silently handing you a binary that won't run.
+#
+# Written in POSIX sh on purpose (no bashisms) so `curl | sh` works
+# regardless of which shell `sh` happens to be on the target machine.
+
+set -eu
+
+REPO="rwilliamspbg-ops/Ghostlink"
+GITHUB="https://github.com/${REPO}"
+API="https://api.github.com/repos/${REPO}"
+
+VERSION="${VERSION:-latest}"
+INSTALL_DIR="${GHOSTLINK_INSTALL_DIR:-${HOME}/.local/bin}"
+
+info() { printf '%s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command '$1' not found on PATH"
+}
+
+need_cmd curl
+need_cmd uname
+need_cmd chmod
+need_cmd mktemp
+need_cmd awk
+
+# --- OS detection ----------------------------------------------------------
+# Maps 1:1 to the `os:` matrix in .github/workflows/release-artifacts.yml,
+# which is also the literal suffix baked into each release asset's filename
+# by scripts/release_bundle.sh (BIN_NAME="ghost-link-${PLATFORM_SUFFIX}...").
+os_name="$(uname -s)"
+case "$os_name" in
+  Linux)
+    asset_os="ubuntu-latest"
+    ;;
+  Darwin)
+    asset_os="macos-latest"
+    ;;
+  *)
+    die "unsupported OS '${os_name}'. Ghostlink release binaries are only published for Linux (built on ubuntu-latest) and macOS (built on macos-latest). On Windows, use scripts/install.ps1 instead, or build from source -- see the README's Quick Start."
+    ;;
+esac
+
+# --- Arch detection ----------------------------------------------------------
+# No arm64/aarch64 build exists for any OS today (single-arch matrix, no
+# cross-compilation step) -- warn clearly and refuse rather than install a
+# binary that will not execute.
+arch_name="$(uname -m)"
+case "$arch_name" in
+  x86_64 | amd64) : ;;
+  *)
+    die "unsupported architecture '${arch_name}'. Ghostlink release binaries are x86_64/amd64-only as of this writing -- there is no arm64/aarch64 build for Linux, macOS, or Windows (check .github/workflows/release-artifacts.yml's build matrix in case this has changed since). Refusing to install a binary that won't run on this machine. On Apple Silicon you may be able to run the x86_64 binary under Rosetta 2 if you have it installed, or build from source: ${GITHUB}#quick-start"
+    ;;
+esac
+
+bin_asset="ghost-link-${asset_os}"
+sums_asset="SHA256SUMS-${asset_os}"
+
+# --- Resolve version ---------------------------------------------------------
+if [ "$VERSION" = "latest" ]; then
+  info "Looking up the latest Ghostlink release..."
+  release_json="$(curl -fsSL "${API}/releases/latest")" \
+    || die "failed to query ${API}/releases/latest -- check your network connection"
+  tag="$(printf '%s' "$release_json" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//; s/".*//')"
+  [ -n "$tag" ] || die "could not determine the latest release tag from the GitHub API response"
+else
+  tag="$VERSION"
+fi
+info "Installing Ghostlink ${tag} (${asset_os}, ${arch_name})"
+
+download_base="${GITHUB}/releases/download/${tag}"
+bin_url="${download_base}/${bin_asset}"
+sums_url="${download_base}/${sums_asset}"
+
+# --- Download ------------------------------------------------------------
+tmp_dir="$(mktemp -d)"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT INT TERM
+
+tmp_bin="${tmp_dir}/${bin_asset}"
+tmp_sums="${tmp_dir}/${sums_asset}"
+
+info "Downloading ${bin_asset}..."
+curl -fsSL -o "$tmp_bin" "$bin_url" \
+  || die "failed to download ${bin_url} -- does release ${tag} exist and include a ${asset_os} build?"
+
+info "Downloading ${sums_asset} for verification..."
+curl -fsSL -o "$tmp_sums" "$sums_url" \
+  || die "failed to download ${sums_url}"
+
+# --- Verify checksum -------------------------------------------------------
+# SHA256SUMS-* files are the direct output of `sha256sum`/`shasum -a 256`
+# (see scripts/release_bundle.sh) and list every file in the release bundle,
+# not just the binary -- lines look like "<hash>  ./ghost-link-ubuntu-latest"
+# (text mode) or "<hash> *./ghost-link-ubuntu-latest" (binary mode, seen on
+# the windows-latest runner's sha256sum). Match on the last field with any
+# leading '*' stripped so either format is handled.
+expected_hash="$(awk -v want="./${bin_asset}" '
+  { name = $NF; sub(/^\*/, "", name); if (name == want) print $1 }
+' "$tmp_sums" | head -1)"
+
+[ -n "$expected_hash" ] \
+  || die "could not find a checksum entry for ${bin_asset} in ${sums_asset} -- refusing to install an unverified binary"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_hash="$(sha256sum "$tmp_bin" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_hash="$(shasum -a 256 "$tmp_bin" | awk '{print $1}')"
+else
+  die "neither sha256sum nor shasum is available -- cannot verify the download's integrity, refusing to install"
+fi
+
+if [ "$expected_hash" != "$actual_hash" ]; then
+  die "checksum mismatch for ${bin_asset}: expected ${expected_hash}, got ${actual_hash}. The download may be corrupted or tampered with -- not installing."
+fi
+info "Checksum verified (sha256:${actual_hash})"
+
+chmod +x "$tmp_bin"
+
+# --- Install ---------------------------------------------------------------
+mkdir -p "$INSTALL_DIR" 2>/dev/null \
+  || die "could not create install directory '${INSTALL_DIR}'. Set GHOSTLINK_INSTALL_DIR to a writable directory and retry."
+[ -w "$INSTALL_DIR" ] \
+  || die "install directory '${INSTALL_DIR}' is not writable. Set GHOSTLINK_INSTALL_DIR to a writable directory and retry (this script never uses sudo)."
+
+dest="${INSTALL_DIR}/ghost-link"
+mv "$tmp_bin" "$dest"
+
+info ""
+info "Ghostlink ${tag} installed to ${dest}"
+info ""
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    warn "${INSTALL_DIR} is not on your PATH."
+    info "Add it, e.g.:"
+    info "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    info "and add that line to your shell profile (~/.bashrc, ~/.zshrc, ~/.profile, etc.) to persist it."
+    info ""
+    ;;
+esac
+
+info "Next steps:"
+info "  ${dest} --help"
+info "  ${dest} doctor --strict         # sanity-check your setup"
+info "  ${dest} serve 127.0.0.1 8003    # start the OpenAI-compatible API server"
+info ""
+info "This installs the ghost-link binary only (CLI + OpenAI-compatible API"
+info "server) -- it does not include the Go control-plane gateway or the"
+info "React GUI, which aren't published as standalone release assets. For"
+info "the full browser GUI, clone the repo and run 'docker compose up' or"
+info "'./launch.sh': ${GITHUB}#quick-start"
+info ""
+info "Models load from a 'models/' directory relative to wherever you run"
+info "ghost-link from. More: ${GITHUB}/blob/main/docs/QUICKSTART.md"

--- a/scripts/rpc_fabric_assert.py
+++ b/scripts/rpc_fabric_assert.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Verification script for docker-compose.rpc-fabric.yml.
+
+Proves Ghostlink's real distributed-inference feature (llama.cpp's ggml-rpc
+backend, see crates/ghost-link/src/rpc_cluster.rs) works end to end across
+two containers:
+
+  1. Waits for both containers' /health to come up.
+  2. Confirms UDP discovery actually found the peer (GET /api/workers/discover).
+  3. PATCHes distributed_inference=true on the coordinator via the live
+     /api/settings API (idempotent — compose already sets it, but this
+     mirrors the original live-toggle verification from commit 46a023c).
+  4. Loads the tiny GGUF test model on the coordinator (POST /api/models/load).
+  5. POSTs a real chat completion and asserts real_inference: true.
+  6. Greps the contributor's ggml-rpc-server log (GHOSTLINK_RPC_SERVER_LOG)
+     for real connection activity — a passing chat completion alone is not
+     enough evidence the contributor did any work; upstream ggml-rpc-server
+     logs a line per incoming connection, which is what's checked here.
+
+Two things that are NOT obvious from the task description but are load-
+bearing here, discovered by actually running this against the built images:
+
+- main.rs forces TLS on for any non-loopback bind host
+  (`let use_tls = settings.enable_tls || !tls::is_loopback_host(host);`),
+  independent of `enable_tls` in settings.json. Both containers bind
+  0.0.0.0 (required for the other container / published host port to reach
+  them), so they always serve HTTPS with a self-signed cert — every request
+  here uses `verify=False`.
+- auth_middleware requires `Authorization: Bearer <key>` on every route
+  except /health. scripts/rpc_fabric_entrypoint.sh seeds a fixed, known key
+  into api_key.txt before ghost-link starts (GHOSTLINK_API_KEY in the
+  compose file) specifically so this script doesn't have to scrape a
+  randomly-generated one out of container logs.
+
+Exits non-zero (with the reason printed) on any failed step. Mirrors the
+wait_http polling style in scripts/run_native_llama_server_stack.sh, and the
+requests-based approach of scripts/remote_flow_benchmark.py.
+"""
+
+import argparse
+import subprocess
+import sys
+import time
+
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+COORDINATOR_URL = "https://127.0.0.1:8010"
+API_KEY = "ghostlink-rpc-fabric-test-key-0123456789abcdef0123456789abcdef"
+MODEL_NAME = "stories15M-q4_0"
+CONTRIBUTOR_CONTAINER = "ghostlink-rpc-contributor"
+COORDINATOR_CONTAINER = "ghostlink-rpc-coordinator"
+RPC_SERVER_LOG_PATH = "/tmp/ggml-rpc-server.log"
+
+HEADERS = {"Authorization": f"Bearer {API_KEY}"}
+
+
+def log(msg: str) -> None:
+    print(f"[assert] {msg}", flush=True)
+
+
+def wait_http(url: str, label: str, attempts: int = 60, delay: float = 2.0):
+    last_err = None
+    for i in range(1, attempts + 1):
+        try:
+            resp = requests.get(url, timeout=3, verify=False)
+            if resp.ok:
+                log(f"{label} is ready ({url}) after {i} attempt(s)")
+                return resp
+        except requests.RequestException as err:
+            last_err = err
+        time.sleep(delay)
+    raise SystemExit(f"FAIL: {label} never became ready at {url}: {last_err}")
+
+
+def docker_exec(container: str, *cmd: str) -> str:
+    result = subprocess.run(
+        ["docker", "exec", container, *cmd],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout + result.stderr
+
+
+def step(n: int, title: str) -> None:
+    print(f"\n=== Step {n}: {title} ===", flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--coordinator-url", default=COORDINATOR_URL)
+    args = parser.parse_args()
+    base = args.coordinator_url.rstrip("/")
+
+    step(1, "wait for both containers healthy")
+    wait_http(f"{base}/health", "rpc-coordinator API")
+    contributor_health = docker_exec(
+        CONTRIBUTOR_CONTAINER, "curl", "-fsSk", "https://localhost:8003/health"
+    )
+    if not contributor_health.strip():
+        raise SystemExit("FAIL: rpc-contributor /health returned nothing")
+    log(f"rpc-contributor /health: {contributor_health.strip()}")
+
+    step(2, "confirm UDP discovery found the peer")
+    discover_resp = None
+    for attempt in range(1, 11):
+        r = requests.get(
+            f"{base}/api/workers/discover", headers=HEADERS, timeout=10, verify=False
+        )
+        r.raise_for_status()
+        discover_resp = r.json()
+        log(f"attempt {attempt}: {discover_resp}")
+        if discover_resp.get("count", 0) >= 2:
+            break
+        time.sleep(3)
+    else:
+        raise SystemExit(
+            f"FAIL: discovery never found the contributor peer. Last response: {discover_resp}"
+        )
+    log(f"discovery OK: {discover_resp}")
+
+    step(3, "PATCH distributed_inference=true via live /api/settings")
+    r = requests.post(
+        f"{base}/api/settings",
+        json={"distributed_inference": True},
+        headers=HEADERS,
+        timeout=10,
+        verify=False,
+    )
+    r.raise_for_status()
+    settings = requests.get(
+        f"{base}/api/settings", headers=HEADERS, timeout=10, verify=False
+    ).json()
+    if not settings.get("distributed_inference"):
+        raise SystemExit(f"FAIL: distributed_inference did not stick: {settings}")
+    log(f"distributed_inference confirmed true: rpc_port={settings.get('rpc_port')}")
+
+    step(4, "load the tiny GGUF model on the coordinator")
+    r = requests.post(
+        f"{base}/api/models/load",
+        json={"model": MODEL_NAME},
+        headers=HEADERS,
+        timeout=120,
+        verify=False,
+    )
+    r.raise_for_status()
+    load_result = r.json()
+    log(f"load result: {load_result}")
+    if "error" in load_result:
+        raise SystemExit(f"FAIL: model load reported an error: {load_result}")
+
+    step(5, "POST a real chat completion")
+    r = requests.post(
+        f"{base}/v1/chat/completions",
+        json={
+            "model": MODEL_NAME,
+            "messages": [
+                {"role": "user", "content": "Once upon a time there was a"}
+            ],
+            "max_tokens": 32,
+        },
+        headers=HEADERS,
+        timeout=120,
+        verify=False,
+    )
+    r.raise_for_status()
+    chat_result = r.json()
+    log(f"chat completion response: {chat_result}")
+    message = chat_result.get("choices", [{}])[0].get("message", {})
+    content = message.get("content", "")
+    real_inference = message.get("real_inference")
+
+    if not real_inference:
+        raise SystemExit(
+            f"FAIL: real_inference was not true in the chat completion response: {chat_result}"
+        )
+    if not content.strip():
+        raise SystemExit("FAIL: chat completion returned empty content")
+
+    log(f"real_inference=True, generated text: {content!r}")
+
+    step(6, "grep the contributor's ggml-rpc-server log for real connection activity")
+    rpc_log = docker_exec(CONTRIBUTOR_CONTAINER, "cat", RPC_SERVER_LOG_PATH)
+    if not rpc_log.strip():
+        raise SystemExit(
+            f"FAIL: {RPC_SERVER_LOG_PATH} on {CONTRIBUTOR_CONTAINER} is empty — "
+            "no evidence the contributor's ggml-rpc-server ever saw a connection. "
+            "A passing chat completion alone does not prove real distributed "
+            "work happened."
+        )
+    log(f"ggml-rpc-server log ({RPC_SERVER_LOG_PATH}), last 40 lines:")
+    for line in rpc_log.strip().splitlines()[-40:]:
+        print(f"    {line}")
+
+    lowered = rpc_log.lower()
+    connection_evidence = any(
+        marker in lowered
+        for marker in (
+            "client connect",
+            "accepted client",
+            "new connection",
+            "start_rpc_server",
+            "127.0.0.1",
+            "172.30.",
+        )
+    )
+    if not connection_evidence:
+        raise SystemExit(
+            "FAIL: ggml-rpc-server log exists but shows no recognizable connection "
+            "evidence (checked for connect/accept/start_rpc_server/peer-IP markers). "
+            "Log contents printed above — inspect manually."
+        )
+
+    step(7, "also show the coordinator's own log building the --rpc / -ts flags")
+    logs_result = subprocess.run(
+        ["docker", "logs", "--tail", "400", COORDINATOR_CONTAINER],
+        capture_output=True,
+        text=True,
+    )
+    coordinator_logs = logs_result.stdout + logs_result.stderr
+    rpc_flag_lines = [
+        line
+        for line in coordinator_logs.splitlines()
+        if "--rpc" in line
+        or "Distributed inference enabled" in line
+        or "Tensor split" in line
+    ]
+    if rpc_flag_lines:
+        log("coordinator log lines showing --rpc/-ts construction:")
+        for line in rpc_flag_lines:
+            print(f"    {line}")
+    else:
+        log(
+            "WARNING: no '--rpc'/'Tensor split' lines found in coordinator's recent "
+            "logs (may have scrolled past --tail 400); real_inference:true and the "
+            "contributor's connection log above are still the load-bearing evidence."
+        )
+
+    print("\n=== ALL CHECKS PASSED ===")
+    print(f"real_inference: {real_inference}")
+    print(f"generated text: {content!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rpc_fabric_benchmark.py
+++ b/scripts/rpc_fabric_benchmark.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Real single-node vs. multi-node benchmark for Ghostlink's ggml-rpc
+distributed-inference path (docker-compose.rpc-fabric-benchmark.yml).
+
+Unlike scripts/remote_flow_benchmark.py (which drives the synthetic
+`flow`/`stage-worker` pipeline harness — fake f32 payloads timed through a
+TCP bridge, no real model math) and scripts/rpc_fabric_assert.py (a pass/
+fail CI correctness gate, not a benchmark), this script:
+
+  1. Runs N repeated timed chat completions through the REAL distributed
+     path — `distributed_inference: true` on the coordinator, a real
+     `llama-server --rpc <contributor>:50052 -ts <split>` process, real
+     cross-container RPC tensor execution (see crates/ghost-link/src/
+     rpc_cluster.rs) — verified per-phase the same way
+     scripts/rpc_fabric_assert.py does: `real_inference: true` in the
+     response, plus fresh "Accepted client connection" lines in the
+     contributor's ggml-rpc-server log (GHOSTLINK_RPC_SERVER_LOG).
+  2. Also runs the same N trials in single-node mode
+     (`distributed_inference: false`, coordinator alone) against the exact
+     same model and prompt, so the numbers show what distribution actually
+     costs or gains here — not one number in isolation.
+  3. Records real per-container memory (cgroup memory.current, not `docker
+     stats`' cache-inclusive summary) right after each phase's model load,
+     to answer the "does a tensor-split reduce the coordinator's own local
+     memory footprint" question empirically instead of by assumption.
+
+Uses the OpenAI-compatible-but-metrics-bearing `/api/inference/chat` route
+(the GUI's chat endpoint — NOT `/v1/chat/completions`, which returns no
+token/timing data at all), which reports `tokens_generated`,
+`tokens_estimated` (a word-count prompt-token estimate — see
+`handle_gui_chat` in crates/ghost-link/src/main.rs, `token_estimate =
+req.message.split_whitespace().count()...` — not an exact tokenizer count),
+and `metrics.throughput` (tokens_out / measured llama-server generation
+wall time, computed server-side).
+
+Output shape mirrors scripts/remote_flow_benchmark.py: raw per-run JSON
+plus a summary.json with avg/min/max, for each of the two modes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+DEFAULT_PROMPT = (
+    "Explain in one paragraph why distributed systems need consensus "
+    "protocols, and give one real-world example."
+)
+
+
+def log(msg: str) -> None:
+    print(f"[bench] {msg}", flush=True)
+
+
+def wait_http(url: str, label: str, attempts: int = 90, delay: float = 2.0):
+    last_err = None
+    for i in range(1, attempts + 1):
+        try:
+            resp = requests.get(url, timeout=3, verify=False)
+            if resp.ok:
+                log(f"{label} is ready ({url}) after {i} attempt(s)")
+                return resp
+        except requests.RequestException as err:
+            last_err = err
+        time.sleep(delay)
+    raise SystemExit(f"FAIL: {label} never became ready at {url}: {last_err}")
+
+
+def docker_exec(container: str, *cmd: str) -> str:
+    result = subprocess.run(
+        ["docker", "exec", container, *cmd],
+        capture_output=True,
+        text=True,
+    )
+    return (result.stdout + result.stderr).strip()
+
+
+def read_cgroup_memory_bytes(container: str) -> dict:
+    """Real resident memory (cgroup, not docker stats' derived/cached
+    number) for `container`. Tries cgroup v2 first, falls back to v1.
+    Returns current usage plus (when available from memory.stat) the
+    anon-vs-file breakdown, which is the load-bearing distinction for the
+    mmap question this script investigates: file-backed pages from an
+    mmap'd GGUF are reclaimable cache, not the same as real committed
+    anonymous memory.
+    """
+    current_raw = docker_exec(container, "cat", "/sys/fs/cgroup/memory.current")
+    if current_raw and current_raw.strip().isdigit():
+        stat_raw = docker_exec(container, "cat", "/sys/fs/cgroup/memory.stat")
+        stat = {}
+        for line in stat_raw.splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1].isdigit():
+                stat[parts[0]] = int(parts[1])
+        return {
+            "cgroup_version": 2,
+            "memory_current_bytes": int(current_raw.strip()),
+            "anon_bytes": stat.get("anon"),
+            "file_bytes": stat.get("file"),
+        }
+
+    # cgroup v1 fallback
+    usage_raw = docker_exec(container, "cat", "/sys/fs/cgroup/memory/memory.usage_in_bytes")
+    if usage_raw and usage_raw.strip().isdigit():
+        stat_raw = docker_exec(container, "cat", "/sys/fs/cgroup/memory/memory.stat")
+        stat = {}
+        for line in stat_raw.splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1].isdigit():
+                stat[parts[0]] = int(parts[1])
+        return {
+            "cgroup_version": 1,
+            "memory_current_bytes": int(usage_raw.strip()),
+            "anon_bytes": stat.get("total_rss"),
+            "file_bytes": stat.get("total_cache"),
+        }
+
+    return {"cgroup_version": None, "memory_current_bytes": None, "anon_bytes": None, "file_bytes": None}
+
+
+def count_rpc_log_lines(container: str, log_path: str, marker: str = "Accepted client connection") -> int:
+    raw = docker_exec(container, "cat", log_path)
+    return sum(1 for line in raw.splitlines() if marker in line)
+
+
+def patch_distributed_inference(base: str, headers: dict, enabled: bool) -> dict:
+    r = requests.post(
+        f"{base}/api/settings",
+        json={"distributed_inference": enabled},
+        headers=headers,
+        timeout=10,
+        verify=False,
+    )
+    r.raise_for_status()
+    settings = requests.get(f"{base}/api/settings", headers=headers, timeout=10, verify=False).json()
+    if bool(settings.get("distributed_inference")) != enabled:
+        raise SystemExit(f"FAIL: distributed_inference did not stick to {enabled}: {settings}")
+    return settings
+
+
+def load_model(base: str, headers: dict, model: str, timeout: int = 180) -> dict:
+    r = requests.post(
+        f"{base}/api/models/load",
+        json={"model": model},
+        headers=headers,
+        timeout=timeout,
+        verify=False,
+    )
+    r.raise_for_status()
+    result = r.json()
+    if "error" in result:
+        raise SystemExit(f"FAIL: model load reported an error: {result}")
+    return result
+
+
+def run_chat(base: str, headers: dict, prompt: str, max_tokens: int, timeout: int = 180) -> dict:
+    wall_start = time.time()
+    r = requests.post(
+        f"{base}/api/inference/chat",
+        json={"message": prompt, "max_tokens": max_tokens},
+        headers=headers,
+        timeout=timeout,
+        verify=False,
+    )
+    wall_ms = (time.time() - wall_start) * 1000.0
+    r.raise_for_status()
+    result = r.json()
+    result["_measured_wall_ms"] = wall_ms
+    return result
+
+
+def run_phase(
+    label: str,
+    base: str,
+    headers: dict,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    runs: int,
+    output_dir: Path,
+    coordinator_container: str,
+    contributor_container: str,
+    rpc_log_path: str,
+    expect_distributed: bool,
+) -> dict:
+    log(f"=== Phase: {label} (distributed_inference={expect_distributed}) ===")
+    patch_distributed_inference(base, headers, expect_distributed)
+
+    connections_before = count_rpc_log_lines(contributor_container, rpc_log_path)
+    load_started = time.time()
+    load_result = load_model(base, headers, model)
+    load_ms = (time.time() - load_started) * 1000.0
+    log(f"model load took {load_ms:.0f} ms: {load_result}")
+
+    # Settle briefly after llama-server reports ready before sampling
+    # memory — RSS/page-cache after a fresh exec/mmap can still be settling
+    # for a few hundred ms.
+    time.sleep(2.0)
+    post_load_memory = {
+        "coordinator": read_cgroup_memory_bytes(coordinator_container),
+        "contributor": read_cgroup_memory_bytes(contributor_container),
+    }
+    log(f"post-load memory: {post_load_memory}")
+
+    run_files = []
+    peak_memory = {"coordinator": 0, "contributor": 0}
+
+    def sample_peak():
+        for name, container in (("coordinator", coordinator_container), ("contributor", contributor_container)):
+            mem = read_cgroup_memory_bytes(container)
+            val = mem.get("memory_current_bytes") or 0
+            if val > peak_memory[name]:
+                peak_memory[name] = val
+
+    sample_peak()
+
+    for i in range(1, runs + 1):
+        result = run_chat(base, headers, prompt, max_tokens)
+        sample_peak()
+
+        real_inference = result.get("real_inference")
+        metrics = result.get("metrics", {})
+        run_record = {
+            "run": i,
+            "phase": label,
+            "real_inference": real_inference,
+            "tokens_estimated_prompt": result.get("tokens_estimated"),
+            "tokens_generated": result.get("tokens_generated"),
+            "exec_tokens": result.get("exec_tokens"),
+            "throughput_tokens_per_sec": metrics.get("throughput"),
+            "latency_ms": metrics.get("latency_ms"),
+            "p50_ms": metrics.get("p50_ms"),
+            "p95_ms": metrics.get("p95_ms"),
+            "measured_wall_ms": result.get("_measured_wall_ms"),
+        }
+        log(
+            f"  run {i}/{runs}: tokens={run_record['tokens_generated']} "
+            f"throughput={run_record['throughput_tokens_per_sec']} tok/s "
+            f"latency={run_record['latency_ms']} ms real_inference={real_inference}"
+        )
+        if expect_distributed and not real_inference:
+            raise SystemExit(f"FAIL: distributed phase run {i} did not report real_inference=true: {result}")
+
+        out_file = output_dir / f"{label}-{i}.json"
+        out_file.write_text(json.dumps(run_record, indent=2), encoding="utf-8")
+        run_files.append(out_file)
+
+    connections_after = count_rpc_log_lines(contributor_container, rpc_log_path)
+    new_connections = connections_after - connections_before
+    log(f"contributor rpc log: {connections_before} -> {connections_after} accepted connections (+{new_connections})")
+    if expect_distributed and new_connections <= 0:
+        raise SystemExit(
+            "FAIL: distributed phase completed but the contributor's ggml-rpc-server log shows "
+            "no new accepted connections — real_inference:true alone is not being trusted here."
+        )
+
+    values = [json.loads(f.read_text(encoding="utf-8")) for f in run_files]
+    throughput = [v["throughput_tokens_per_sec"] for v in values if v["throughput_tokens_per_sec"] is not None]
+    latency = [v["latency_ms"] for v in values if v["latency_ms"] is not None]
+    wall = [v["measured_wall_ms"] for v in values if v["measured_wall_ms"] is not None]
+    tokens_gen = [v["tokens_generated"] for v in values if v["tokens_generated"] is not None]
+
+    summary = {
+        "phase": label,
+        "distributed_inference": expect_distributed,
+        "runs": len(values),
+        "new_rpc_connections_observed": new_connections,
+        "load_ms": load_ms,
+        "post_load_memory_bytes": post_load_memory,
+        "peak_memory_bytes_during_runs": peak_memory,
+        "tokens_generated_avg": statistics.mean(tokens_gen) if tokens_gen else None,
+    }
+    if throughput:
+        summary["throughput_tok_s_avg"] = statistics.mean(throughput)
+        summary["throughput_tok_s_min"] = min(throughput)
+        summary["throughput_tok_s_max"] = max(throughput)
+        summary["throughput_tok_s_stdev"] = statistics.pstdev(throughput) if len(throughput) > 1 else 0.0
+    if latency:
+        summary["latency_ms_avg"] = statistics.mean(latency)
+        summary["latency_ms_min"] = min(latency)
+        summary["latency_ms_max"] = max(latency)
+    if wall:
+        summary["measured_wall_ms_avg"] = statistics.mean(wall)
+
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--coordinator-url", default="https://127.0.0.1:8020")
+    parser.add_argument("--api-key", default="ghostlink-rpc-fabric-bench-test-key-0123456789abcdef0123456789ab")
+    parser.add_argument("--model", default="qwen2.5-1.5b-instruct-q4_k_m")
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--output-dir", default="tmp/rpc_fabric_benchmark")
+    parser.add_argument("--coordinator-container", default="ghostlink-rpc-bench-coordinator")
+    parser.add_argument("--contributor-container", default="ghostlink-rpc-bench-contributor")
+    parser.add_argument("--rpc-log-path", default="/tmp/ggml-rpc-server.log")
+    parser.add_argument(
+        "--skip-single-node",
+        action="store_true",
+        help="Only run the distributed phase (e.g. for a quick real_inference smoke check).",
+    )
+    args = parser.parse_args()
+
+    if args.runs <= 0:
+        parser.error("--runs must be greater than 0")
+
+    base = args.coordinator_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {args.api_key}"}
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    log("waiting for coordinator health")
+    wait_http(f"{base}/health", "rpc-bench-coordinator API")
+    contributor_health = docker_exec(args.contributor_container, "curl", "-fsSk", "https://localhost:8003/health")
+    if not contributor_health.strip():
+        raise SystemExit("FAIL: rpc-bench-contributor /health returned nothing")
+    log(f"rpc-bench-contributor /health: {contributor_health.strip()}")
+
+    log("confirming UDP discovery found the peer")
+    discover_resp = None
+    for attempt in range(1, 11):
+        r = requests.get(f"{base}/api/workers/discover", headers=headers, timeout=10, verify=False)
+        r.raise_for_status()
+        discover_resp = r.json()
+        if discover_resp.get("count", 0) >= 2:
+            break
+        time.sleep(3)
+    else:
+        raise SystemExit(f"FAIL: discovery never found the contributor peer. Last response: {discover_resp}")
+    log(f"discovery OK: {discover_resp}")
+
+    phases = {}
+    if not args.skip_single_node:
+        phases["single-node"] = run_phase(
+            "single-node",
+            base,
+            headers,
+            args.model,
+            args.prompt,
+            args.max_tokens,
+            args.runs,
+            output_dir,
+            args.coordinator_container,
+            args.contributor_container,
+            args.rpc_log_path,
+            expect_distributed=False,
+        )
+
+    phases["distributed"] = run_phase(
+        "distributed",
+        base,
+        headers,
+        args.model,
+        args.prompt,
+        args.max_tokens,
+        args.runs,
+        output_dir,
+        args.coordinator_container,
+        args.contributor_container,
+        args.rpc_log_path,
+        expect_distributed=True,
+    )
+
+    summary = {
+        "model": args.model,
+        "runs_per_phase": args.runs,
+        "max_tokens": args.max_tokens,
+        "prompt": args.prompt,
+        "phases": phases,
+    }
+
+    print("\n=== SUMMARY ===")
+    for name, phase in phases.items():
+        print(
+            f"{name}: throughput_avg={phase.get('throughput_tok_s_avg', float('nan')):.2f} tok/s "
+            f"(min={phase.get('throughput_tok_s_min', float('nan')):.2f} "
+            f"max={phase.get('throughput_tok_s_max', float('nan')):.2f}) "
+            f"latency_avg={phase.get('latency_ms_avg', float('nan')):.1f} ms "
+            f"coordinator_post_load_mem={phase['post_load_memory_bytes']['coordinator'].get('memory_current_bytes')} bytes"
+        )
+
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    log(f"wrote {output_dir / 'summary.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rpc_fabric_entrypoint.sh
+++ b/scripts/rpc_fabric_entrypoint.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Entrypoint for the docker-compose.rpc-fabric.yml containers.
+#
+# ghost-link's `load_settings()` (crates/ghost-link/src/main.rs) does
+# `serde_json::from_str::<RuntimeSettings>(&data).unwrap_or_default()` — if
+# ANY field without a `#[serde(default...)]` attribute is missing from
+# settings.json, the whole parse fails and it SILENTLY falls back to
+# RuntimeSettings::default() (contribute_compute/distributed_inference both
+# false). A partial JSON with only the fields we care about would therefore
+# silently do nothing. This script writes every field RuntimeSettings
+# declares (mirroring RuntimeSettings::default() in main.rs) so the file
+# always deserializes successfully.
+set -euo pipefail
+
+NODE_ID="${GHOSTLINK_NODE_ID:?GHOSTLINK_NODE_ID must be set}"
+API_HOST="${GHOSTLINK_API_HOST:-0.0.0.0}"
+API_PORT="${GHOSTLINK_API_PORT:-8003}"
+CONTRIBUTE_COMPUTE="${GHOSTLINK_CONTRIBUTE_COMPUTE:-false}"
+DISTRIBUTED_INFERENCE="${GHOSTLINK_DISTRIBUTED_INFERENCE:-false}"
+RPC_PORT="${GHOSTLINK_RPC_PORT:-50052}"
+MODEL_PATH="${GHOSTLINK_MODEL_PATH:-/app/models/stories15M-q4_0.gguf}"
+MODELS_DIR="${GHOSTLINK_MODELS_DIR:-/app/models}"
+DISCOVERY_LISTEN="${GHOSTLINK_DISCOVERY_LISTEN:-0.0.0.0:45885}"
+DISCOVERY_BROADCAST="${GHOSTLINK_DISCOVERY_BROADCAST:-255.255.255.255:45885}"
+SETTINGS_PATH="${GHOSTLINK_SETTINGS_PATH:-/app/settings.json}"
+# main.rs forces TLS on whenever the bind host isn't loopback
+# (`let use_tls = settings.enable_tls || !tls::is_loopback_host(host);`),
+# regardless of `enable_tls` in settings.json. Binding 0.0.0.0 (required so
+# the other container / published host port can reach this API) therefore
+# always serves HTTPS with a self-signed cert — callers need `curl -k` /
+# `verify=False`, not plain http://.
+API_KEY_PATH="${GHOSTLINK_API_KEY_PATH:-/app/api_key.txt}"
+# auth::load_or_create_api_key() reuses whatever's already at this path
+# verbatim (trimmed) instead of generating a random one, so pre-seeding it
+# here gives scripts/rpc_fabric_assert.py a fixed, known bearer token
+# instead of having to scrape it out of container startup logs.
+API_KEY="${GHOSTLINK_API_KEY:-ghostlink-rpc-fabric-test-key-0123456789abcdef0123456789abcdef}"
+
+log() { printf '[entrypoint:%s] %s\n' "$NODE_ID" "$*"; }
+
+cat > "$SETTINGS_PATH" <<JSON
+{
+  "inference_backend": "native",
+  "native_engine": "llama_server",
+  "ngl": 0,
+  "model_path": "${MODEL_PATH}",
+  "models_dir": "${MODELS_DIR}",
+  "llama_server_url": "http://127.0.0.1:8080/completion",
+  "vllm_base_url": "http://127.0.0.1:8000",
+  "vllm_api_key": "",
+  "llama_port": 8080,
+  "api_host": "${API_HOST}",
+  "api_port": ${API_PORT},
+  "gui_port": 5173,
+  "threads": 4,
+  "ctx_size": 4096,
+  "parallel_slots": 1,
+  "temperature": 0.7,
+  "top_p": 0.9,
+  "top_k": 40,
+  "repeat_penalty": 1.1,
+  "max_tokens": 256,
+  "chat_exec_tokens": 256,
+  "chat_micro_batch": 4,
+  "tcp_max_inflight": 256,
+  "discovery_listen": "${DISCOVERY_LISTEN}",
+  "discovery_broadcast": "${DISCOVERY_BROADCAST}",
+  "discovery_auth_token": "",
+  "tcp_auth_token": "",
+  "xdp_interface": "eth0",
+  "conversation_token_limit": 1920,
+  "enable_tls": false,
+  "distributed_inference": ${DISTRIBUTED_INFERENCE},
+  "contribute_compute": ${CONTRIBUTE_COMPUTE},
+  "rpc_port": ${RPC_PORT}
+}
+JSON
+
+log "wrote $SETTINGS_PATH:"
+cat "$SETTINGS_PATH"
+
+printf '%s' "$API_KEY" > "$API_KEY_PATH"
+log "seeded fixed API key at $API_KEY_PATH (len=${#API_KEY})"
+
+# CPU-only container: force llama-server's -ngl to 0 regardless of any
+# VRAM-based auto-detection main.rs might otherwise attempt.
+export GHOSTLINK_LLAMA_NGL="${GHOSTLINK_LLAMA_NGL:-0}"
+export GHOSTLINK_NODE_ID="$NODE_ID"
+export GHOSTLINK_DISCOVERY_LISTEN="$DISCOVERY_LISTEN"
+export GHOSTLINK_DISCOVERY_BROADCAST="$DISCOVERY_BROADCAST"
+export GHOSTLINK_API_KEY_PATH="$API_KEY_PATH"
+
+log "starting: ghost-link serve $API_HOST $API_PORT"
+exec /app/bin/ghost-link serve "$API_HOST" "$API_PORT"

--- a/sdks/js/LICENSE
+++ b/sdks/js/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ghostlink contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdks/js/README.md
+++ b/sdks/js/README.md
@@ -1,0 +1,136 @@
+# ghostlink-client
+
+JavaScript/TypeScript client for a [Ghostlink](https://github.com/rwilliamspbg-ops/Ghostlink) Studio API server — the OpenAI-compatible REST endpoints (`/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`) plus Ghostlink's native `/api/*` surface (workers, sessions, settings, metrics, and real token-by-token streaming chat).
+
+This is the JS/TS counterpart of `sdks/python` — same method names, same nested structure (`client.chat.completions.create`, `client.workers.connect`, ...), same endpoints. Built on the native `fetch`/`ReadableStream` APIs, so it has no runtime dependencies and works in Node 18+ and modern browsers alike.
+
+## Install
+
+```bash
+npm install ghostlink-client
+```
+
+(Not yet published to npm — install from a local checkout or a Git URL until then.)
+
+## Quick start
+
+```ts
+import { GhostlinkClient } from "ghostlink-client";
+
+const client = new GhostlinkClient("http://127.0.0.1:8003", { apiKey: "<your api key>" });
+
+const resp = await client.chat.completions.create({
+  model: "llama3.2:3b",
+  messages: [{ role: "user", content: "Say hello in one sentence." }],
+});
+console.log(resp.content);
+```
+
+The API key is the one Ghostlink generates on first run (printed at startup, persisted to `api_key.txt` by default — see `GHOSTLINK_API_KEY_PATH`).
+
+## OpenAI-compatible endpoints
+
+```ts
+// Chat
+const resp = await client.chat.completions.create({ model: "llama3.2:3b", messages: [...] });
+
+// Legacy text completion
+const cmpl = await client.completions.create({ model: "llama3.2:3b", prompt: "Once upon a time" });
+console.log(cmpl.text);
+
+// Embeddings
+const emb = await client.embeddings.create({ model: "nomic-embed-text", input: "hello world" });
+
+// List models
+for (const m of await client.listModels()) {
+  console.log(m.id);
+}
+```
+
+## Real streaming chat
+
+`/v1/chat/completions` accepts a `stream` field but Ghostlink doesn't act on it yet — real token-by-token streaming is only available today through Ghostlink Studio's native chat endpoint:
+
+```ts
+for await (const chunk of client.streamChat("Tell me a short story")) {
+  if (chunk.error) {
+    console.log(`\n[error: ${chunk.token}]`);
+  } else if (!chunk.done) {
+    process.stdout.write(chunk.token);
+  }
+}
+```
+
+## Cluster, metrics, settings
+
+```ts
+await client.workers.list();
+await client.workers.discover();       // UDP broadcast + mDNS sweep
+await client.workers.connect("192.168.1.42", 8003);
+
+await client.metrics();                // JSON snapshot
+await client.metricsPrometheus();      // Prometheus exposition format
+
+await client.settings.get();
+await client.settings.update({ inference_backend: "ollama" });
+```
+
+## Error handling
+
+```ts
+import { GhostlinkAPIError, GhostlinkAuthError, GhostlinkConnectionError } from "ghostlink-client";
+
+try {
+  await client.chat.completions.create({ model: "x", messages: [] });
+} catch (err) {
+  if (err instanceof GhostlinkAuthError) {
+    console.log("bad or missing API key:", err.message);
+  } else if (err instanceof GhostlinkAPIError) {
+    console.log(`server rejected the request: HTTP ${err.statusCode}: ${err.message}`);
+  } else if (err instanceof GhostlinkConnectionError) {
+    console.log("could not reach the server:", err.message);
+  } else {
+    throw err;
+  }
+}
+```
+
+## Custom inference backends
+
+If the server has a custom backend plugin registered (see `backend_plugin.rs` / `GHOSTLINK_OPENAI_COMPAT_BASE_URL` in the main project), select it the same way as any built-in backend:
+
+```ts
+await client.settings.update({ inference_backend: "my_custom_backend" });
+const resp = await client.chat.completions.create({ model: "anything", messages: [...] });
+```
+
+## API surface at a glance
+
+| Python (`sdks/python`)                | JS/TS (this package)                    |
+| -------------------------------------- | ---------------------------------------- |
+| `client.chat.completions.create(...)`  | `client.chat.completions.create({...})`  |
+| `client.completions.create(...)`       | `client.completions.create({...})`       |
+| `client.embeddings.create(...)`        | `client.embeddings.create({...})`        |
+| `client.models.list()`                 | `client.models.list()`                   |
+| `client.list_models()`                 | `client.listModels()`                    |
+| `client.workers.list()` / `.discover()` / `.connect()` / `.add()` / `.disconnect()` | same, unchanged |
+| `client.sessions.list()`               | `client.sessions.list()`                 |
+| `client.settings.get()` / `.update()` / `.reset()` | same, unchanged |
+| `client.health()` / `.metrics()` / `.metrics_prometheus()` | `client.health()` / `.metrics()` / `.metricsPrometheus()` |
+| `client.studio_chat(...)`              | `client.studioChat(...)`                 |
+| `client.stream_chat(...)` (generator)  | `client.streamChat(...)` (async generator) |
+
+Method and namespace names match the Python client one-for-one; only casing follows each language's convention (`snake_case` in Python, `camelCase` in JS/TS) and multi-argument calls take a single options object instead of keyword arguments.
+
+## Node vs. browser
+
+This SDK is built on the standard `fetch`, `ReadableStream`, and `TextDecoder` APIs — no HTTP client dependency (no axios) — so it runs unmodified in Node 18+ and in any modern browser. The one caveat: calling it directly from a browser page means the API key ships in that page's JS, so for browser use put this behind your own backend (or a proxy that injects the key) rather than embedding a Ghostlink API key in client-side code.
+
+## Development
+
+```bash
+npm install
+npm run build       # emits dist/ (ESM + CJS + .d.ts)
+npm run type-check
+npm test
+```

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,0 +1,2830 @@
+{
+  "name": "ghostlink-client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ghostlink-client",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "tsup": "^8.5.1",
+        "typescript": "^5.3.0",
+        "vitest": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "ghostlink-client",
+  "version": "0.1.0",
+  "description": "JavaScript/TypeScript client for the Ghostlink Studio API: OpenAI-compatible chat/completions/embeddings, plus native token-streaming chat, workers, metrics, and settings.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "ghostlink",
+    "llm",
+    "self-hosted",
+    "inference",
+    "openai-compatible",
+    "sdk",
+    "streaming",
+    "sse"
+  ],
+  "author": "Ghostlink contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rwilliamspbg-ops/Ghostlink.git",
+    "directory": "sdks/js"
+  },
+  "homepage": "https://github.com/rwilliamspbg-ops/Ghostlink",
+  "bugs": {
+    "url": "https://github.com/rwilliamspbg-ops/Ghostlink/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "tsup": "^8.5.1",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/sdks/js/src/client.ts
+++ b/sdks/js/src/client.ts
@@ -1,0 +1,390 @@
+/**
+ * Client for a Ghostlink Studio API server.
+ *
+ * Wraps both the OpenAI-compatible REST surface (`/v1/chat/completions`,
+ * `/v1/completions`, `/v1/embeddings`, `/v1/models`) and Ghostlink's native
+ * `/api/*` surface (workers, sessions, settings, metrics, and real
+ * token-by-token streaming chat via `/api/inference/chat`).
+ *
+ * Mirrors `sdks/python/ghostlink_client/client.py` method-for-method and
+ * endpoint-for-endpoint. Parameter names use camelCase (idiomatic
+ * TypeScript) rather than the Python client's snake_case kwargs, but map
+ * onto the exact same JSON wire fields.
+ */
+
+import { iterSseJson, streamLines, type JsonObject } from "./sse.js";
+import { GhostlinkAPIError, GhostlinkAuthError, GhostlinkConnectionError } from "./exceptions.js";
+import { ChatCompletion, Completion, Model, StreamChunk } from "./models.js";
+
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface ChatMessage {
+  role: string;
+  content: string;
+  [key: string]: unknown;
+}
+
+/** Shared sampling parameters accepted by the OpenAI-compatible endpoints. */
+export interface SamplingParams {
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  penalty?: number;
+  maxTokens?: number;
+}
+
+export interface CreateChatCompletionParams extends SamplingParams {
+  model: string;
+  messages: ChatMessage[];
+}
+
+export interface CreateCompletionParams extends SamplingParams {
+  model: string;
+  prompt: string;
+}
+
+export interface CreateEmbeddingsParams {
+  model: string;
+  input: string | string[];
+}
+
+export interface StudioChatParams extends SamplingParams {
+  messages?: ChatMessage[];
+  model?: string;
+}
+
+function addOptional(payload: JsonObject, fields: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) payload[key] = value;
+  }
+}
+
+function samplingParamsToPayload(params: SamplingParams): JsonObject {
+  const payload: JsonObject = {};
+  addOptional(payload, {
+    temperature: params.temperature,
+    top_p: params.topP,
+    top_k: params.topK,
+    penalty: params.penalty,
+    max_tokens: params.maxTokens,
+  });
+  return payload;
+}
+
+function extractErrorMessage(body: unknown): string | undefined {
+  if (body && typeof body === "object") {
+    const error = (body as JsonObject).error;
+    if (error && typeof error === "object") {
+      const message = (error as JsonObject).message;
+      if (typeof message === "string") return message;
+    }
+    if (typeof error === "string") return error;
+  }
+  return undefined;
+}
+
+class ChatCompletions {
+  constructor(private readonly client: GhostlinkClient) {}
+
+  /** `POST /v1/chat/completions` — OpenAI-compatible, non-streaming. */
+  async create(params: CreateChatCompletionParams): Promise<ChatCompletion> {
+    const payload: JsonObject = {
+      model: params.model,
+      messages: params.messages,
+      ...samplingParamsToPayload(params),
+    };
+    const data = await this.client._request("POST", "/v1/chat/completions", payload);
+    return ChatCompletion.fromDict(data);
+  }
+}
+
+class Chat {
+  readonly completions: ChatCompletions;
+  constructor(client: GhostlinkClient) {
+    this.completions = new ChatCompletions(client);
+  }
+}
+
+class Completions {
+  constructor(private readonly client: GhostlinkClient) {}
+
+  /** `POST /v1/completions` — OpenAI's legacy completions endpoint. */
+  async create(params: CreateCompletionParams): Promise<Completion> {
+    const payload: JsonObject = {
+      model: params.model,
+      prompt: params.prompt,
+      ...samplingParamsToPayload(params),
+    };
+    const data = await this.client._request("POST", "/v1/completions", payload);
+    return Completion.fromDict(data);
+  }
+}
+
+class Embeddings {
+  constructor(private readonly client: GhostlinkClient) {}
+
+  /** `POST /v1/embeddings`. */
+  async create(params: CreateEmbeddingsParams): Promise<JsonObject> {
+    return this.client._request("POST", "/v1/embeddings", {
+      model: params.model,
+      input: params.input,
+    });
+  }
+}
+
+class Models {
+  constructor(private readonly client: GhostlinkClient) {}
+
+  /** `GET /v1/models`. */
+  async list(): Promise<Model[]> {
+    const data = await this.client._request("GET", "/v1/models");
+    const items = Array.isArray(data.data) ? (data.data as JsonObject[]) : [];
+    return items.map((m) => Model.fromDict(m));
+  }
+}
+
+class Workers {
+  constructor(private readonly client: GhostlinkClient) {}
+
+  async list(): Promise<JsonObject[]> {
+    const data = await this.client._request("GET", "/api/workers");
+    return Array.isArray(data.workers) ? (data.workers as JsonObject[]) : [];
+  }
+
+  /**
+   * Triggers a UDP-broadcast + mDNS discovery sweep and registers any peers
+   * found. See `GET /api/workers/discover`.
+   */
+  async discover(): Promise<JsonObject> {
+    return this.client._request("GET", "/api/workers/discover");
+  }
+
+  async connect(host: string, port: number): Promise<JsonObject> {
+    return this.client._request("POST", "/api/workers/connect", { host, port });
+  }
+
+  async add(fields: JsonObject): Promise<JsonObject> {
+    return this.client._request("POST", "/api/workers/add", fields);
+  }
+
+  async disconnect(workerId: string): Promise<JsonObject> {
+    return this.client._request("POST", `/api/workers/${workerId}/disconnect`);
+  }
+}
+
+class Sessions {
+  constructor(private readonly client: GhostlinkClient) {}
+
+  async list(): Promise<JsonObject[]> {
+    const data = await this.client._request("GET", "/api/sessions");
+    return Array.isArray(data.sessions) ? (data.sessions as JsonObject[]) : [];
+  }
+}
+
+class Settings {
+  constructor(private readonly client: GhostlinkClient) {}
+
+  async get(): Promise<JsonObject> {
+    return this.client._request("GET", "/api/settings");
+  }
+
+  async update(fields: JsonObject): Promise<JsonObject> {
+    return this.client._request("POST", "/api/settings", fields);
+  }
+
+  async reset(): Promise<JsonObject> {
+    return this.client._request("POST", "/api/settings/reset");
+  }
+}
+
+export interface GhostlinkClientOptions {
+  apiKey?: string;
+  timeoutMs?: number;
+  /** Override `fetch` (for tests, or an alternate runtime implementation). */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Client for a Ghostlink Studio API server.
+ *
+ * @example
+ * ```ts
+ * const client = new GhostlinkClient("http://127.0.0.1:8003", { apiKey: "..." });
+ * const resp = await client.chat.completions.create({
+ *   model: "llama3.2:3b",
+ *   messages: [{ role: "user", content: "hello" }],
+ * });
+ * console.log(resp.content);
+ * ```
+ */
+export class GhostlinkClient {
+  readonly baseUrl: string;
+  readonly apiKey?: string;
+  readonly timeoutMs: number;
+
+  readonly chat: Chat;
+  readonly completions: Completions;
+  readonly embeddings: Embeddings;
+  readonly models: Models;
+  readonly workers: Workers;
+  readonly sessions: Sessions;
+  readonly settings: Settings;
+
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(baseUrl: string, options: GhostlinkClientOptions = {}) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.apiKey = options.apiKey;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+
+    this.chat = new Chat(this);
+    this.completions = new Completions(this);
+    this.embeddings = new Embeddings(this);
+    this.models = new Models(this);
+    this.workers = new Workers(this);
+    this.sessions = new Sessions(this);
+    this.settings = new Settings(this);
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) headers["Authorization"] = `Bearer ${this.apiKey}`;
+    return headers;
+  }
+
+  /** Fetches with a total-duration timeout on the connect/response-headers phase. */
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: controller.signal });
+    } catch (err) {
+      throw new GhostlinkConnectionError(
+        `failed to reach ${url}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async raiseForStatus(resp: Response): Promise<void> {
+    if (resp.status < 400) return;
+    const text = await resp.text();
+    let body: unknown = text;
+    try {
+      body = text ? JSON.parse(text) : undefined;
+    } catch {
+      // not JSON — keep the raw text as the body, matching the Python client.
+    }
+    const message = extractErrorMessage(body) ?? resp.statusText ?? "request failed";
+    if (resp.status === 401 || resp.status === 403) {
+      throw new GhostlinkAuthError(resp.status, message, body);
+    }
+    throw new GhostlinkAPIError(resp.status, message, body);
+  }
+
+  /** @internal used by the nested resource classes. */
+  async _request(method: string, path: string, json?: unknown): Promise<JsonObject> {
+    const url = `${this.baseUrl}${path}`;
+    const resp = await this.fetchWithTimeout(url, {
+      method,
+      headers: this.headers(),
+      body: json !== undefined ? JSON.stringify(json) : undefined,
+    });
+
+    await this.raiseForStatus(resp);
+
+    const text = await resp.text();
+    if (!text) return {};
+    return JSON.parse(text) as JsonObject;
+  }
+
+  /** `GET /health` — unauthenticated liveness/version/backend info. */
+  async health(): Promise<JsonObject> {
+    return this._request("GET", "/health");
+  }
+
+  /**
+   * `GET /api/metrics` — JSON metrics snapshot. See `metricsPrometheus` for
+   * the Prometheus-exposition-format sibling.
+   */
+  async metrics(): Promise<JsonObject> {
+    return this._request("GET", "/api/metrics");
+  }
+
+  /**
+   * `GET /metrics` — the same snapshot as `metrics()`, formatted for a
+   * Prometheus scrape config instead of JSON.
+   */
+  async metricsPrometheus(): Promise<string> {
+    const url = `${this.baseUrl}/metrics`;
+    const resp = await this.fetchWithTimeout(url, { method: "GET", headers: this.headers() });
+    await this.raiseForStatus(resp);
+    return resp.text();
+  }
+
+  /** Convenience alias for `client.models.list()`. */
+  async listModels(): Promise<Model[]> {
+    return this.models.list();
+  }
+
+  /**
+   * Non-streaming call to Ghostlink Studio's native chat endpoint
+   * (`POST /api/inference/chat`) — richer than the OpenAI-compatible routes
+   * (session bookkeeping, MCP tool results, live metrics in the response),
+   * but Ghostlink-specific rather than portable. Use `streamChat` for real
+   * token-by-token streaming.
+   */
+  async studioChat(message: string, params: StudioChatParams = {}): Promise<JsonObject> {
+    const payload: JsonObject = { message };
+    if (params.messages !== undefined) payload.messages = params.messages;
+    if (params.model !== undefined) payload.model = params.model;
+    Object.assign(payload, samplingParamsToPayload(params));
+    return this._request("POST", "/api/inference/chat", payload);
+  }
+
+  /**
+   * Real token-by-token streaming via `POST /api/inference/chat`
+   * (`stream: true`) over Server-Sent Events. Yields one `StreamChunk` per
+   * token as the model produces it; the final chunk has `done: true`. This
+   * is the only endpoint with genuine incremental streaming today — the
+   * OpenAI-compatible `/v1/chat/completions` accepts a `stream` field but
+   * does not yet act on it.
+   *
+   * Note: unlike the other request methods, the client's timeout is only
+   * applied to the connect/response-headers phase here, not the full
+   * duration of the stream — a long-running token stream would otherwise be
+   * truncated by a total-duration timeout meant for quick JSON calls.
+   *
+   * @example
+   * ```ts
+   * for await (const chunk of client.streamChat("tell me a story")) {
+   *   if (!chunk.done) process.stdout.write(chunk.token);
+   * }
+   * ```
+   */
+  async *streamChat(message: string, params: StudioChatParams = {}): AsyncGenerator<StreamChunk> {
+    const payload: JsonObject = { message, stream: true };
+    if (params.messages !== undefined) payload.messages = params.messages;
+    if (params.model !== undefined) payload.model = params.model;
+    Object.assign(payload, samplingParamsToPayload(params));
+
+    const url = `${this.baseUrl}/api/inference/chat`;
+    const resp = await this.fetchWithTimeout(url, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify(payload),
+    });
+
+    await this.raiseForStatus(resp);
+
+    if (!resp.body) {
+      throw new GhostlinkConnectionError(`no response body from ${url}`);
+    }
+
+    for await (const chunkData of iterSseJson(streamLines(resp.body))) {
+      yield StreamChunk.fromDict(chunkData);
+    }
+  }
+}

--- a/sdks/js/src/exceptions.ts
+++ b/sdks/js/src/exceptions.ts
@@ -1,0 +1,60 @@
+/**
+ * Exception hierarchy for the Ghostlink client.
+ *
+ * Mirrors `sdks/python/ghostlink_client/exceptions.py`:
+ *   - `GhostlinkError` — base class for everything this client throws.
+ *   - `GhostlinkConnectionError` — the client could not reach the server at
+ *     all (DNS failure, connection refused, or a timeout before any response
+ *     arrived).
+ *   - `GhostlinkAPIError` — the server responded with a non-2xx status code.
+ *     Carries `statusCode` and `body` (the parsed JSON error body, or raw
+ *     text if the body wasn't JSON).
+ *   - `GhostlinkAuthError` — a `GhostlinkAPIError` specifically for 401/403
+ *     (missing, invalid, or expired bearer token).
+ */
+
+/** Base class for all errors raised by this client. */
+export class GhostlinkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GhostlinkError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * The client could not reach the Ghostlink server at all — DNS failure,
+ * connection refused, or a timeout before any response arrived.
+ */
+export class GhostlinkConnectionError extends GhostlinkError {
+  constructor(message: string) {
+    super(message);
+    this.name = "GhostlinkConnectionError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** The server responded with a non-2xx status code. */
+export class GhostlinkAPIError extends GhostlinkError {
+  /** The HTTP status code returned by the server. */
+  readonly statusCode: number;
+  /** The parsed JSON error body, or raw response text if it wasn't JSON. */
+  readonly body: unknown;
+
+  constructor(statusCode: number, message: string, body?: unknown) {
+    super(`HTTP ${statusCode}: ${message}`);
+    this.name = "GhostlinkAPIError";
+    this.statusCode = statusCode;
+    this.body = body;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** 401/403 — missing, invalid, or expired bearer token. */
+export class GhostlinkAuthError extends GhostlinkAPIError {
+  constructor(statusCode: number, message: string, body?: unknown) {
+    super(statusCode, message, body);
+    this.name = "GhostlinkAuthError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1,0 +1,24 @@
+/** TypeScript/JavaScript client SDK for the Ghostlink Studio API. */
+
+export {
+  GhostlinkClient,
+  DEFAULT_TIMEOUT_MS,
+  type GhostlinkClientOptions,
+  type ChatMessage,
+  type SamplingParams,
+  type CreateChatCompletionParams,
+  type CreateCompletionParams,
+  type CreateEmbeddingsParams,
+  type StudioChatParams,
+} from "./client.js";
+
+export {
+  GhostlinkError,
+  GhostlinkAPIError,
+  GhostlinkAuthError,
+  GhostlinkConnectionError,
+} from "./exceptions.js";
+
+export { ChatCompletion, Completion, Model, StreamChunk, type ChatChoice, type CompletionChoice, type JsonObject } from "./models.js";
+
+export const VERSION = "0.1.0";

--- a/sdks/js/src/models.ts
+++ b/sdks/js/src/models.ts
@@ -1,0 +1,194 @@
+/**
+ * Typed response wrappers.
+ *
+ * Mirrors `sdks/python/ghostlink_client/models.py`: thin, permissive views
+ * over the JSON the server returns. Every field is read with a default
+ * rather than assumed present, so a minor server version skew (a new field
+ * added, one renamed) doesn't throw inside the client. The original decoded
+ * JSON is always available on `.raw` for anything not modeled explicitly
+ * here.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type JsonObject = Record<string, any>;
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" ? value : fallback;
+}
+
+function asBool(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : Boolean(value ?? fallback);
+}
+
+export interface ChatChoice {
+  index: number;
+  message: JsonObject;
+  finishReason: string | null;
+}
+
+function chatChoiceFromDict(data: JsonObject): ChatChoice {
+  return {
+    index: asNumber(data.index, 0),
+    message: (data.message as JsonObject) ?? {},
+    finishReason: data.finish_reason ?? null,
+  };
+}
+
+/** `POST /v1/chat/completions` response. */
+export class ChatCompletion {
+  readonly id: string;
+  readonly object: string;
+  readonly created: number;
+  readonly model: string;
+  readonly choices: ChatChoice[];
+  /** The original decoded JSON response. */
+  readonly raw: JsonObject;
+
+  constructor(fields: {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: ChatChoice[];
+    raw: JsonObject;
+  }) {
+    this.id = fields.id;
+    this.object = fields.object;
+    this.created = fields.created;
+    this.model = fields.model;
+    this.choices = fields.choices;
+    this.raw = fields.raw;
+  }
+
+  /** The first choice's assistant text, or `""` if there are none. */
+  get content(): string {
+    if (this.choices.length === 0) return "";
+    const content = this.choices[0].message?.content;
+    return typeof content === "string" ? content : "";
+  }
+
+  static fromDict(data: JsonObject): ChatCompletion {
+    return new ChatCompletion({
+      id: asString(data.id),
+      object: asString(data.object),
+      created: asNumber(data.created),
+      model: asString(data.model),
+      choices: Array.isArray(data.choices) ? data.choices.map(chatChoiceFromDict) : [],
+      raw: data,
+    });
+  }
+}
+
+export interface CompletionChoice {
+  text: string;
+  index: number;
+  finishReason: string | null;
+}
+
+/** `POST /v1/completions` response. */
+export class Completion {
+  readonly id: string;
+  readonly object: string;
+  readonly created: number;
+  readonly model: string;
+  readonly choices: CompletionChoice[];
+  readonly raw: JsonObject;
+
+  constructor(fields: {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: CompletionChoice[];
+    raw: JsonObject;
+  }) {
+    this.id = fields.id;
+    this.object = fields.object;
+    this.created = fields.created;
+    this.model = fields.model;
+    this.choices = fields.choices;
+    this.raw = fields.raw;
+  }
+
+  get text(): string {
+    return this.choices.length > 0 ? this.choices[0].text : "";
+  }
+
+  static fromDict(data: JsonObject): Completion {
+    return new Completion({
+      id: asString(data.id),
+      object: asString(data.object),
+      created: asNumber(data.created),
+      model: asString(data.model),
+      choices: Array.isArray(data.choices)
+        ? data.choices.map((c: JsonObject) => ({
+            text: asString(c.text),
+            index: asNumber(c.index),
+            finishReason: c.finish_reason ?? null,
+          }))
+        : [],
+      raw: data,
+    });
+  }
+}
+
+/** One entry from `GET /v1/models`. */
+export class Model {
+  readonly id: string;
+  readonly raw: JsonObject;
+
+  constructor(fields: { id: string; raw: JsonObject }) {
+    this.id = fields.id;
+    this.raw = fields.raw;
+  }
+
+  static fromDict(data: JsonObject): Model {
+    return new Model({ id: asString(data.id), raw: data });
+  }
+}
+
+/** One incremental piece of a `/api/inference/chat` streamed response. */
+export class StreamChunk {
+  readonly token: string;
+  readonly requestId: string;
+  readonly sessionId: string;
+  readonly error: boolean;
+  readonly done: boolean;
+  readonly truncated: boolean;
+  readonly raw: JsonObject;
+
+  constructor(fields: {
+    token: string;
+    requestId: string;
+    sessionId: string;
+    error: boolean;
+    done: boolean;
+    truncated: boolean;
+    raw: JsonObject;
+  }) {
+    this.token = fields.token;
+    this.requestId = fields.requestId;
+    this.sessionId = fields.sessionId;
+    this.error = fields.error;
+    this.done = fields.done;
+    this.truncated = fields.truncated;
+    this.raw = fields.raw;
+  }
+
+  static fromDict(data: JsonObject): StreamChunk {
+    return new StreamChunk({
+      token: asString(data.token),
+      requestId: asString(data.request_id),
+      sessionId: asString(data.session_id),
+      error: asBool(data.error),
+      done: asBool(data.done),
+      truncated: asBool(data.truncated),
+      raw: data,
+    });
+  }
+}

--- a/sdks/js/src/sse.ts
+++ b/sdks/js/src/sse.ts
@@ -1,0 +1,91 @@
+/**
+ * Minimal Server-Sent Events parser for a `fetch` `Response.body` stream.
+ *
+ * Mirrors `sdks/python/ghostlink_client/_sse.py`. Ghostlink's streaming
+ * endpoint (`/api/inference/chat` with `stream: true`) sends unnamed SSE
+ * events — each a single `data: {json}` line followed by a blank line — so
+ * this parser only needs to handle the `data:` field, but follows the SSE
+ * spec generally (multiple `data:` lines per event are joined with `\n`,
+ * comment lines starting with `:` are ignored) rather than assuming that
+ * shape, so it keeps working if the server ever splits a payload across
+ * lines.
+ */
+
+export type JsonObject = Record<string, unknown>;
+
+/**
+ * Decodes a raw byte stream (as `Response.body` from `fetch`) into a line
+ * stream, the way `requests`' `iter_lines()` does for the Python client.
+ * Handles chunk boundaries that split in the middle of a line, `\n` and
+ * `\r\n` line endings, and a final line with no trailing newline.
+ */
+export async function* streamLines(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+        let line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line.endsWith("\r")) line = line.slice(0, -1);
+        yield line;
+      }
+    }
+    buffer += decoder.decode();
+    if (buffer.length > 0) {
+      yield buffer.endsWith("\r") ? buffer.slice(0, -1) : buffer;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Decodes an SSE line stream into one object per event's `data:` payload.
+ *
+ * A payload that isn't valid JSON is silently skipped rather than thrown —
+ * a keep-alive comment or a non-JSON control line is valid SSE, not a
+ * client-side bug.
+ */
+export async function* iterSseJson(
+  lines: AsyncIterable<string> | Iterable<string>,
+): AsyncGenerator<JsonObject> {
+  const dataLines: string[] = [];
+
+  function flush(): JsonObject | null {
+    if (dataLines.length === 0) return null;
+    const payload = dataLines.join("\n");
+    dataLines.length = 0;
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(payload);
+    } catch {
+      return null;
+    }
+    return decoded !== null && typeof decoded === "object" && !Array.isArray(decoded)
+      ? (decoded as JsonObject)
+      : null;
+  }
+
+  for await (const line of lines) {
+    if (line === "") {
+      const decoded = flush();
+      if (decoded !== null) yield decoded;
+      continue;
+    }
+    if (line.startsWith(":")) continue;
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).replace(/^ /, ""));
+    }
+    // event:/id:/retry: fields are ignored — the server only ever sends
+    // unnamed data-only events today.
+  }
+
+  const decoded = flush();
+  if (decoded !== null) yield decoded;
+}

--- a/sdks/js/test/client.test.ts
+++ b/sdks/js/test/client.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  GhostlinkAPIError,
+  GhostlinkAuthError,
+  GhostlinkClient,
+  GhostlinkConnectionError,
+} from "../src/index.js";
+
+const BASE_URL = "http://127.0.0.1:8003";
+
+/**
+ * Builds a mock `fetch` that mirrors the Python test suite's use of the
+ * `responses` library: register one JSON (or text) response per URL+method,
+ * and assert on the captured request afterwards.
+ */
+function mockFetch(responseFor: (url: string, init: RequestInit) => Response) {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const fn = vi.fn(async (input: string | URL | Request, init: RequestInit = {}) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return responseFor(url, init);
+  });
+  return { fetchImpl: fn as unknown as typeof fetch, calls };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function client(fetchImpl: typeof fetch): GhostlinkClient {
+  return new GhostlinkClient(BASE_URL, { apiKey: "test-key", fetchImpl });
+}
+
+describe("GhostlinkClient", () => {
+  it("chat.completions.create returns a ChatCompletion and sends the bearer token", async () => {
+    const { fetchImpl, calls } = mockFetch(() =>
+      jsonResponse({
+        id: "chatcmpl-1",
+        object: "chat.completion",
+        created: 123,
+        model: "llama3.2:3b",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "hi there" },
+            finish_reason: "stop",
+          },
+        ],
+      }),
+    );
+
+    const resp = await client(fetchImpl).chat.completions.create({
+      model: "llama3.2:3b",
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(resp.content).toBe("hi there");
+    expect(resp.model).toBe("llama3.2:3b");
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer test-key");
+    expect(calls[0].url).toBe(`${BASE_URL}/v1/chat/completions`);
+  });
+
+  it("completions.create returns a Completion", async () => {
+    const { fetchImpl } = mockFetch(() =>
+      jsonResponse({
+        id: "cmpl-1",
+        object: "text_completion",
+        created: 123,
+        model: "llama3.2:3b",
+        choices: [{ text: "once upon a time", index: 0, finish_reason: "stop" }],
+      }),
+    );
+
+    const resp = await client(fetchImpl).completions.create({
+      model: "llama3.2:3b",
+      prompt: "Once",
+    });
+
+    expect(resp.text).toBe("once upon a time");
+  });
+
+  it("listModels returns Model instances", async () => {
+    const { fetchImpl } = mockFetch(() =>
+      jsonResponse({ data: [{ id: "llama3.2:3b" }, { id: "gemma2:2b" }] }),
+    );
+
+    const models = await client(fetchImpl).listModels();
+    expect(models.map((m) => m.id)).toEqual(["llama3.2:3b", "gemma2:2b"]);
+  });
+
+  it("raises GhostlinkAuthError on a 401", async () => {
+    const { fetchImpl } = mockFetch(() =>
+      jsonResponse(
+        { error: { message: "missing bearer token", type: "invalid_request_error" } },
+        401,
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await client(fetchImpl).chat.completions.create({
+        model: "x",
+        messages: [{ role: "user", content: "hi" }],
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(GhostlinkAuthError);
+    const authErr = caught as GhostlinkAuthError;
+    expect(authErr.statusCode).toBe(401);
+    expect(authErr.message).toContain("missing bearer token");
+  });
+
+  it("raises GhostlinkAPIError on a 400", async () => {
+    const { fetchImpl } = mockFetch(() =>
+      jsonResponse(
+        { error: { message: "messages must not be empty", type: "invalid_request_error" } },
+        400,
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await client(fetchImpl).chat.completions.create({ model: "x", messages: [] });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(GhostlinkAPIError);
+    expect(caught).not.toBeInstanceOf(GhostlinkAuthError);
+    const apiErr = caught as GhostlinkAPIError;
+    expect(apiErr.statusCode).toBe(400);
+    expect(apiErr.message).toContain("messages must not be empty");
+  });
+
+  it("raises GhostlinkConnectionError when fetch itself fails", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof fetch;
+
+    const unreachable = new GhostlinkClient(BASE_URL, { apiKey: "k", fetchImpl });
+    await expect(unreachable.health()).rejects.toBeInstanceOf(GhostlinkConnectionError);
+  });
+
+  it("health returns the raw JSON body", async () => {
+    const { fetchImpl } = mockFetch(() => jsonResponse({ status: "healthy" }));
+    expect(await client(fetchImpl).health()).toEqual({ status: "healthy" });
+  });
+
+  it("metricsPrometheus returns raw text, not parsed JSON", async () => {
+    const { fetchImpl } = mockFetch(
+      () =>
+        new Response("# HELP ghostlink_uptime_seconds ...\nghostlink_uptime_seconds 12.5\n", {
+          status: 200,
+          headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
+        }),
+    );
+    const text = await client(fetchImpl).metricsPrometheus();
+    expect(text).toContain("ghostlink_uptime_seconds 12.5");
+  });
+
+  it("settings.update posts the given fields and returns the response", async () => {
+    const { fetchImpl, calls } = mockFetch(() =>
+      jsonResponse({ settings: { inference_backend: "ollama" }, status: "ok" }),
+    );
+
+    const result = await client(fetchImpl).settings.update({ inference_backend: "ollama" });
+    expect(result.status).toBe("ok");
+    expect(calls[0].init.body).toContain("ollama");
+  });
+
+  it("streamChat yields one StreamChunk per token via /api/inference/chat", async () => {
+    const events = [
+      { token: "Once", request_id: "req-1", session_id: "s1" },
+      { token: " upon", request_id: "req-1", session_id: "s1" },
+      { token: "", request_id: "req-1", session_id: "s1", done: true, truncated: false },
+    ];
+    const sseBody = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init: RequestInit = {}) => {
+      const url = typeof input === "string" ? input : input.toString();
+      expect(url).toBe(`${BASE_URL}/api/inference/chat`);
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        message: "tell me a story",
+        stream: true,
+      });
+      const bytes = new TextEncoder().encode(sseBody);
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(bytes);
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as unknown as typeof fetch;
+
+    const chunks = [];
+    for await (const chunk of client(fetchImpl).streamChat("tell me a story")) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.map((c) => c.token)).toEqual(["Once", " upon", ""]);
+    expect(chunks[chunks.length - 1].done).toBe(true);
+    expect(chunks.every((c) => !c.error)).toBe(true);
+  });
+});

--- a/sdks/js/test/sse.test.ts
+++ b/sdks/js/test/sse.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { iterSseJson } from "../src/sse.js";
+import { StreamChunk } from "../src/models.js";
+
+/**
+ * Builds an SSE line stream the way the server would produce it, from a
+ * list of already-JSON-encoded data payload strings. Mirrors
+ * `sdks/python/tests/test_sse.py`'s `sse_lines` helper.
+ */
+function sseLines(...events: string[]): string[] {
+  const lines: string[] = [];
+  for (const event of events) {
+    lines.push(`data: ${event}`);
+    lines.push("");
+  }
+  return lines;
+}
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+describe("iterSseJson", () => {
+  it("parses a single event", async () => {
+    const lines = sseLines('{"token": "hello", "request_id": "req-1", "session_id": "s1"}');
+    const events = await collect(iterSseJson(lines));
+    expect(events).toEqual([{ token: "hello", request_id: "req-1", session_id: "s1" }]);
+  });
+
+  it("parses multiple events in order", async () => {
+    const lines = sseLines(
+      '{"token": "hel", "request_id": "req-1", "session_id": "s1"}',
+      '{"token": "lo", "request_id": "req-1", "session_id": "s1"}',
+      '{"done": true, "request_id": "req-1", "session_id": "s1", "truncated": false}',
+    );
+    const events = await collect(iterSseJson(lines));
+    expect(events.slice(0, 2).map((e) => e.token)).toEqual(["hel", "lo"]);
+    expect(events[2].done).toBe(true);
+  });
+
+  it("ignores comment lines", async () => {
+    const lines = [
+      ": ping",
+      "",
+      ...sseLines('{"token": "x", "request_id": "r", "session_id": "s"}'),
+    ];
+    const events = await collect(iterSseJson(lines));
+    expect(events).toHaveLength(1);
+    expect(events[0].token).toBe("x");
+  });
+
+  it("skips an invalid JSON payload", async () => {
+    const lines = [
+      "data: not json",
+      "",
+      ...sseLines('{"token": "ok", "request_id": "r", "session_id": "s"}'),
+    ];
+    const events = await collect(iterSseJson(lines));
+    expect(events).toHaveLength(1);
+    expect(events[0].token).toBe("ok");
+  });
+
+  it("handles a trailing event without a final blank line", async () => {
+    const lines = ['data: {"token": "x", "request_id": "r", "session_id": "s"}'];
+    const events = await collect(iterSseJson(lines));
+    expect(events).toHaveLength(1);
+  });
+});
+
+describe("StreamChunk.fromDict", () => {
+  it("applies defaults for missing fields", () => {
+    const chunk = StreamChunk.fromDict({ token: "hi", request_id: "r1", session_id: "s1" });
+    expect(chunk.token).toBe("hi");
+    expect(chunk.done).toBe(false);
+    expect(chunk.error).toBe(false);
+  });
+
+  it("reads done/error/truncated flags", () => {
+    const doneChunk = StreamChunk.fromDict({
+      done: true,
+      request_id: "r1",
+      session_id: "s1",
+      truncated: true,
+    });
+    expect(doneChunk.done).toBe(true);
+    expect(doneChunk.truncated).toBe(true);
+
+    const errorChunk = StreamChunk.fromDict({
+      token: "[err]",
+      error: true,
+      request_id: "r1",
+      session_id: "s1",
+    });
+    expect(errorChunk.error).toBe(true);
+  });
+});

--- a/sdks/js/tsconfig.json
+++ b/sdks/js/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "exclude": ["test", "dist", "node_modules"]
+}

--- a/sdks/js/tsup.config.ts
+++ b/sdks/js/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2020",
+  platform: "neutral",
+  outDir: "dist",
+});

--- a/sdks/js/vitest.config.ts
+++ b/sdks/js/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

This is the accumulated real work from an extended distributed-inference testing and hardening session, prepared as one coordinated v1.17.0 release. Three commits:

1. **`6e38689`** — Real Docker-based E2E CI gate (`.github/workflows/distributed-e2e.yml`) proving Ghostlink's `ggml-rpc`-backed distributed inference actually executes across containers (`real_inference: true`, live RPC connection log evidence), plus a benchmark harness and extensive real findings from testing on genuinely separate physical hardware (two real machines on a LAN) — including the actual proof this project's roadmap has been chasing: a real 30B-class model that cannot load on one machine alone loading and serving correctly once split across two.

2. **`0b1afdb`** — Fixes for three real bugs found during that hardware testing: silent output corruption from version-mismatched `ggml-rpc` peers (confirmed via a controlled A/B test — now detected and refused via a build-fingerprint check in the discovery protocol), an unsupervised RPC contributor child process (advertised capability via discovery even after crashing — now periodically re-supervised), and a 90-second model-ready timeout too short for real distributed loads (now scales to 600s for RPC-distributed loads specifically).

3. **`3cc4916`** — Three independent features plus release prep: an IP allowlist for the RPC contributor (`ggml-rpc-server` has no auth of its own — this closes that gap with a Ghostlink-controlled TCP proxy, off by default), a one-line install script (`curl -fsSL .../install.sh | sh`, tested end-to-end against the real live release), a JS/TS client SDK (`sdks/js/`, mirroring the Python SDK's shape), and version bumps (`ghost-link`/`ghostlink-core` 1.16.1 → 1.17.0) with full per-crate READMEs.

Full detail on every claim above — including honest caveats about what wasn't yet proven — is in `docs/BENCHMARKS.md` and `docs/ROADMAP.md`, both updated extensively as part of this work.

## Test plan

- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all clean (164 ghost-link + 183 ghostlink-core tests)
- [x] Real Docker E2E fabric (`docker-compose.rpc-fabric.yml` + `scripts/rpc_fabric_assert.py`) rebuilt and rerun after each change, confirming no regression to the existing passing gate
- [x] Install scripts actually run end-to-end against the real live v1.16.1 release (not simulated) — real binary downloaded, checksum verified, installed binary executed
- [x] JS SDK: `tsc --noEmit` clean, real `tsup` build (ESM + CJS + `.d.ts`), 17/17 `vitest` tests passing
- [x] `cargo publish --dry-run` run for real on both publishable crates
- [ ] CI checks on this PR (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)