### PR TITLE
🎨 Palette: Chat Copy Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal
 
+## 2026-08-08 - [Markdown Code Blocks and Compare Mode Copy Tooltips and Focus Rings]
+**Learning:** Core user utilities such as copy-to-clipboard buttons (both nested inside markdown code blocks and listed within Compare Mode column segments) are easily lost during keyboard navigation if they lack distinct, high-contrast focus visible indicator classes. Sighted desktop users expect visual hover confirmation via browser `title` tooltips, while keyboard/assistive navigators require the elements to become visually apparent and highlighted (e.g. `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500`) to track active cursor context correctly.
+**Action:** Always provide custom high-contrast focus outlines and descriptive `title` attributes on all localized, action-oriented clipboard utility trigger elements.
+
 ## 2026-08-07 - [Metrics Tab Header Accessibility]
 **Learning:** Live monitoring headers often contain specialized quick-action buttons (like Export CSV and Manual Refresh) that lack text labels to keep the dashboard visual design minimal. While they have correct `aria-label` and `title` attributes, they must also be styled with customized, high-contrast focus rings (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) to preserve keyboard navigation. Without explicit indicators, users tabbing through live performance monitors will lose their selection completely, severely degrading the accessibility of critical dashboard features.
 **Action:** Always complement icon-only action triggers in live monitors and charts with explicit focus rings to guarantee seamless, visual keyboard tracking.

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -107,7 +107,8 @@ const CodeBlock: React.FC<{ children?: React.ReactNode }> = ({ children, ...rest
       <button
         onClick={handleCopy}
         aria-label="Copy code"
-        className="absolute top-2 right-2 p-1.5 rounded-lg bg-slate-800/80 border border-slate-700 text-slate-400 hover:text-white hover:bg-slate-700 opacity-0 group-hover/code:opacity-100 focus:opacity-100 transition"
+        title="Copy code"
+        className="absolute top-2 right-2 p-1.5 rounded-lg bg-slate-800/80 border border-slate-700 text-slate-400 hover:text-white hover:bg-slate-700 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition"
       >
         {copied ? <Check size={13} className="text-green-400" aria-hidden="true" /> : <Copy size={13} aria-hidden="true" />}
       </button>
@@ -154,8 +155,9 @@ const CompareColumn: React.FC<{
     {msg.content && !isLoading && (
       <button
         onClick={() => onCopy(msg.content, msg.id)}
-        className="self-start p-1.5 rounded-lg hover:bg-slate-800 text-slate-500 hover:text-slate-300 transition"
+        className="self-start p-1.5 rounded-lg hover:bg-slate-800 text-slate-500 hover:text-slate-300 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition"
         aria-label="Copy response"
+        title="Copy response"
       >
         {copiedId === msg.id ? <Check size={12} className="text-green-400" aria-hidden="true" /> : <Copy size={12} aria-hidden="true" />}
       </button>


### PR DESCRIPTION
This change enhances the accessibility and micro-interactions of the Core Chat view by implementing the following UX refinements:
1. Configured custom visual focus-visible rings (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) on markdown CodeBlock copy buttons and CompareColumn copy buttons in ChatTab.tsx.
2. Added descriptive `title` attributes ("Copy code" and "Copy response") to both copy elements to serve as native hover tooltips.
3. Ensured hidden codeblock copy buttons become visible when receiving focus, providing a smooth, visual keyboard tracking experience.

---
*PR created automatically by Jules for task [15443566164354696942](https://jules.google.com/task/15443566164354696942) started by @rwilliamspbg-ops*