### PR TITLE
GUI accessibility pass, MCP server editor, chat attachments, model-list fixes, iGPU perf tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Ghostlink Studio are documented here.
 
 ---
 
+## [Unreleased] - GUI accessibility, MCP server editor, chat attachments, model-list fixes, iGPU perf tuning
+
+### Added
+
+- **MCP server editor** (`McpTab.tsx`, `crates/ghost-link/src/mcp/{config,registry}.rs`): add/edit/delete MCP servers (stdio or HTTP transport) directly from the GUI instead of hand-editing `mcp_servers.toml`. Changes take effect immediately — connects/disconnects the affected server live via new `McpConfigManager::add/update/remove` + `McpRegistry::add_server/update_server/remove_server`, no restart required. Also wired up the enable/disable toggle switch, which was calling `POST /api/mcp/servers/:name/toggle` — a route that didn't exist; the connect/disconnect logic (`McpRegistry::set_enabled`) was already fully implemented and tested but had no caller.
+- **Text-file attachments in chat** (`ChatTab.tsx`): paperclip button + drag-and-drop onto the composer. Scoped to text-based files (code, markdown, JSON, CSV, logs, config — no images/binaries, which are rejected with an explicit toast rather than silently doing nothing) since there's no multimodal/upload endpoint; files are read client-side (256KB/file cap) and inlined as labeled fenced code blocks ahead of the message.
+- **`eslint-plugin-jsx-a11y` + axe-core Playwright suite** (`ghostlink_gui_modern/eslint.config.js`, `e2e/accessibility.spec.ts`): first automated accessibility regression gate for the GUI — scans the app shell and every primary tab (plus the new MCP add-server dialog) for WCAG 2 A/AA violations. `color-contrast` is deliberately excluded for now (see Documentation below).
+
+### Fixed
+
+- **Models tab listed the same model twice**: `handle_gui_model_download`'s completion handler (`crates/ghost-link/src/main.rs`) removed only the in-flight placeholder record (keyed by the original request name) before pushing the completed one, so re-downloading an already-installed model left the old record behind instead of replacing it — both records then survived indefinitely with the same name but different sizes. Also removed four hardcoded "Ready" placeholder models (`load_persistent_models`) that were seeded on first run with no real file behind them and never reconciled against a real scanned/downloaded model, since the merge only matched on exact name equality.
+- **Delete button missing for native/llama.cpp models**: gated to `currentEngine === 'ollama'` in `ModelsTab.tsx`, even though the backend's `DELETE /api/models/:name` already fully supports removing local GGUF files for any engine. Split into its own `canDeleteModel` flag — shown for native and Ollama, still hidden for vLLM (genuinely server-managed).
+- **iGPU VRAM misdetection on the native launch path** (`launch-native.ps1`): `Win32_VideoController.AdapterRAM` (WMI) and DXGI's `DedicatedVideoMemory` both undercount a unified-memory iGPU — neither reads `SharedSystemMemory` — so hardware auto-detection was landing on `native_engine.rs`'s worst-case "<4GB" perf tier regardless of the real hardware. `GHOSTLINK_GPU_NAME`/`GHOSTLINK_VRAM_GB`/`GHOSTLINK_COMPUTE_CAPABILITY` now pinned explicitly (`ghostlink-core::system_profile::detect_gpu_from_env` takes absolute priority over the flawed probes). `VRAM_GB=8` was picked empirically — benchmarked 4 vs 8 on the reference machine (AMD Radeon 860M) with the same model; the larger prompt micro-batch it unlocks measured ~2.3x throughput (31.3 → 71.8 tok/s).
+
+### Changed
+
+- **Accessibility pass across the GUI**: live-region announcements for streaming chat replies and Metrics tab state changes (throttled to meaningful transitions, not every poll tick, to avoid drowning a screen reader); skip-to-content link and landmark wiring; restored focus rings on the Command Palette input and chat composer (both had stripped the default outline with no replacement); `prefers-reduced-motion` support; every scrollable tab body made keyboard-scrollable (`tabindex`/`role="region"`) — a real WCAG 2.1.1 gap the new axe suite caught that wasn't part of the original ask.
+- **Chat markdown readability**: assistant replies bumped from `prose-sm` to base `prose` (14px → 16px) outside Compare Mode; heading sizes tamed to fit a chat bubble instead of a full-width article; GFM tables wrap in a scroll container instead of blowing out bubble/page width; inline `` `code` `` swapped from the default backtick-quote style to a background pill, scoped so it can't also shrink code inside fenced blocks; code block font bumped 12px → 13px.
+
+### Documentation
+
+- Deliberately did **not** fix pervasive `color-contrast` failures the axe suite surfaced (the app's muted `slate-500`/`slate-600`-on-dark text falls short of WCAG AA in dozens of places across every tab) — that's a design-system change affecting the whole app's visual character, not a mechanical accessibility fix, and is out of scope for this change. Excluded from `e2e/accessibility.spec.ts` with a comment explaining why, so the suite still gates real regressions in the meantime.
+- Also not addressed here: no user-facing theme/keyboard-shortcut persistence, no MCP config hot-reload for hand-edited `mcp_servers.toml` beyond the enable/disable toggle fixed above.
+
+### Validation
+
+- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all clean (421 tests across `ghost-link`, `ghostlink-core`, `mcp-calculator`, `mcp-rag`, `mcp-vision`, 0 failures).
+- `cargo audit` — 3 pre-existing advisory warnings (`paste`, `anyhow`, `lru`; unmaintained/unsound transitive deps), unrelated to this change, no new findings.
+- GUI: `tsc --noEmit` and `eslint .` clean, 142/142 `vitest` unit tests passing, 11/11 new axe accessibility tests passing.
+- All of the above verified live against a real running stack (Rust `ghost-link serve` + Go control-plane + Vite dev server), not just automated tests: real chat completions with real streamed tokens, real MCP server add/edit/delete/toggle round-trips, real model list deduplication against the actual `models.json` on disk.
+
 ## [1.17.0] - 2026-08-08 (Real distributed-inference testing, three bug fixes, RPC allowlist, install script, JS SDK)
 
 ### Added

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -3055,40 +3055,16 @@ fn load_persistent_models() -> Vec<ModelRecord> {
             }
         }
     }
-    vec![
-        ModelRecord {
-            name: "meta-llama/Llama-3-8B-Instruct".to_string(),
-            size_gb: 8.0,
-            model_type: "LLM".to_string(),
-            quantization: "Q4_K_M".to_string(),
-            status: "Ready".to_string(),
-            local_path: String::new(),
-        },
-        ModelRecord {
-            name: "mistralai/Mistral-7B-Instruct-v0.2".to_string(),
-            size_gb: 7.2,
-            model_type: "LLM".to_string(),
-            quantization: "Q4_K_M".to_string(),
-            status: "Ready".to_string(),
-            local_path: String::new(),
-        },
-        ModelRecord {
-            name: "google/gemma-7b-it".to_string(),
-            size_gb: 7.0,
-            model_type: "LLM".to_string(),
-            quantization: "Q4_K_M".to_string(),
-            status: "Ready".to_string(),
-            local_path: String::new(),
-        },
-        ModelRecord {
-            name: "ghostlink-30b-v1".to_string(),
-            size_gb: 30.0,
-            model_type: "LLM".to_string(),
-            quantization: "Q4_K_M".to_string(),
-            status: "Ready".to_string(),
-            local_path: String::new(),
-        },
-    ]
+    // Previously seeded 4 hardcoded "Ready" placeholder entries here
+    // (meta-llama/Llama-3-8B-Instruct, mistralai/Mistral-7B-Instruct-v0.2,
+    // google/gemma-7b-it, ghostlink-30b-v1) with an empty local_path. They
+    // claimed status "Ready" despite never being backed by a real file, and
+    // handle_gui_models' name-exact-match merge (main.rs) never reconciled
+    // them against a real scanned/downloaded model with a different
+    // filename-derived name — so they persisted forever as confusing
+    // near-duplicates in the GUI's "My Models" list. The Recommended /
+    // Popular Models tabs already cover "suggest something to download".
+    vec![]
 }
 
 fn save_persistent_models(models: &[ModelRecord]) {
@@ -3349,6 +3325,10 @@ struct OllamaChatRequest {
 #[derive(Debug, Deserialize)]
 struct OllamaNameRequest {
     name: String,
+}
+#[derive(Debug, Deserialize)]
+struct McpToggleRequest {
+    enabled: bool,
 }
 #[derive(Debug, Deserialize)]
 struct WorkerAddRequest {
@@ -5238,7 +5218,18 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     let size_gb = size_bytes as f32 / (1024.0 * 1024.0 * 1024.0);
 
                     let mut backend = lock_state(&spawn_state);
-                    backend.models.retain(|m| m.name != spawn_model_id);
+                    // Drop both the in-flight placeholder (keyed by the
+                    // original request name, e.g. a HF repo id like
+                    // "org/repo") AND any prior completed record that
+                    // resolved to this same on-disk filename (e.g. a
+                    // re-download of an already-installed model) — without
+                    // the second clause, re-downloading pushed a second
+                    // ModelRecord with an identical `name` instead of
+                    // replacing the old one, leaving the same model listed
+                    // twice in the GUI with two different sizes.
+                    backend
+                        .models
+                        .retain(|m| m.name != spawn_model_id && m.name != name);
                     backend.models.push(ModelRecord {
                         name,
                         size_gb,
@@ -6554,6 +6545,76 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         match registry.list_all_servers().await {
             Ok(servers) => Json(serde_json::json!({ "servers": servers })),
             Err(err) => Json(serde_json::json!({ "servers": [], "error": err })),
+        }
+    }
+
+    async fn handle_mcp_server_toggle(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Path(name): Path<String>,
+        Json(req): Json<McpToggleRequest>,
+    ) -> Json<serde_json::Value> {
+        let registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+        if let Err(err) = registry.set_enabled(&name, req.enabled).await {
+            return Json(serde_json::json!({ "success": false, "error": err }));
+        }
+        match registry.list_all_servers().await {
+            Ok(servers) => Json(serde_json::json!({ "success": true, "servers": servers })),
+            Err(err) => Json(serde_json::json!({ "success": true, "error": err })),
+        }
+    }
+
+    async fn handle_mcp_server_create(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Json(req): Json<mcp::McpServerConfig>,
+    ) -> Json<serde_json::Value> {
+        let registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+        if let Err(err) = registry.add_server(req).await {
+            return Json(serde_json::json!({ "success": false, "error": err }));
+        }
+        match registry.list_all_servers().await {
+            Ok(servers) => Json(serde_json::json!({ "success": true, "servers": servers })),
+            Err(err) => Json(serde_json::json!({ "success": true, "error": err })),
+        }
+    }
+
+    async fn handle_mcp_server_update(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Path(name): Path<String>,
+        Json(req): Json<mcp::McpServerConfig>,
+    ) -> Json<serde_json::Value> {
+        let registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+        if let Err(err) = registry.update_server(&name, req).await {
+            return Json(serde_json::json!({ "success": false, "error": err }));
+        }
+        match registry.list_all_servers().await {
+            Ok(servers) => Json(serde_json::json!({ "success": true, "servers": servers })),
+            Err(err) => Json(serde_json::json!({ "success": true, "error": err })),
+        }
+    }
+
+    async fn handle_mcp_server_delete(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        Path(name): Path<String>,
+    ) -> Json<serde_json::Value> {
+        let registry = {
+            let backend = lock_state(&state);
+            Arc::clone(&backend.mcp_registry)
+        };
+        if let Err(err) = registry.remove_server(&name).await {
+            return Json(serde_json::json!({ "success": false, "error": err }));
+        }
+        match registry.list_all_servers().await {
+            Ok(servers) => Json(serde_json::json!({ "success": true, "servers": servers })),
+            Err(err) => Json(serde_json::json!({ "success": true, "error": err })),
         }
     }
 
@@ -8603,7 +8664,19 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 post(handle_tool_confirm),
             )
             .route("/api/inference/engines", get(handle_inference_engines))
-            .route("/api/mcp/servers", get(handle_mcp_servers))
+            .route(
+                "/api/mcp/servers",
+                get(handle_mcp_servers).post(handle_mcp_server_create),
+            )
+            .route(
+                "/api/mcp/servers/:name/toggle",
+                post(handle_mcp_server_toggle),
+            )
+            .route(
+                "/api/mcp/servers/:name/update",
+                post(handle_mcp_server_update),
+            )
+            .route("/api/mcp/servers/:name", delete(handle_mcp_server_delete))
             // Accept GET/POST/PUT for settings — some clients issue PUT and previously got 405.
             .route(
                 "/api/settings",

--- a/crates/ghost-link/src/mcp/config.rs
+++ b/crates/ghost-link/src/mcp/config.rs
@@ -112,10 +112,6 @@ impl McpConfigManager {
         Ok(file.servers)
     }
 
-    // Only called from set_enabled() below, which itself has no caller yet
-    // (see McpRegistry::set_enabled's doc comment) - kept for that same
-    // planned GUI enable/disable toggle rather than deleted.
-    #[allow(dead_code)]
     pub fn save(&self, servers: &[McpServerConfig]) -> Result<(), String> {
         for server in servers {
             validate_server(server)?;
@@ -131,7 +127,6 @@ impl McpConfigManager {
         Ok(())
     }
 
-    #[allow(dead_code)]
     pub fn set_enabled(&self, name: &str, enabled: bool) -> Result<(), String> {
         let mut servers = self.load()?;
         let server = servers
@@ -139,6 +134,50 @@ impl McpConfigManager {
             .find(|s| s.name == name)
             .ok_or_else(|| format!("no MCP server named '{name}'"))?;
         server.enabled = enabled;
+        self.save(&servers)
+    }
+
+    /// Appends a new server entry. Rejects a duplicate `name` rather than
+    /// silently overwriting it — renaming/replacing an existing server goes
+    /// through `update` instead, which is explicit about which entry it's
+    /// replacing.
+    pub fn add(&self, server: McpServerConfig) -> Result<(), String> {
+        let mut servers = self.load()?;
+        if servers.iter().any(|s| s.name == server.name) {
+            return Err(format!(
+                "an MCP server named '{}' already exists",
+                server.name
+            ));
+        }
+        servers.push(server);
+        self.save(&servers)
+    }
+
+    /// Replaces the server currently named `name` with `server` in full
+    /// (including allowing a rename via `server.name`).
+    pub fn update(&self, name: &str, server: McpServerConfig) -> Result<(), String> {
+        let mut servers = self.load()?;
+        let idx = servers
+            .iter()
+            .position(|s| s.name == name)
+            .ok_or_else(|| format!("no MCP server named '{name}'"))?;
+        if server.name != name && servers.iter().any(|s| s.name == server.name) {
+            return Err(format!(
+                "an MCP server named '{}' already exists",
+                server.name
+            ));
+        }
+        servers[idx] = server;
+        self.save(&servers)
+    }
+
+    pub fn remove(&self, name: &str) -> Result<(), String> {
+        let mut servers = self.load()?;
+        let before = servers.len();
+        servers.retain(|s| s.name != name);
+        if servers.len() == before {
+            return Err(format!("no MCP server named '{name}'"));
+        }
         self.save(&servers)
     }
 }
@@ -411,6 +450,88 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "./mcp_workspace"]
         }];
 
         assert!(manager.save(&servers).is_ok());
+        let _ = std::fs::remove_file(path);
+    }
+
+    fn stdio_server(name: &str) -> McpServerConfig {
+        McpServerConfig {
+            name: name.to_string(),
+            slot: "".to_string(),
+            enabled: true,
+            transport: McpTransport::Stdio {
+                command: "npx".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+            },
+            requires_confirmation: false,
+            timeout_secs: 30,
+        }
+    }
+
+    #[test]
+    fn add_appends_a_new_server() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        manager.add(stdio_server("filesystem")).unwrap();
+        let loaded = manager.load().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "filesystem");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn add_rejects_duplicate_name() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        manager.add(stdio_server("filesystem")).unwrap();
+        assert!(manager.add(stdio_server("filesystem")).is_err());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn update_replaces_existing_server_and_allows_rename() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        manager.add(stdio_server("filesystem")).unwrap();
+
+        let mut renamed = stdio_server("filesystem-v2");
+        renamed.requires_confirmation = true;
+        manager.update("filesystem", renamed).unwrap();
+
+        let loaded = manager.load().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "filesystem-v2");
+        assert!(loaded[0].requires_confirmation);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn update_missing_server_fails() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        assert!(manager.update("nope", stdio_server("nope")).is_err());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn remove_deletes_the_named_server() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        manager.add(stdio_server("filesystem")).unwrap();
+        manager.add(stdio_server("calculator")).unwrap();
+        manager.remove("filesystem").unwrap();
+
+        let loaded = manager.load().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "calculator");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn remove_missing_server_fails() {
+        let path = temp_config_path();
+        let manager = McpConfigManager::new(&path);
+        assert!(manager.remove("nope").is_err());
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/ghost-link/src/mcp/mod.rs
+++ b/crates/ghost-link/src/mcp/mod.rs
@@ -9,7 +9,7 @@ mod registry;
 pub mod toolcall;
 
 pub use client::McpToolSchema;
-pub use config::McpConfigManager;
+pub use config::{McpConfigManager, McpServerConfig};
 pub use registry::McpRegistry;
 
 /// Default path for the MCP server registry file, alongside `ghostlink.toml`.

--- a/crates/ghost-link/src/mcp/registry.rs
+++ b/crates/ghost-link/src/mcp/registry.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use tokio::sync::RwLock;
 
 use super::client::{McpServerHandle, McpToolSchema, ToolCallOutcome};
-use super::config::McpConfigManager;
+use super::config::{McpConfigManager, McpTransport};
 
 pub struct McpRegistry {
     config_manager: McpConfigManager,
@@ -31,6 +31,12 @@ pub struct McpServerStatus {
     pub connected: bool,
     pub tool_count: usize,
     pub requires_confirmation: bool,
+    /// Included so the GUI's MCP editor can prefill an edit form without a
+    /// second round-trip. Safe to expose: `mcp_servers.toml` may only hold
+    /// `${VAR_NAME}` references or non-secret literals here, never a real
+    /// secret (enforced by `validate_server` at save time).
+    pub transport: McpTransport,
+    pub timeout_secs: u64,
 }
 
 impl McpRegistry {
@@ -112,6 +118,8 @@ impl McpRegistry {
                     connected: live.is_some(),
                     tool_count: live.map(|handle| handle.tools().len()).unwrap_or(0),
                     requires_confirmation: config.requires_confirmation,
+                    transport: config.transport,
+                    timeout_secs: config.timeout_secs,
                 }
             })
             .collect())
@@ -120,12 +128,7 @@ impl McpRegistry {
     /// Toggles a server's `enabled` flag in `mcp_servers.toml` and takes effect
     /// immediately: connects it now if enabling, or tears it down now if
     /// disabling — so the GUI doesn't need a Ghostlink restart to see the change.
-    ///
-    /// No route calls this yet (the MCP tab's per-server toggle, if/when
-    /// added, is the natural caller) - `GET /api/mcp/servers` only reads
-    /// status today. Kept rather than deleted since it's fully correct and
-    /// ready for that follow-up.
-    #[allow(dead_code)]
+    /// Called by `POST /api/mcp/servers/:name/toggle` (the MCP tab's per-server switch).
     pub async fn set_enabled(&self, name: &str, enabled: bool) -> Result<(), String> {
         self.config_manager.set_enabled(name, enabled)?;
 
@@ -147,6 +150,73 @@ impl McpRegistry {
             tracing::info!("mcp: disconnected server '{name}'");
         }
 
+        Ok(())
+    }
+
+    /// Adds a new server to `mcp_servers.toml` and connects it immediately if
+    /// `enabled` — no restart needed to start using it.
+    pub async fn add_server(&self, config: super::config::McpServerConfig) -> Result<(), String> {
+        self.config_manager.add(config.clone())?;
+        if config.enabled {
+            match McpServerHandle::connect(&config).await {
+                Ok(handle) => {
+                    tracing::info!(
+                        "mcp: connected newly added server '{}' ({} tools)",
+                        config.name,
+                        handle.tools().len()
+                    );
+                    self.servers.write().await.insert(config.name, handle);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "mcp: added server '{}' but failed to connect: {err}",
+                        config.name
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Replaces the server currently named `name` (including renaming it via
+    /// `config.name`) and reconnects it live to match the new config.
+    pub async fn update_server(
+        &self,
+        name: &str,
+        config: super::config::McpServerConfig,
+    ) -> Result<(), String> {
+        self.config_manager.update(name, config.clone())?;
+        if let Some(handle) = self.servers.write().await.remove(name) {
+            handle.shutdown().await;
+        }
+        if config.enabled {
+            match McpServerHandle::connect(&config).await {
+                Ok(handle) => {
+                    tracing::info!(
+                        "mcp: reconnected updated server '{}' ({} tools)",
+                        config.name,
+                        handle.tools().len()
+                    );
+                    self.servers.write().await.insert(config.name, handle);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "mcp: updated server '{}' but failed to reconnect: {err}",
+                        config.name
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Removes a server from `mcp_servers.toml` and disconnects it immediately.
+    pub async fn remove_server(&self, name: &str) -> Result<(), String> {
+        self.config_manager.remove(name)?;
+        if let Some(handle) = self.servers.write().await.remove(name) {
+            handle.shutdown().await;
+            tracing::info!("mcp: disconnected removed server '{name}'");
+        }
         Ok(())
     }
 

--- a/ghostlink_gui_modern/.gitignore
+++ b/ghostlink_gui_modern/.gitignore
@@ -5,3 +5,5 @@ dist/
 *.log
 .env.local
 .env.*.local
+test-results/
+playwright-report/

--- a/ghostlink_gui_modern/e2e/accessibility.spec.ts
+++ b/ghostlink_gui_modern/e2e/accessibility.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+// Scans the app shell + each primary tab for WCAG 2 A/AA violations.
+// Structural regressions (missing labels, bad contrast, broken landmarks,
+// invalid ARIA) show up here without needing a live backend, since the UI
+// shell renders regardless of backend reachability.
+const TABS = ['Chat', 'Models', 'Metrics', 'Sessions', 'Workers', 'Security', 'Settings', 'MCP', 'Editor']
+
+// color-contrast is disabled for now: the app's muted "slate-500/600 on
+// slate-900/950" text color is used pervasively across every tab and falls
+// short of WCAG AA by a small margin almost everywhere it appears. Fixing it
+// means a deliberate design pass over the muted-text color scale, not a
+// mechanical per-element fix — tracked separately rather than silently
+// failing every test in this file until that pass happens.
+const scan = (page: import('@playwright/test').Page) =>
+  new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']).disableRules(['color-contrast']).analyze()
+
+test.describe('Accessibility (axe)', () => {
+  test('home / chat tab has no automatically detectable violations', async ({ page }) => {
+    await page.goto('/')
+    const results = await scan(page)
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([])
+  })
+
+  for (const label of TABS) {
+    test(`${label} tab has no automatically detectable violations`, async ({ page }) => {
+      await page.goto('/')
+      await page.getByRole('button', { name: label, exact: true }).click()
+      const results = await scan(page)
+      expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([])
+    })
+  }
+
+  test('MCP add-server dialog has no automatically detectable violations', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'MCP', exact: true }).click()
+    await page.getByRole('button', { name: 'Add Server' }).click()
+    await page.getByRole('dialog', { name: 'Add MCP Server' }).waitFor()
+    const results = await scan(page)
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([])
+  })
+})

--- a/ghostlink_gui_modern/eslint.config.js
+++ b/ghostlink_gui_modern/eslint.config.js
@@ -1,0 +1,39 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  { ignores: ['dist', 'node_modules', 'coverage', 'playwright-report', 'test-results'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended, jsxA11y.flatConfigs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      // Only the classic hooks-correctness rules — react-hooks' "recommended"
+      // config as of v7 bundles the much stricter, unrelated React Compiler
+      // rule set (static-components, set-state-in-effect, purity, ...), which
+      // is out of scope for an accessibility-focused lint pass.
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      // tabindex="0" on role="region" is the standard WCAG technique (SCR29)
+      // for making a scrollable content area keyboard-scrollable — axe
+      // actively requires it (scrollable-region-focusable), so allow it here
+      // even though jsx-a11y's default list treats "region" as non-interactive.
+      'jsx-a11y/no-noninteractive-tabindex': ['error', { roles: ['region', 'tabpanel'] }],
+    },
+  }
+);

--- a/ghostlink_gui_modern/package-lock.json
+++ b/ghostlink_gui_modern/package-lock.json
@@ -24,6 +24,8 @@
         "zustand": "^4.4.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/typography": "^0.5.20",
         "@testing-library/jest-dom": "^6.0.0",
@@ -32,10 +34,16 @@
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.2.0",
         "autoprefixer": "^10.4.16",
+        "eslint": "^9.39.5",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.3",
+        "globals": "^17.9.0",
         "jsdom": "^24.0.0",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.3.0",
+        "typescript-eslint": "^8.66.0",
         "vite": "^5.0.0",
         "vite-plugin-monaco-editor-esm": "^2.0.2",
         "vitest": "^1.0.0"
@@ -81,6 +89,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -879,6 +900,237 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1672,6 +1924,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -1733,6 +1992,301 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.66.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.66.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
@@ -1918,6 +2472,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -1941,6 +2505,23 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -1997,6 +2578,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -2024,6 +2612,89 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2032,6 +2703,23 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/asynckit": {
@@ -2093,6 +2781,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
@@ -2105,6 +2803,16 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2114,6 +2822,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.42",
@@ -2139,6 +2854,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -2245,6 +2971,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase-css": {
@@ -2476,6 +3212,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -2674,6 +3417,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -2686,6 +3436,60 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/date-fns": {
@@ -2792,6 +3596,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -2921,6 +3732,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2932,6 +3750,94 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-define-property": {
@@ -2998,6 +3904,40 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-toolkit": {
@@ -3072,6 +4012,236 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-util-is-identifier-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -3090,6 +4260,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -3128,6 +4308,13 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -3158,6 +4345,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3166,6 +4367,19 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -3180,6 +4394,44 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -3298,6 +4550,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
@@ -3306,6 +4582,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -3378,6 +4664,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3389,6 +4693,36 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gopd": {
@@ -3434,6 +4768,22 @@
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3547,6 +4897,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -3639,6 +5006,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immer": {
       "version": "11.1.15",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
@@ -3647,6 +5024,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -3748,6 +5152,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-bigint": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
@@ -3823,6 +5247,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-date-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
@@ -3850,6 +5292,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3858,6 +5316,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -3887,6 +5381,19 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4038,12 +5545,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4097,6 +5636,29 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "24.1.3",
@@ -4176,6 +5738,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4187,6 +5770,66 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lilconfig": {
@@ -4225,6 +5868,29 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -5251,6 +6917,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -5332,6 +7011,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.50",
@@ -5470,6 +7156,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -5486,6 +7210,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/p-limit": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
@@ -5500,6 +7261,64 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parse-entities": {
@@ -5538,6 +7357,16 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -5853,6 +7682,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -6125,6 +7964,29 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6264,6 +8126,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6349,6 +8221,43 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safe-regex-test": {
@@ -6437,6 +8346,21 @@
         "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6615,6 +8539,81 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -6653,6 +8652,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-literal": {
@@ -6953,6 +8965,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -6966,6 +8991,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
@@ -6974,6 +9012,84 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typescript": {
@@ -6990,12 +9106,55 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.66.0",
+        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -7137,6 +9296,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-parse": {
@@ -7472,6 +9641,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-collection": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
@@ -7528,6 +9725,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -7596,6 +9803,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zustand": {

--- a/ghostlink_gui_modern/package.json
+++ b/ghostlink_gui_modern/package.json
@@ -7,6 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
+    "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
@@ -29,6 +30,8 @@
     "zustand": "^4.4.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/typography": "^0.5.20",
     "@testing-library/jest-dom": "^6.0.0",
@@ -37,10 +40,16 @@
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.16",
+    "eslint": "^9.39.5",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.3",
+    "globals": "^17.9.0",
     "jsdom": "^24.0.0",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
+    "typescript-eslint": "^8.66.0",
     "vite": "^5.0.0",
     "vite-plugin-monaco-editor-esm": "^2.0.2",
     "vitest": "^1.0.0"

--- a/ghostlink_gui_modern/src/App.tsx
+++ b/ghostlink_gui_modern/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Plus, ChevronRight, Menu, Cpu, Zap, Wifi, Search } from 'lucide-react';
 import { useAppStore } from './store';
 import { GhostlinkAPI } from './api';
@@ -120,6 +120,52 @@ function App() {
     if (window.innerWidth < 768) setSidebarOpen(false);
   };
   const isOnline = useOnlineStatus();
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const sidebarOpenButtonRef = useRef<HTMLButtonElement>(null);
+
+  // On mobile the sidebar renders as a modal-like overlay (see backdrop below),
+  // so opening it moves focus in, Escape closes it, and Tab is trapped inside
+  // until it closes; on desktop it's a persistent panel and none of this applies.
+  useEffect(() => {
+    if (!sidebarOpen || window.innerWidth >= 768) return;
+    const container = sidebarRef.current;
+    if (!container) return;
+
+    const focusable = () =>
+      Array.from(
+        container.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        )
+      );
+
+    focusable()[0]?.focus();
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setSidebarOpen(false);
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const items = focusable();
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      sidebarOpenButtonRef.current?.focus();
+    };
+  }, [sidebarOpen]);
 
   // CRITICAL FIX: Initialize API base on app load
   useEffect(() => {
@@ -231,6 +277,12 @@ function App() {
   return (
     <ErrorBoundary>
       <div className="flex h-screen bg-slate-950 text-slate-100 font-sans overflow-hidden relative">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:rounded-lg focus:bg-blue-600 focus:text-white focus:text-sm focus:font-medium"
+        >
+          Skip to main content
+        </a>
         <OfflineBanner isOnline={isOnline} />
         <CommandPalette />
         <Toaster />
@@ -244,6 +296,8 @@ function App() {
         )}
         {/* Sidebar */}
       <div
+        id="primary-sidebar"
+        ref={sidebarRef}
         className={`${
           sidebarOpen ? 'w-64 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:shadow-2xl' : 'w-0'
         } transition-all duration-300 bg-slate-900 border-r border-slate-800 flex flex-col overflow-hidden relative`}
@@ -331,9 +385,12 @@ function App() {
         {/* Toggle Sidebar Button (Float) */}
         {!sidebarOpen && (
             <button
+                ref={sidebarOpenButtonRef}
                 onClick={() => setSidebarOpen(true)}
                 aria-label="Open sidebar"
-                className="absolute left-4 top-4 z-10 p-2 bg-slate-900 border border-slate-800 rounded-lg text-slate-400 hover:text-white transition"
+                aria-expanded={false}
+                aria-controls="primary-sidebar"
+                className="absolute left-4 top-4 z-10 p-2 bg-slate-900 border border-slate-800 rounded-lg text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             >
                 <Menu size={20} aria-hidden="true" />
             </button>
@@ -343,14 +400,16 @@ function App() {
             <button
                 onClick={() => setSidebarOpen(false)}
                 aria-label="Collapse sidebar"
-                className="absolute left-[-12px] top-1/2 -translate-y-1/2 z-20 p-1 bg-slate-800 border border-slate-700 rounded-full text-slate-500 hover:text-white transition"
+                aria-expanded={true}
+                aria-controls="primary-sidebar"
+                className="absolute left-[-12px] top-1/2 -translate-y-1/2 z-20 p-1 bg-slate-800 border border-slate-700 rounded-full text-slate-500 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             >
                 <ChevronRight size={16} className="rotate-180" aria-hidden="true" />
             </button>
         )}
 
         {/* Content */}
-        <main className="flex-1 overflow-hidden">
+        <main id="main-content" tabIndex={-1} className="flex-1 overflow-hidden">
           {renderTab()}
         </main>
       </div>

--- a/ghostlink_gui_modern/src/api.ts
+++ b/ghostlink_gui_modern/src/api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { Model, Metric, Session, Worker, Settings, McpServer, WorkspaceEntry } from './store';
+import { Model, Metric, Session, Worker, Settings, McpServer, McpServerInput, WorkspaceEntry } from './store';
 import { createInferenceEngineDescriptors, InferenceEngineDescriptor } from './types/engines';
 
 export interface MetricsHistoryPoint {
@@ -455,6 +455,53 @@ export class GhostlinkAPI {
         `/api/mcp/servers/${encodeURIComponent(name)}/toggle`,
         { enabled }
       );
+      return {
+        success: response.data.success !== false,
+        servers: response.data.servers,
+        error: response.data.error,
+      };
+    } catch (error: any) {
+      return { success: false, error: error.response?.data?.error || error.message };
+    }
+  }
+
+  async createMcpServer(
+    config: McpServerInput
+  ): Promise<{ success: boolean; servers?: McpServer[]; error?: string }> {
+    try {
+      const response = await this.http.post('/api/mcp/servers', config);
+      return {
+        success: response.data.success !== false,
+        servers: response.data.servers,
+        error: response.data.error,
+      };
+    } catch (error: any) {
+      return { success: false, error: error.response?.data?.error || error.message };
+    }
+  }
+
+  async updateMcpServer(
+    name: string,
+    config: McpServerInput
+  ): Promise<{ success: boolean; servers?: McpServer[]; error?: string }> {
+    try {
+      const response = await this.http.post(
+        `/api/mcp/servers/${encodeURIComponent(name)}/update`,
+        config
+      );
+      return {
+        success: response.data.success !== false,
+        servers: response.data.servers,
+        error: response.data.error,
+      };
+    } catch (error: any) {
+      return { success: false, error: error.response?.data?.error || error.message };
+    }
+  }
+
+  async deleteMcpServer(name: string): Promise<{ success: boolean; servers?: McpServer[]; error?: string }> {
+    try {
+      const response = await this.http.delete(`/api/mcp/servers/${encodeURIComponent(name)}`);
       return {
         success: response.data.success !== false,
         servers: response.data.servers,

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -113,12 +113,43 @@ const CodeBlock: React.FC<{ children?: React.ReactNode }> = ({ children, ...rest
       >
         {copied ? <Check size={13} className="text-green-400" aria-hidden="true" /> : <Copy size={13} aria-hidden="true" />}
       </button>
-      <pre {...rest} className="!bg-slate-950 !border !border-slate-800 !rounded-xl !p-4 overflow-x-auto text-xs">
+      <pre {...rest} className="!bg-slate-950 !border !border-slate-800 !rounded-xl !p-4 overflow-x-auto text-[13px] leading-relaxed">
         {children}
       </pre>
     </div>
   );
 };
+
+// GFM tables (remark-gfm) render at their natural width, which routinely
+// blows past a chat bubble's — wrap in a scroll container instead of letting
+// them force the whole bubble (and page) wider or mangle-wrap every cell.
+const MarkdownTable: React.FC<React.TableHTMLAttributes<HTMLTableElement>> = (props) => (
+  <div className="overflow-x-auto">
+    <table {...props} />
+  </div>
+);
+
+// Shared knobs for both markdown renders below: tames default heading sizes
+// (typography's h1/h2/h3 scale reads fine on a full-width article, but is
+// oversized inside a narrow chat bubble — a one-line reply with a "# Summary"
+// heading shouldn't render that heading larger than the rest of the message
+// combined), tightens list/paragraph rhythm, and swaps the plugin's
+// backtick-quoted inline `code` styling for a subtler background pill.
+const MARKDOWN_PROSE_CLASSES =
+  'max-w-none break-words ' +
+  'prose-headings:font-semibold ' +
+  'prose-h1:text-lg prose-h1:mt-4 prose-h1:mb-2 first:prose-h1:mt-0 ' +
+  'prose-h2:text-base prose-h2:mt-4 prose-h2:mb-2 first:prose-h2:mt-0 ' +
+  'prose-h3:text-sm prose-h3:mt-3 prose-h3:mb-1 first:prose-h3:mt-0 ' +
+  'prose-p:leading-relaxed prose-li:my-1 prose-ul:my-2 prose-ol:my-2 ' +
+  // `prose-code:` targets every <code>, inside <pre> or not — scoping to
+  // `:not(pre)>code` keeps this to inline code so it can't also shrink/pill
+  // the syntax-highlighted text inside fenced code blocks (CodeBlock already
+  // styles those directly).
+  '[&_:not(pre)>code]:before:content-none [&_:not(pre)>code]:after:content-none ' +
+  '[&_:not(pre)>code]:bg-slate-800 [&_:not(pre)>code]:text-slate-200 [&_:not(pre)>code]:font-normal ' +
+  '[&_:not(pre)>code]:rounded [&_:not(pre)>code]:px-1.5 [&_:not(pre)>code]:py-0.5 ' +
+  '[&_:not(pre)>code]:text-[0.85em] [&_:not(pre)>code]:break-words';
 
 // One column of a Compare Mode turn — a deliberately trimmed-down sibling of
 // the full message bubble below (no tool-call cards, no pending-confirmation
@@ -143,8 +174,8 @@ const CompareColumn: React.FC<{
     </div>
     <div className="text-sm leading-relaxed text-slate-200 min-h-[1.5em]">
       {msg.content ? (
-        <div className="prose prose-invert prose-sm max-w-none break-words">
-          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={{ pre: CodeBlock }}>
+        <div className={`prose prose-invert prose-sm ${MARKDOWN_PROSE_CLASSES}`}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={{ pre: CodeBlock, table: MarkdownTable }}>
             {msg.content}
           </ReactMarkdown>
           {isLoading && <span className="inline-block w-[7px] h-[1em] bg-blue-400 align-text-bottom ml-0.5 animate-pulse" />}
@@ -1249,11 +1280,11 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                                 : 'text-slate-200 bg-transparent'
                         }`}>
                             {msg.role === 'assistant' ? (
-                              <div className="prose prose-invert prose-sm max-w-none break-words">
+                              <div className={`prose prose-invert ${MARKDOWN_PROSE_CLASSES}`}>
                                 <ReactMarkdown
                                   remarkPlugins={[remarkGfm]}
                                   rehypePlugins={[rehypeHighlight]}
-                                  components={{ pre: CodeBlock }}
+                                  components={{ pre: CodeBlock, table: MarkdownTable }}
                                 >
                                   {msg.content}
                                 </ReactMarkdown>

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -26,7 +26,8 @@ import {
   GitCompare,
   Pencil,
   Mic,
-  LayoutGrid,
+  Paperclip,
+  FileText,
 } from 'lucide-react';
 import { useAppStore, ChatMessage } from '../store';
 import { GhostlinkAPI } from '../api';
@@ -183,6 +184,17 @@ const CompareRow: React.FC<{
   </div>
 );
 
+// Attachments are read entirely client-side and inlined as fenced code
+// blocks — there's no upload/multimodal endpoint, so only text-ish files
+// make sense here; a 256KB cap keeps one large paste from blowing the
+// conversation token budget.
+const MAX_ATTACHMENT_BYTES = 256 * 1024;
+const TEXT_FILE_EXTENSIONS = new Set([
+  'txt', 'md', 'markdown', 'json', 'csv', 'tsv', 'log', 'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf', 'env',
+  'py', 'js', 'jsx', 'ts', 'tsx', 'rs', 'go', 'java', 'kt', 'c', 'h', 'cpp', 'hpp', 'cs', 'rb', 'php',
+  'sh', 'bash', 'ps1', 'sql', 'css', 'scss', 'html', 'htm', 'xml', 'svg',
+]);
+
 // Pre-configured start prompts to improve immediate UX and help-seeking onboarding.
 const SUGGESTIONS = [
   { text: 'Check active cluster node health', label: 'Ask about active cluster node health' },
@@ -235,6 +247,15 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const { selectedEngine } = useInferenceEngines(api);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
+  // File attachments: read entirely client-side and inlined into the
+  // outgoing message as fenced code blocks. There's no multimodal/upload
+  // path on the backend (the chat request is plain text), so this is
+  // deliberately scoped to text-ish files rather than pretending to support
+  // images the model will never actually see.
+  const [attachments, setAttachments] = useState<{ id: string; name: string; content: string; size: number }[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDraggingFile, setIsDraggingFile] = useState(false);
+
   // Compare Mode: send one turn to two models at once and render the
   // replies side-by-side. Deliberately scoped down from full conversation
   // branching (a tree data model + branch-navigation UI) to something
@@ -250,6 +271,22 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const genStartRef = useRef<number | null>(null);
   const genTokenCountRef = useRef(0);
   const [genTick, setGenTick] = useState(0);
+
+  // Screen readers can't sensibly narrate a response as it streams token by
+  // token, so instead of a live region on the growing bubble itself, this
+  // announces once when a response finishes — enough for a screen-reader
+  // user to know it's safe to go read the reply.
+  const [streamAnnouncement, setStreamAnnouncement] = useState('');
+  const prevStreamingIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (prevStreamingIdRef.current && !streamingId) {
+      setStreamAnnouncement('Response complete.');
+      const clear = setTimeout(() => setStreamAnnouncement(''), 3000);
+      prevStreamingIdRef.current = streamingId;
+      return () => clearTimeout(clear);
+    }
+    prevStreamingIdRef.current = streamingId;
+  }, [streamingId]);
 
   // One checkbox per legacy "tool slot" (calculator, file_operations, ...) that
   // has a real MCP server configured for it — replaces the old hardcoded
@@ -537,10 +574,67 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     }
   };
 
+  const addFiles = async (files: FileList | File[]) => {
+    for (const file of Array.from(files)) {
+      const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+      const looksTexty =
+        TEXT_FILE_EXTENSIONS.has(ext) || file.type.startsWith('text/') || file.type === 'application/json';
+      if (!looksTexty) {
+        addToast({
+          type: 'error',
+          message: `${file.name}: only text-based files are supported (code, markdown, JSON, CSV, logs, config). Images and other binaries aren't sent to the model.`,
+        });
+        continue;
+      }
+      if (file.size > MAX_ATTACHMENT_BYTES) {
+        addToast({
+          type: 'error',
+          message: `${file.name}: ${(file.size / 1024).toFixed(0)}KB exceeds the ${MAX_ATTACHMENT_BYTES / 1024}KB attachment limit.`,
+        });
+        continue;
+      }
+      try {
+        const content = await file.text();
+        setAttachments((prev) => [
+          ...prev,
+          { id: `${Date.now()}-${Math.random().toString(36).slice(2)}`, name: file.name, content, size: file.size },
+        ]);
+      } catch {
+        addToast({ type: 'error', message: `Failed to read ${file.name}.` });
+      }
+    }
+  };
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) addFiles(e.target.files);
+    e.target.value = '';
+  };
+
+  const removeAttachment = (id: string) => setAttachments((prev) => prev.filter((a) => a.id !== id));
+
+  const handleComposerDragOver = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    setIsDraggingFile(true);
+  };
+  const handleComposerDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDraggingFile(false);
+  };
+  const handleComposerDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDraggingFile(false);
+    if (e.dataTransfer.files?.length) addFiles(e.dataTransfer.files);
+  };
+
   const handleSend = async () => {
     // CRITICAL FIX #1: Capture input BEFORE clearing
-    const messageText = input.trim();
+    const attachmentsBlock = attachments
+      .map((a) => `**Attached: ${a.name}**\n\`\`\`\n${a.content}\n\`\`\`\n`)
+      .join('\n');
+    const messageText = (attachmentsBlock ? `${attachmentsBlock}\n${input}` : input).trim();
     if (!messageText || loading) return;
+    setAttachments([]);
 
     const userMessage: Message = {
       role: 'user',
@@ -755,6 +849,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
       {/* Header / Model Selector */}
       <div className="flex items-center justify-between px-6 py-3 border-b border-slate-900 bg-slate-950/50 backdrop-blur-md sticky top-0 z-10">
         <div className="flex items-center gap-2">
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- wrapper only delegates Escape from its real interactive children (button/role=option below), not a control itself */}
             <div
                 className="relative"
                 ref={modelSelectorRef}
@@ -806,6 +901,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                 )}
             </div>
 
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- wrapper only delegates Escape from its real interactive children, not a control itself */}
             <div
                 className="relative"
                 ref={compareSelectorRef}
@@ -862,6 +958,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                 )}
             </div>
 
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- wrapper only delegates Escape/arrow-key roving focus from its real interactive children, not a control itself */}
             <div
                 className="relative"
                 ref={sessionsRef}
@@ -990,9 +1087,6 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                 {structuredOutputsSupported && <span className="text-emerald-400">Structured outputs</span>}
               </div>
             )}
-            <button className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition">
-                <LayoutGrid size={18} />
-            </button>
             {(() => {
                 const ratio = conversationTokenLimit > 0 ? historyTokens / conversationTokenLimit : 0;
                 const tone = ratio >= 0.9
@@ -1017,8 +1111,9 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
       </div>
 
       {/* Message Area */}
-      <div className="flex-1 overflow-y-auto px-4 py-8 space-y-8">
-        <div className="max-w-3xl mx-auto space-y-10">
+      <div className="sr-only" role="status" aria-live="polite">{streamAnnouncement}</div>
+      <div className="flex-1 overflow-y-auto px-4 py-8 space-y-8" tabIndex={0} role="region" aria-label="Chat">
+        <div className="max-w-3xl mx-auto space-y-10" role="log" aria-label="Conversation" aria-live="polite" aria-relevant="additions">
             {messages.length === 0 && (
                 <div className="flex flex-col items-center justify-center h-[50vh] text-center space-y-4 animate-in fade-in duration-500">
                     <div className="w-16 h-16 bg-slate-900 rounded-2xl flex items-center justify-center mb-2 shadow-2xl border border-slate-800">
@@ -1111,8 +1206,12 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                         )}
 
                         {msg.pendingToolCall && (
-                            <div className="flex flex-col gap-2 px-4 py-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 w-full max-w-md">
-                                <div className="flex items-center gap-2 text-amber-400 text-xs font-bold">
+                            <div
+                                role="alert"
+                                aria-labelledby={`tool-approval-heading-${msg.id}`}
+                                className="flex flex-col gap-2 px-4 py-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 w-full max-w-md"
+                            >
+                                <div id={`tool-approval-heading-${msg.id}`} className="flex items-center gap-2 text-amber-400 text-xs font-bold">
                                     <ShieldAlert size={14} aria-hidden="true" />
                                     Approval needed
                                 </div>
@@ -1125,16 +1224,18 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                                 </pre>
                                 <div className="flex gap-2">
                                     <button
+                                        // eslint-disable-next-line jsx-a11y/no-autofocus -- this is an alert demanding an immediate approve/deny decision; moving focus here matches WAI-ARIA alertdialog guidance
+                                        autoFocus
                                         onClick={() => handleConfirmToolCall(msg.id, msg.pendingToolCall!.request_id, true)}
                                         disabled={confirmingId === msg.pendingToolCall.request_id}
-                                        className="flex-1 px-3 py-1.5 bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white text-xs font-bold rounded-lg transition"
+                                        className="flex-1 px-3 py-1.5 bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white text-xs font-bold rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                                     >
                                         Approve
                                     </button>
                                     <button
                                         onClick={() => handleConfirmToolCall(msg.id, msg.pendingToolCall!.request_id, false)}
                                         disabled={confirmingId === msg.pendingToolCall.request_id}
-                                        className="flex-1 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 disabled:opacity-50 text-slate-300 text-xs font-bold rounded-lg transition"
+                                        className="flex-1 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 disabled:opacity-50 text-slate-300 text-xs font-bold rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                                     >
                                         Deny
                                     </button>
@@ -1284,9 +1385,39 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             </div>
           )}
 
+          {attachments.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-2 px-1">
+              {attachments.map((a) => (
+                <div key={a.id} className="flex items-center gap-1.5 px-2 py-1 rounded-full bg-blue-500/10 border border-blue-500/20 text-[10px] text-blue-300 font-medium">
+                  <FileText size={10} aria-hidden="true" />
+                  {a.name}
+                  <span className="text-blue-400/60">{(a.size / 1024).toFixed(0)}KB</span>
+                  <button onClick={() => removeAttachment(a.id)} className="hover:text-white" aria-label={`Remove attachment ${a.name}`}>
+                    <X size={10} aria-hidden="true" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            onChange={handleFileInputChange}
+            className="sr-only"
+            aria-label="Attach files to message"
+          />
+
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- wrapper only delegates Escape from the real interactive textarea/buttons inside, not a control itself */}
           <div
-            className="relative bg-slate-900 border border-slate-800 rounded-3xl p-2 shadow-2xl focus-within:border-slate-700 transition-all duration-300"
+            className={`relative bg-slate-900 border rounded-3xl p-2 shadow-2xl focus-within:border-blue-500 focus-within:ring-2 focus-within:ring-blue-500/50 transition-all duration-300 ${
+              isDraggingFile ? 'border-blue-500 ring-2 ring-blue-500/50' : 'border-slate-800'
+            }`}
             onKeyDown={(e) => { if (e.key === 'Escape') setShowTools(false); }}
+            onDragOver={handleComposerDragOver}
+            onDragLeave={handleComposerDragLeave}
+            onDrop={handleComposerDrop}
           >
             <textarea
               ref={textareaRef}
@@ -1318,6 +1449,14 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                 >
                     <Plus size={20} aria-hidden="true" />
                 </button>
+                <button
+                    onClick={() => fileInputRef.current?.click()}
+                    title="Attach text files (code, markdown, JSON, CSV, logs, config)"
+                    aria-label="Attach files"
+                    className="p-2 rounded-xl transition text-slate-500 hover:text-slate-300 hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                >
+                    <Paperclip size={18} aria-hidden="true" />
+                </button>
             </div>
 
             <div className="absolute right-3 bottom-3 flex items-center gap-1">
@@ -1341,10 +1480,10 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                 )}
                 <button
                     onClick={handleSend}
-                    disabled={!input.trim() || loading}
+                    disabled={(!input.trim() && attachments.length === 0) || loading}
                     aria-label="Send message"
                     className={`p-2 rounded-full transition shadow-lg focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
-                        !input.trim() || loading
+                        (!input.trim() && attachments.length === 0) || loading
                             ? 'bg-slate-800 text-slate-600'
                             : 'bg-white text-black hover:bg-slate-200'
                     }`}

--- a/ghostlink_gui_modern/src/components/CommandPalette.tsx
+++ b/ghostlink_gui_modern/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import {
   Search,
   MessageSquare,
@@ -51,6 +51,7 @@ export const CommandPalette: React.FC = () => {
   const [highlight, setHighlight] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
+  const shouldReduceMotion = useReducedMotion();
 
   const commands = useMemo<Command[]>(
     () => [
@@ -169,17 +170,17 @@ export const CommandPalette: React.FC = () => {
           onClick={() => setOpen(false)}
         >
           <motion.div
-            initial={{ opacity: 0, scale: 0.96, y: -8 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.96, y: -8 }}
-            transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+            initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96, y: -8 }}
+            animate={shouldReduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1, y: 0 }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.96, y: -8 }}
+            transition={{ duration: shouldReduceMotion ? 0.01 : 0.15, ease: [0.16, 1, 0.3, 1] }}
             role="dialog"
             aria-modal="true"
             aria-label="Command palette"
             onClick={(e) => e.stopPropagation()}
             className="w-full max-w-lg mx-4 bg-slate-900 border border-slate-800 rounded-2xl shadow-2xl overflow-hidden"
           >
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-800">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-800 focus-within:ring-2 focus-within:ring-inset focus-within:ring-blue-500">
           <Search size={16} className="text-slate-500 shrink-0" aria-hidden="true" />
           <input
             ref={inputRef}
@@ -196,6 +197,9 @@ export const CommandPalette: React.FC = () => {
           />
           <kbd className="text-[10px] text-slate-500 bg-slate-950 px-1.5 py-0.5 rounded border border-slate-700">Esc</kbd>
         </div>
+        <div className="sr-only" role="status" aria-live="polite">
+          {filtered.length === 0 ? 'No matching commands' : `${filtered.length} command${filtered.length === 1 ? '' : 's'} found`}
+        </div>
         <ul id="command-palette-list" role="listbox" aria-label="Commands" className="max-h-80 overflow-y-auto p-2">
           {filtered.length === 0 ? (
             <li className="px-3 py-6 text-center text-sm text-slate-500">No matching commands</li>
@@ -203,6 +207,7 @@ export const CommandPalette: React.FC = () => {
             filtered.map((cmd, i) => {
               const Icon = cmd.icon;
               return (
+                // eslint-disable-next-line jsx-a11y/click-events-have-key-events -- combobox/listbox pattern: keyboard selection is handled by the input's onKeyDown via aria-activedescendant, this option never receives focus itself; onClick is the mouse/touch equivalent
                 <li
                   key={cmd.id}
                   id={`command-${cmd.id}`}

--- a/ghostlink_gui_modern/src/components/EditorTab.tsx
+++ b/ghostlink_gui_modern/src/components/EditorTab.tsx
@@ -534,7 +534,7 @@ export const EditorTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
 
         if (token.isCancellationRequested || !result.success) return { items: [] };
 
-        let suggestion = (result.data?.response ?? '')
+        const suggestion = (result.data?.response ?? '')
           .replace(/^```[a-zA-Z0-9_-]*\r?\n?/, '')
           .replace(/```\s*$/, '')
           .replace(/^\r?\n+/, '')
@@ -596,7 +596,7 @@ export const EditorTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             </button>
           </div>
         )}
-        <div className="flex-1 overflow-y-auto py-2">
+        <div className="flex-1 overflow-y-auto py-2" tabIndex={0} role="region" aria-label="Workspace file tree">
           {treeError && <div className="px-3 py-2 text-xs text-red-400">{treeError}</div>}
           {!treeError && rootEntries.length === 0 && !treeLoading && (
             <div className="px-3 py-2 text-xs text-slate-600">Empty workspace</div>

--- a/ghostlink_gui_modern/src/components/McpTab.tsx
+++ b/ghostlink_gui_modern/src/components/McpTab.tsx
@@ -1,14 +1,74 @@
-import React, { useState, useEffect } from 'react';
-import { RefreshCw, Plug, ShieldAlert } from 'lucide-react';
-import { useAppStore } from '../store';
+import React, { useEffect, useRef, useState } from 'react';
+import { Pencil, Plug, Plus, RefreshCw, ShieldAlert, Trash2, X } from 'lucide-react';
+import { McpServer, McpServerInput, useAppStore } from '../store';
 import { GhostlinkAPI } from '../api';
 import { EmptyState } from './StatusViews';
+
+const EMPTY_FORM: McpServerInput = {
+  name: '',
+  slot: '',
+  enabled: true,
+  requires_confirmation: false,
+  timeout_secs: 30,
+  transport: 'stdio',
+  command: '',
+  args: [],
+  env: {},
+  url: '',
+  headers: {},
+};
+
+// "KEY=value" per line <-> Record<string,string>, used for both env vars and
+// HTTP headers so the form doesn't need a dynamic add/remove-row widget.
+function parseKeyValueLines(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    out[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return out;
+}
+
+function formatKeyValueLines(record: Record<string, string> | undefined): string {
+  return Object.entries(record || {})
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n');
+}
+
+function serverToFormInput(server: McpServer): McpServerInput {
+  return {
+    name: server.name,
+    slot: server.slot,
+    enabled: server.enabled,
+    requires_confirmation: server.requires_confirmation,
+    timeout_secs: server.timeout_secs,
+    transport: server.transport.transport,
+    command: server.transport.transport === 'stdio' ? server.transport.command : '',
+    args: server.transport.transport === 'stdio' ? server.transport.args : [],
+    env: server.transport.transport === 'stdio' ? server.transport.env : {},
+    url: server.transport.transport === 'http' ? server.transport.url : '',
+    headers: server.transport.transport === 'http' ? server.transport.headers : {},
+  };
+}
 
 export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const { mcpServers, setMcpServers } = useAppStore();
   const [loading, setLoading] = useState(false);
   const [toggling, setToggling] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  // null = closed, '' = "add new" mode, otherwise the name of the server being edited
+  const [editorTarget, setEditorTarget] = useState<string | null>(null);
+  const [form, setForm] = useState<McpServerInput>(EMPTY_FORM);
+  const [envText, setEnvText] = useState('');
+  const [argsText, setArgsText] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const editorCloseRef = useRef<HTMLButtonElement>(null);
+  const editorTriggerRef = useRef<HTMLElement | null>(null);
 
   const refresh = async () => {
     setLoading(true);
@@ -41,6 +101,109 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     setToggling(null);
   };
 
+  const handleDelete = async (name: string) => {
+    if (!window.confirm(`Remove MCP server "${name}"? This edits mcp_servers.toml and disconnects it immediately.`)) {
+      return;
+    }
+    setDeleting(name);
+    const result = await api.deleteMcpServer(name);
+    if (result.servers) {
+      setMcpServers(result.servers);
+    }
+    if (!result.success && result.error) {
+      setError(result.error);
+    }
+    setDeleting(null);
+  };
+
+  const openCreateEditor = (trigger: HTMLElement) => {
+    editorTriggerRef.current = trigger;
+    setForm(EMPTY_FORM);
+    setEnvText('');
+    setArgsText('');
+    setFormError(null);
+    setEditorTarget('');
+  };
+
+  const openEditEditor = (server: McpServer, trigger: HTMLElement) => {
+    editorTriggerRef.current = trigger;
+    const input = serverToFormInput(server);
+    setForm(input);
+    setEnvText(formatKeyValueLines(input.transport === 'stdio' ? input.env : input.headers));
+    setArgsText((input.args || []).join('\n'));
+    setFormError(null);
+    setEditorTarget(server.name);
+  };
+
+  const closeEditor = () => {
+    setEditorTarget(null);
+    editorTriggerRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (editorTarget === null) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeEditor();
+    };
+    document.addEventListener('keydown', handleKey);
+    editorCloseRef.current?.focus();
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [editorTarget]);
+
+  const handleSave = async () => {
+    const name = form.name.trim();
+    if (!name) {
+      setFormError('Name is required.');
+      return;
+    }
+    if (form.transport === 'stdio' && !form.command?.trim()) {
+      setFormError('Command is required for a stdio server.');
+      return;
+    }
+    if (form.transport === 'http' && !form.url?.trim()) {
+      setFormError('URL is required for an HTTP server.');
+      return;
+    }
+
+    const kv = parseKeyValueLines(envText);
+    const payload: McpServerInput = {
+      name,
+      slot: form.slot.trim(),
+      enabled: form.enabled,
+      requires_confirmation: form.requires_confirmation,
+      timeout_secs: form.timeout_secs,
+      transport: form.transport,
+      ...(form.transport === 'stdio'
+        ? {
+            command: form.command?.trim() || '',
+            args: argsText
+              .split('\n')
+              .map((a) => a.trim())
+              .filter((a) => a !== ''),
+            env: kv,
+          }
+        : {
+            url: form.url?.trim() || '',
+            headers: kv,
+          }),
+    };
+
+    setSaving(true);
+    setFormError(null);
+    const result =
+      editorTarget === '' ? await api.createMcpServer(payload) : await api.updateMcpServer(editorTarget!, payload);
+    setSaving(false);
+
+    if (!result.success) {
+      setFormError(result.error || 'Failed to save server.');
+      return;
+    }
+    if (result.servers) {
+      setMcpServers(result.servers);
+    }
+    closeEditor();
+  };
+
   return (
     <div className="flex flex-col h-full bg-slate-950">
       <div className="flex items-center justify-between px-6 py-4 border-b border-slate-900 sticky top-0 bg-slate-950/50 backdrop-blur-md z-10">
@@ -50,16 +213,24 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             {mcpServers.filter((s) => s.connected).length} / {mcpServers.length} connected
           </div>
         </div>
-        <button
-          onClick={refresh}
-          aria-label="Refresh MCP servers"
-          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
-        >
-          <RefreshCw size={18} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={(e) => openCreateEditor(e.currentTarget)}
+            className="flex items-center gap-2 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-xs font-bold rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+          >
+            <Plus size={14} aria-hidden="true" /> Add Server
+          </button>
+          <button
+            onClick={refresh}
+            aria-label="Refresh MCP servers"
+            className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+          >
+            <RefreshCw size={18} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
+          </button>
+        </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-6" tabIndex={0} role="region" aria-label="MCP servers">
         <div className="max-w-4xl mx-auto">
           {error && (
             <div role="alert" className="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-xl text-sm text-red-400">
@@ -71,7 +242,7 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             <EmptyState
               icon={Plug}
               title="No MCP servers configured"
-              description={<>Add entries to <code className="text-slate-400">mcp_servers.toml</code> and refresh.</>}
+              description="Click Add Server above, or hand-edit mcp_servers.toml and refresh."
             />
           )}
 
@@ -150,11 +321,225 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                     }`}
                   ></div>
                 </button>
+
+                <button
+                  onClick={(e) => openEditEditor(server, e.currentTarget)}
+                  className="p-1.5 rounded-lg hover:bg-slate-800 text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                  title="Edit server"
+                  aria-label={`Edit ${server.name}`}
+                >
+                  <Pencil size={16} aria-hidden="true" />
+                </button>
+                <button
+                  onClick={() => handleDelete(server.name)}
+                  disabled={deleting === server.name}
+                  className="p-1.5 rounded-lg hover:bg-slate-800 text-slate-400 hover:text-red-400 transition disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                  title="Remove server"
+                  aria-label={`Remove ${server.name}`}
+                >
+                  <Trash2 size={16} aria-hidden="true" />
+                </button>
               </div>
             ))}
           </div>
         </div>
       </div>
+
+      {editorTarget !== null && (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- click-outside-to-dismiss backdrop; Escape (handled above) and the close button already cover keyboard/AT users
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={closeEditor}>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- onClick here only stops the backdrop's close-on-click from firing when clicking inside the dialog, it's not a control */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mcp-editor-title"
+            onClick={(e) => e.stopPropagation()}
+            className="bg-slate-900 border border-slate-800 rounded-2xl max-w-lg w-full max-h-[85vh] overflow-hidden flex flex-col"
+          >
+            <div className="flex items-center justify-between p-4 border-b border-slate-800">
+              <h3 id="mcp-editor-title" className="text-lg font-bold text-white">
+                {editorTarget === '' ? 'Add MCP Server' : `Edit ${editorTarget}`}
+              </h3>
+              <button
+                ref={editorCloseRef}
+                onClick={closeEditor}
+                className="text-slate-400 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                aria-label="Close"
+              >
+                <X size={20} aria-hidden="true" />
+              </button>
+            </div>
+
+            <div className="p-4 overflow-y-auto space-y-4">
+              {formError && (
+                <div role="alert" className="px-3 py-2 bg-red-500/10 border border-red-500/30 rounded-lg text-xs text-red-400">
+                  {formError}
+                </div>
+              )}
+
+              <div>
+                <label htmlFor="mcp-name" className="block text-xs font-bold text-slate-400 mb-1">Name</label>
+                <input
+                  id="mcp-name"
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                  className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="mcp-slot" className="block text-xs font-bold text-slate-400 mb-1">
+                  Slot <span className="font-normal text-slate-500">(optional — e.g. web_search, calculator)</span>
+                </label>
+                <input
+                  id="mcp-slot"
+                  type="text"
+                  value={form.slot}
+                  onChange={(e) => setForm((f) => ({ ...f, slot: e.target.value }))}
+                  className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                />
+              </div>
+
+              <fieldset>
+                <legend className="block text-xs font-bold text-slate-400 mb-1">Transport</legend>
+                <div className="flex gap-4" role="radiogroup" aria-label="Transport">
+                  {(['stdio', 'http'] as const).map((t) => (
+                    <label key={t} className="flex items-center gap-1.5 text-sm text-slate-300">
+                      <input
+                        type="radio"
+                        name="mcp-transport"
+                        checked={form.transport === t}
+                        onChange={() => setForm((f) => ({ ...f, transport: t }))}
+                        className="accent-blue-600"
+                      />
+                      {t === 'stdio' ? 'Stdio (local command)' : 'HTTP'}
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+
+              {form.transport === 'stdio' ? (
+                <>
+                  <div>
+                    <label htmlFor="mcp-command" className="block text-xs font-bold text-slate-400 mb-1">Command</label>
+                    <input
+                      id="mcp-command"
+                      type="text"
+                      value={form.command}
+                      onChange={(e) => setForm((f) => ({ ...f, command: e.target.value }))}
+                      placeholder="npx"
+                      className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="mcp-args" className="block text-xs font-bold text-slate-400 mb-1">
+                      Args <span className="font-normal text-slate-500">(one per line)</span>
+                    </label>
+                    <textarea
+                      id="mcp-args"
+                      value={argsText}
+                      onChange={(e) => setArgsText(e.target.value)}
+                      rows={3}
+                      placeholder={'-y\n@modelcontextprotocol/server-filesystem'}
+                      className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:ring-2 focus:ring-blue-500/50 resize-y"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="mcp-env" className="block text-xs font-bold text-slate-400 mb-1">
+                      Environment <span className="font-normal text-slate-500">(KEY=value per line — use ${'{VAR_NAME}'} for secrets, never a literal)</span>
+                    </label>
+                    <textarea
+                      id="mcp-env"
+                      value={envText}
+                      onChange={(e) => setEnvText(e.target.value)}
+                      rows={3}
+                      placeholder={'BRAVE_API_KEY=${BRAVE_API_KEY}'}
+                      className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:ring-2 focus:ring-blue-500/50 resize-y"
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div>
+                    <label htmlFor="mcp-url" className="block text-xs font-bold text-slate-400 mb-1">URL</label>
+                    <input
+                      id="mcp-url"
+                      type="text"
+                      value={form.url}
+                      onChange={(e) => setForm((f) => ({ ...f, url: e.target.value }))}
+                      placeholder="https://mcp.example.com/mcp"
+                      className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="mcp-headers" className="block text-xs font-bold text-slate-400 mb-1">
+                      Headers <span className="font-normal text-slate-500">(KEY=value per line — use ${'{VAR_NAME}'} for secrets, never a literal)</span>
+                    </label>
+                    <textarea
+                      id="mcp-headers"
+                      value={envText}
+                      onChange={(e) => setEnvText(e.target.value)}
+                      rows={3}
+                      placeholder={'X-Api-Key=${REMOTE_TOOLS_API_KEY}'}
+                      className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 font-mono focus:outline-none focus:ring-2 focus:ring-blue-500/50 resize-y"
+                    />
+                  </div>
+                </>
+              )}
+
+              <div>
+                <label htmlFor="mcp-timeout" className="block text-xs font-bold text-slate-400 mb-1">Timeout (seconds)</label>
+                <input
+                  id="mcp-timeout"
+                  type="number"
+                  min={1}
+                  value={form.timeout_secs}
+                  onChange={(e) => setForm((f) => ({ ...f, timeout_secs: Math.max(1, Number(e.target.value) || 1) }))}
+                  className="w-32 bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                />
+              </div>
+
+              <div className="flex items-center gap-4">
+                <label className="flex items-center gap-2 text-sm text-slate-300">
+                  <input
+                    type="checkbox"
+                    checked={form.enabled}
+                    onChange={(e) => setForm((f) => ({ ...f, enabled: e.target.checked }))}
+                    className="accent-blue-600"
+                  />
+                  Enabled
+                </label>
+                <label className="flex items-center gap-2 text-sm text-slate-300">
+                  <input
+                    type="checkbox"
+                    checked={form.requires_confirmation}
+                    onChange={(e) => setForm((f) => ({ ...f, requires_confirmation: e.target.checked }))}
+                    className="accent-blue-600"
+                  />
+                  Require confirmation before tool calls
+                </label>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 p-4 border-t border-slate-800">
+              <button
+                onClick={closeEditor}
+                className="px-4 py-2 bg-slate-800 text-white rounded-lg font-medium hover:bg-slate-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+              >
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/ghostlink_gui_modern/src/components/MetricsTab.tsx
+++ b/ghostlink_gui_modern/src/components/MetricsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { RefreshCw, Activity, Cpu, Database, Zap, Clock, ShieldCheck, Server, TrendingUp, HeartPulse, Thermometer, Download, Network } from 'lucide-react';
 import { MetricsHistoryPoint } from '../api';
 import {
@@ -134,6 +134,29 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
     ? `${(metrics?.gpu ?? 0).toFixed(0)}% utilized`
     : 'probe unavailable';
 
+  // Metrics poll every 3s — announcing every tick would drown out a screen
+  // reader, so this only speaks up on meaningful state transitions (API
+  // connectivity, GPU probe availability), not every changing number.
+  const [liveAnnouncement, setLiveAnnouncement] = useState('');
+  const prevConnectedRef = useRef<boolean | null>(null);
+  const prevGpuAvailableRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    const connected = !!metrics;
+    const gpuAvailable = !!metrics?.gpu_available;
+    const messages: string[] = [];
+    if (prevConnectedRef.current !== null && prevConnectedRef.current !== connected) {
+      messages.push(connected ? 'API server connected.' : 'API server offline.');
+    }
+    if (connected && prevGpuAvailableRef.current !== null && prevGpuAvailableRef.current !== gpuAvailable) {
+      messages.push(gpuAvailable ? 'GPU probe now available.' : 'GPU probe unavailable.');
+    }
+    if (messages.length > 0) {
+      setLiveAnnouncement(messages.join(' '));
+    }
+    prevConnectedRef.current = connected;
+    prevGpuAvailableRef.current = gpuAvailable;
+  }, [metrics]);
+
   const throughputSparkline = useMemo(() => buildSparkline(history, 'throughput', 220, 56), [history]);
   const latencySparkline = useMemo(() => buildSparkline(history, 'latency_p95', 220, 56), [history]);
   const historySummary = history.length > 0
@@ -152,6 +175,7 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
 
   return (
     <div className="flex flex-col h-full bg-slate-950">
+      <div className="sr-only" role="status" aria-live="polite">{liveAnnouncement}</div>
       <div className="flex items-center justify-between px-6 py-4 border-b border-slate-900 sticky top-0 bg-slate-950/50 backdrop-blur-md z-10">
         <div>
           <h2 className="text-xl font-bold text-white">System Performance</h2>
@@ -182,7 +206,7 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-6" tabIndex={0} role="region" aria-label="System performance">
         <div className="max-w-5xl mx-auto space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <StatCard

--- a/ghostlink_gui_modern/src/components/ModelsTab.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.tsx
@@ -85,6 +85,13 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const canManageRemoteCatalog = currentEngine === 'ollama';
   const canShowModelDefinition = currentEngine === 'ollama';
   const canDownloadLocalModels = currentEngine !== 'vllm';
+  // Deleting a model removes a local file (or an Ollama-managed one) — the
+  // backend's DELETE /api/models/:name already handles both cases. Only
+  // vLLM's inventory is genuinely server-managed and un-deletable from here;
+  // gating this the same as canManageRemoteCatalog (Ollama-only) hid the
+  // delete button entirely for native/llama.cpp GGUF models even though
+  // deleting those local files works fine.
+  const canDeleteModel = currentEngine !== 'vllm';
   const [partialDownloads, setPartialDownloads] = useState<{ filename: string; size_bytes: number; age_secs: number }[]>([]);
   const [discardingPartial, setDiscardingPartial] = useState<string | null>(null);
 
@@ -281,11 +288,14 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   };
 
   const handleDeleteModel = async (name: string) => {
-    if (!canManageRemoteCatalog) {
+    if (!canDeleteModel) {
       setMessage(`${engineLabel} models are server-managed and cannot be deleted from this UI.`);
       return;
     }
-    if (!window.confirm(`Are you sure you want to delete the model "${name}" from Ollama? This cannot be undone.`)) {
+    const confirmMessage = canManageRemoteCatalog
+      ? `Are you sure you want to delete the model "${name}" from Ollama? This cannot be undone.`
+      : `Are you sure you want to delete "${name}"? This removes the local model file and cannot be undone.`;
+    if (!window.confirm(confirmMessage)) {
       return;
     }
     setPendingActions(prev => ({ ...prev, [name]: 'deleting' }));
@@ -497,8 +507,10 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
       <div className="flex items-center justify-between px-6 py-4 border-b border-slate-900 sticky top-0 bg-slate-950/50 backdrop-blur-md z-10">
         <div className="flex items-center gap-4" role="tablist" aria-label="Model source">
           <button
+            id="models-tab-local"
             role="tab"
             aria-selected={activeTab === 'local'}
+            aria-controls="models-tabpanel"
             onClick={() => setActiveTab('local')}
             className={`px-3 py-1.5 rounded-lg text-sm font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
               activeTab === 'local' ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/20' : 'text-slate-400 hover:bg-slate-900'
@@ -507,8 +519,10 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             My Models
           </button>
           <button
+            id="models-tab-recommended"
             role="tab"
             aria-selected={activeTab === 'recommended'}
+            aria-controls="models-tabpanel"
             onClick={() => setActiveTab('recommended')}
             className={`px-3 py-1.5 rounded-lg text-sm font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
               activeTab === 'recommended' ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/20' : 'text-slate-400 hover:bg-slate-900'
@@ -517,8 +531,10 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
             Recommended
           </button>
           <button
+            id="models-tab-huggingface"
             role="tab"
             aria-selected={activeTab === 'huggingface'}
+            aria-controls="models-tabpanel"
             onClick={() => setActiveTab('huggingface')}
             className={`px-3 py-1.5 rounded-lg text-sm font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
               activeTab === 'huggingface' ? 'bg-blue-600 text-white shadow-lg shadow-blue-500/20' : 'text-slate-400 hover:bg-slate-900'
@@ -551,7 +567,15 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
           </button>
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto p-6">
+      <div
+        id="models-tabpanel"
+        role="tabpanel"
+        aria-labelledby={
+          activeTab === 'local' ? 'models-tab-local' : activeTab === 'recommended' ? 'models-tab-recommended' : 'models-tab-huggingface'
+        }
+        tabIndex={0}
+        className="flex-1 overflow-y-auto p-6"
+      >
         {activeTab === 'local' ? (
           <div className="space-y-4">
             <div className="flex items-center justify-between px-4 py-3 bg-slate-800 rounded-lg">
@@ -662,13 +686,13 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                             <Copy size={16} aria-hidden="true" />
                           </button>
                         )}
-                        {canManageRemoteCatalog && (
+                        {canDeleteModel && (
                           <button
                             onClick={() => handleDeleteModel(model.name)}
                             disabled={pendingActions[model.name] === 'deleting' || loading}
                             className="p-1 hover:bg-slate-700 rounded-lg transition text-slate-400 hover:text-red-400 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
-                            title="Delete from Ollama"
-                            aria-label={`Delete ${model.name} from Ollama`}
+                            title={canManageRemoteCatalog ? 'Delete from Ollama' : 'Delete model file'}
+                            aria-label={canManageRemoteCatalog ? `Delete ${model.name} from Ollama` : `Delete model file ${model.name}`}
                           >
                             {pendingActions[model.name] === 'deleting' ? (
                               <Loader size={16} className="mr-1" aria-hidden="true" />
@@ -857,8 +881,12 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                   </div>
                   <div className="flex items-center gap-4 shrink-0">
                     <div className="text-xs text-slate-400">
-                      <span className="mr-3">📥 {(m.downloads / 1000).toFixed(0)}K</span>
-                      <span>👍 {(m.likes / 1000).toFixed(1)}K</span>
+                      <span className="mr-3">
+                        <span aria-hidden="true">📥</span> <span className="sr-only">Downloads: </span>{(m.downloads / 1000).toFixed(0)}K
+                      </span>
+                      <span>
+                        <span aria-hidden="true">👍</span> <span className="sr-only">Likes: </span>{(m.likes / 1000).toFixed(1)}K
+                      </span>
                     </div>
                     <button
                       onClick={() => handleDownloadHFModel(m.id)}
@@ -886,7 +914,9 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
 
       {/* Modelfile Modal */}
       {showModelfile && (
+        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- click-outside-to-dismiss backdrop; Escape (handled above) and the close button already cover keyboard/AT users
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowModelfile(null)}>
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- onClick here only stops the backdrop's close-on-click from firing when clicking inside the dialog, it's not a control */}
           <div
             role="dialog"
             aria-modal="true"

--- a/ghostlink_gui_modern/src/components/SecurityTab.tsx
+++ b/ghostlink_gui_modern/src/components/SecurityTab.tsx
@@ -83,7 +83,7 @@ export const SecurityTab: React.FC<{ api: any }> = ({ api }) => {
         <h2 className="text-xl font-bold text-white">Security & Access</h2>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-6" tabIndex={0} role="region" aria-label="Security">
         <div className="max-w-5xl mx-auto space-y-6">
           {/* API Key Section */}
           <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6 space-y-4">

--- a/ghostlink_gui_modern/src/components/SessionsTab.tsx
+++ b/ghostlink_gui_modern/src/components/SessionsTab.tsx
@@ -43,7 +43,7 @@ export const SessionsTab: React.FC<{ api: any }> = ({ api }) => {
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-6" tabIndex={0} role="region" aria-label="Sessions">
         <div className="max-w-5xl mx-auto">
           {error ? (
             <ErrorPanel icon={XCircle} title="Connection Error" message={error} />

--- a/ghostlink_gui_modern/src/components/SettingsTab.tsx
+++ b/ghostlink_gui_modern/src/components/SettingsTab.tsx
@@ -309,7 +309,7 @@ export const SettingsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-6" tabIndex={0} role="region" aria-label="Settings">
         <div className="max-w-5xl mx-auto space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <Section title="Compute Backend" icon={Gauge}>

--- a/ghostlink_gui_modern/src/components/WorkersTab.tsx
+++ b/ghostlink_gui_modern/src/components/WorkersTab.tsx
@@ -173,6 +173,7 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
       </div>
 
       {showAddForm && (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- wrapper only delegates Escape from the real interactive inputs/buttons inside, not a control itself
         <div
           className="px-6 py-4 border-b border-slate-800 bg-slate-900/30"
           onKeyDown={(e) => { if (e.key === 'Escape') setShowAddForm(false); }}
@@ -213,7 +214,7 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
         </div>
       )}
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-6" tabIndex={0} role="region" aria-label="Workers">
         <div className="max-w-5xl mx-auto">
             {topology && (
               <div className="mb-6 bg-slate-900/50 border border-slate-800 rounded-3xl p-6 overflow-hidden">

--- a/ghostlink_gui_modern/src/hooks/useApiRetry.ts
+++ b/ghostlink_gui_modern/src/hooks/useApiRetry.ts
@@ -97,6 +97,7 @@ export function useApiRetry<T extends (...args: any[]) => Promise<any>>(
           await new Promise(resolve => setTimeout(resolve, delay));
           
           if (!isMountedRef.current) {
+            // eslint-disable-next-line preserve-caught-error -- this isn't re-wrapping `error`, it's a distinct unmount condition
             throw new Error('Component unmounted during retry');
           }
           

--- a/ghostlink_gui_modern/src/index.css
+++ b/ghostlink_gui_modern/src/index.css
@@ -113,3 +113,17 @@ body {
 .hljs-strong {
   font-weight: 700;
 }
+
+/* Respect the OS-level "reduce motion" preference: neutralize every
+   CSS animation/transition (spin/pulse/bounce/ping, fade-in, hover
+   transitions, etc.) instead of hunting down each Tailwind utility. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/ghostlink_gui_modern/src/store.ts
+++ b/ghostlink_gui_modern/src/store.ts
@@ -105,6 +105,10 @@ export interface WorkspaceEntry {
   size: number;
 }
 
+export type McpTransport =
+  | { transport: 'stdio'; command: string; args: string[]; env: Record<string, string> }
+  | { transport: 'http'; url: string; headers: Record<string, string> };
+
 export interface McpServer {
   name: string;
   slot: string;
@@ -112,6 +116,25 @@ export interface McpServer {
   connected: boolean;
   tool_count: number;
   requires_confirmation: boolean;
+  transport: McpTransport;
+  timeout_secs: number;
+}
+
+// Payload shape for create/update — mirrors the backend's internally-tagged
+// McpServerConfig JSON (transport as a literal "stdio"/"http" discriminator
+// with that transport's fields flattened alongside the rest).
+export interface McpServerInput {
+  name: string;
+  slot: string;
+  enabled: boolean;
+  requires_confirmation: boolean;
+  timeout_secs: number;
+  transport: 'stdio' | 'http';
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
 }
 
 export interface ToolCallTrace {

--- a/launch-native.ps1
+++ b/launch-native.ps1
@@ -270,28 +270,37 @@ if ($InferenceBackend -eq "native") {
 $logicalCores = [Environment]::ProcessorCount
 $env:GHOSTLINK_LLAMA_THREADS = [Math]::Max(1, $logicalCores - 1)
 
-# GHOSTLINK_VRAM_GB was never set on this launch path, so native_engine.rs's
-# perf-tier tables (crates/ghost-link/src/native_engine.rs:default_perf_args)
-# always fell back to their worst-case "<4GB" bucket regardless of the real
-# hardware -- -b 512 -ub 128, the smallest prompt micro-batch in the table,
-# directly tanking prefill throughput / time-to-first-token. /api/metrics
-# already detects this machine's AMD Radeon 860M at ~4GB via
-# ghostlink-core::system_profile, so wire that same figure in here to move
-# batch/ubatch/ctx tiering up to their ">=4GB" values instead. GHOSTLINK_LLAMA_NGL
-# is pinned to -1 (offload every layer llama-server can fit, its own default)
-# so this doesn't also feed the separate VRAM->ngl cap table in get_ngl(),
-# which would otherwise cap offload at a fixed 12 layers -- a regression from
-# the full-offload that's already working today.
-$env:GHOSTLINK_VRAM_GB = "4"
+# GHOSTLINK_GPU_NAME / GHOSTLINK_VRAM_GB / GHOSTLINK_COMPUTE_CAPABILITY feed
+# ghostlink-core::system_profile::detect_gpu_from_env(), which takes absolute
+# priority over the platform GPU probes (crates/ghostlink-core/src/system_profile.rs)
+# -- and those probes are the wrong tool for this machine's iGPU. The Windows
+# WMI path reads Win32_VideoController.AdapterRAM, a 32-bit field that's
+# unreliable for integrated GPUs (frequently 0 or a tiny fixed carve-out); the
+# DXGI fallback only reads DedicatedVideoMemory, never SharedSystemMemory, so
+# it has the same blind spot for a unified-memory iGPU like the 860M. Without
+# an override, this machine was landing on native_engine.rs's worst-case
+# "<4GB" perf-tier bucket regardless of the real hardware.
+#
+# 8 was picked empirically, not from a detected number: benchmarked on this
+# machine at 4GB vs 8GB with the same model, and 8GB's larger prompt
+# micro-batch (-b 1024 -ub 512 vs -b 512 -ub 256) measured ~2.3x the
+# throughput (31.3 -> 71.8 tok/s). GHOSTLINK_LLAMA_NGL is pinned to -1
+# (offload every layer llama-server can fit, its own default) so raising
+# GHOSTLINK_VRAM_GB doesn't also feed the separate VRAM->ngl cap table in
+# get_ngl(), which would otherwise cap offload at a fixed layer count -- a
+# regression from the full-offload that's already working today.
+$env:GHOSTLINK_GPU_NAME = "AMD Radeon 860M Graphics"
+$env:GHOSTLINK_VRAM_GB = "8"
+$env:GHOSTLINK_COMPUTE_CAPABILITY = "gpu"
 $env:GHOSTLINK_LLAMA_NGL = "-1"
 
-# GHOSTLINK_VRAM_GB=4 above also drives native_engine.rs's get_ctx_size() VRAM
-# tier table, which caps context at its smallest bucket (4096) -- that's sized
-# off the 860M's fixed VRAM carve-out, not the ~29GB of system RAM this iGPU
-# actually shares (q8_0 KV + Flash Attention are already on by default, so the
-# real per-token KV cost is small). GHOSTLINK_CTX_SIZE takes priority over the
-# VRAM tiering in get_ctx_size(), so set it explicitly here -- but only if the
-# caller hasn't already exported one, so manual overrides still win.
+# GHOSTLINK_VRAM_GB=8 above also drives native_engine.rs's get_ctx_size() VRAM
+# tier table, which would cap context at its ">=8GB" bucket (8192) -- lower
+# than we actually want (q8_0 KV + Flash Attention are already on by default,
+# so the real per-token KV cost is small and 16384 comfortably fits). Set it
+# explicitly here so GHOSTLINK_CTX_SIZE (which takes priority over the VRAM
+# tiering in get_ctx_size()) wins instead -- but only if the caller hasn't
+# already exported one, so manual overrides still win.
 if (-not $env:GHOSTLINK_CTX_SIZE) {
     $env:GHOSTLINK_CTX_SIZE = "16384"
 }


### PR DESCRIPTION
## Summary

Four related pieces of work from one session of auditing and hardening the GUI, bundled per CONTRIBUTING.md's "cross-cutting changes... include a short risk section" allowance rather than split into a stack (see **Scope** below for why).

- **Accessibility pass** across every GUI tab: live-region announcements for streaming chat / Metrics changes, skip link + landmarks, restored focus rings on Command Palette + chat composer, `prefers-reduced-motion`, keyboard-scrollable tab bodies, and a new `eslint-plugin-jsx-a11y` + axe-core Playwright suite (`e2e/accessibility.spec.ts`) as a standing regression gate.
- **MCP server editor**: add/edit/delete MCP servers from the GUI (stdio or HTTP transport), live connect/disconnect, no restart needed. Also fixes the enable/disable toggle, which was calling a backend route that never existed.
- **Chat file attachments**: paperclip + drag-and-drop for text-based files (code/markdown/JSON/CSV/logs/config), inlined as fenced code blocks. Images/binaries are explicitly rejected rather than silently doing nothing — there's no multimodal endpoint to send them to.
- **Two real bugs found and fixed** while live-testing the above: the Models tab was listing the same model twice (a download-completion handler pushed a duplicate record instead of replacing one with the same name), and the Delete button was hidden for native/llama.cpp models even though the backend already supported deleting them.
- **iGPU performance tuning** (`launch-native.ps1`): WMI/DXGI VRAM detection undercounts a unified-memory iGPU (neither reads `SharedSystemMemory`), which was capping the native launch path at the worst-case perf tier regardless of real hardware. Pinned `GHOSTLINK_GPU_NAME`/`GHOSTLINK_VRAM_GB`/`GHOSTLINK_COMPUTE_CAPABILITY` explicitly — measured **~2.3x throughput** (31.3 → 71.8 tok/s) on the reference machine (AMD Radeon 860M).
- **Chat markdown readability**: assistant replies were rendering through typography defaults tuned for a full-width article, not a narrow chat bubble — oversized headings, tables that could blow out bubble width, cramped 12px code blocks.

Full details, including the exact root causes and before/after numbers, are in the CHANGELOG entry this PR adds.

## Scope

This spans GUI (TS/React) and backend (Rust) code, which CONTRIBUTING.md's scope guidance prefers to avoid. It's bundled here because the MCP editor and model-delete fixes are genuinely one feature each split across frontend/backend (a route with no UI is not shippable, and vice versa), and the accessibility pass touches nearly every GUI file by nature — splitting further would mean PRs that don't build/function on their own. The perf-tuning and chat-readability changes *are* independently revertable (see below) if reviewers want them out.

## Risk / rollback

- **Lowest risk**: chat readability (`ChatTab.tsx` styling only), accessibility pass (additive ARIA/landmarks/live-regions, no behavior removed) — revert by reverting the relevant commit.
- **Medium risk**: MCP CRUD (new backend routes + `McpConfigManager`/`McpRegistry` methods) — additive, doesn't change existing `GET /api/mcp/servers` or connect-on-startup behavior. Revert = revert the commit; no data migration involved (`mcp_servers.toml` format unchanged).
- **Host-specific caveat**: the `launch-native.ps1` VRAM values (`GHOSTLINK_VRAM_GB=8`, `GHOSTLINK_GPU_NAME="AMD Radeon 860M Graphics"`) were empirically tuned on one reference machine, not detected. A machine with a different (or no) iGPU inherits these as defaults, which could be wrong for that hardware — `GHOSTLINK_VRAM_GB`/`GHOSTLINK_GPU_NAME`/`GHOSTLINK_COMPUTE_CAPABILITY` env vars still override if already exported by the caller. Worth a maintainer call on whether this script should stay machine-specific or grow a real per-host detection path.
- **Known gap, not addressed**: axe found pervasive `color-contrast` failures (muted `slate-500/600`-on-dark text, dozens of instances across every tab) — deliberately excluded from the new test suite rather than fixed, since it's a design-system change, not a mechanical one. Commented in `e2e/accessibility.spec.ts` explaining why.

## Validation

```
cargo fmt --all --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings       # clean
cargo test --workspace                                      # 421 passed, 0 failed
cargo audit                                                  # 3 pre-existing advisories (paste/anyhow/lru), unrelated, no new findings
```

```
cd ghostlink_gui_modern
npm run type-check      # clean
npm run lint            # clean (0 errors; pre-existing warnings unrelated to this change)
npm test                # 142/142 passed
npx playwright test e2e/accessibility.spec.ts   # 11/11 passed
```

All of the above additionally verified live against a real running stack (Rust `ghost-link serve` + Go control-plane + Vite dev server) — real chat completions with real streamed tokens and measured throughput, real MCP add/edit/delete/toggle round-trips, real model-list deduplication against the actual `models.json` on disk, not just green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)