### PR TITLE
Fix: launch.sh's independently-duplicated ngl tiering had a real regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,15 @@ flag was omitted entirely in that case, and llama-server's own default
 GPU offload and no warning on any launch path that didn't set
 `GHOSTLINK_VRAM_GB`/`GHOSTLINK_LLAMA_NGL` itself.
 
+That auto-detect default is itself capped to CPU-only for large (≥10GB)
+models on an integrated GPU, regardless of VRAM tier — measured directly,
+full offload on this class of hardware duplicates weights into RAM rather
+than freeing it the way a discrete GPU would, and can leave a host with
+under 1GB free while a large model is loaded. `GHOSTLINK_LLAMA_NGL` always
+overrides this either way. See
+[docs/LOCAL_INFERENCE_TUNING.md](docs/LOCAL_INFERENCE_TUNING.md) for the
+measured numbers and the reasoning.
+
 Compiling with `RUSTFLAGS="-C target-cpu=native"` further improves performance by enabling CPU-specific instruction sets (opt-in; not set by default — a multi-node cluster can't assume every node shares one CPU microarchitecture).
 
 ### Build profile

--- a/docs/LOCAL_INFERENCE_TUNING.md
+++ b/docs/LOCAL_INFERENCE_TUNING.md
@@ -10,7 +10,7 @@ native engine (`native_engine.rs`) now enable:
 
 | Knob | Flag | Default (VRAM-scaled) |
 |------|------|------------------------|
-| Context size | `-c` | **8192** on 8GB, up to 32768 on 16GB+ (never model default 128k) — see `GHOSTLINK_CTX_SIZE`/`GHOSTLINK_VRAM_GB` in `native_engine::get_ctx_size` |
+| Context size | `-c` | **8192** on 8GB, up to 32768 on 16GB+ (never model default 128k); further capped down for large (≥10GB) models regardless of VRAM tier — see [GPU offload and large models](#gpu-offload-and-large-models--read-this-before-setting--ngl--1-on-an-igpu) below, and `GHOSTLINK_CTX_SIZE`/`GHOSTLINK_VRAM_GB` in `native_engine::get_ctx_size` |
 | KV cache type | `-ctk/-ctv q8_0` | compact KV (~2× less cache memory) |
 | Flash Attention | `-fa on` | always on (requires value on current llama.cpp) |
 | Batch size | `-b` | 2048 (≥12GB) / 1024 (≥8GB) / 512 (else) |
@@ -24,6 +24,43 @@ export GHOSTLINK_LLAMA_SERVER_ARGS="-fa on -b 2048 -ub 512"
 export GHOSTLINK_VRAM_GB=12
 export GHOSTLINK_LLAMA_NGL=40
 ```
+
+## GPU offload and large models — read this before setting `-ngl -1` on an iGPU
+
+`native_engine::get_ngl` (Rust) and `launch.sh`'s own shell tiering both cap
+**large models (≥10GB) toward CPU-only (`ngl=0`) by default** when
+`GHOSTLINK_LLAMA_NGL` isn't set — this is deliberate, not an oversight, and
+`GHOSTLINK_LLAMA_NGL` still wins outright as an explicit override either way.
+
+Why: on an integrated GPU (Vulkan backend — AMD/Intel iGPUs on Windows and
+Linux), "VRAM" is the same physical RAM as everything else. Unlike a
+discrete GPU, where offloading a layer *moves* its weights out of system RAM
+into separate VRAM, llama.cpp's Vulkan backend on this class of hardware
+**duplicates** offloaded weights into a separate device-local allocation
+instead. Measured directly (AMD Radeon 860M, 27.6GB host, 13.6GB model,
+controlled comparison — same prompt/seed, same direct llama-server timings,
+`ngl` 0 vs 24 vs -1):
+
+| `ngl` | decode speed | committed memory | free system RAM while loaded |
+|---|---|---|---|
+| `0` (CPU-only) | 8.78 tok/s | 0.54GB | ~18GB |
+| `24` (partial offload) | 8.03 tok/s | 7.35GB | ~11GB — **not a viable middle ground**, same or worse speed than 0 for 13x the memory |
+| `-1` (full offload) | 16.84 tok/s | 14.15GB | ~0.4GB — reproduced twice |
+
+Full offload really is ~1.9x faster, but leaves well under 1GB free for
+everything else on the host while a model that size is loaded — real,
+reproducible, not a hypothetical. CUDA (real discrete NVIDIA VRAM) and ROCm
+don't have this problem, so the automatic large-model cap only applies to
+the Vulkan backend; it doesn't second-guess a CUDA/ROCm setup. Apple Metal's
+behavior here is unverified (not tested on this hardware) and is
+deliberately *not* capped by this logic — Metal's buffer model may not have
+the same duplication behavior, and claiming otherwise without measuring it
+would just be a guess.
+
+If you want full offload on an iGPU anyway (e.g. you've measured your own
+tradeoff and it's worth it, like `launch-native.ps1`'s reference machine
+does), set `GHOSTLINK_LLAMA_NGL=-1` yourself — that's a permanent, explicit
+opt-in, not something to leave to chance on a host you haven't measured.
 
 Docker Compose uses:
 

--- a/launch.sh
+++ b/launch.sh
@@ -938,9 +938,20 @@ start_services() {
     elif [ "$VRAM_GB" -ge 8 ] 2>/dev/null; then
         LLAMA_NGL=24
     elif [ "$VRAM_GB" -ge 4 ] 2>/dev/null; then
-        LLAMA_NGL=99
+        LLAMA_NGL=12
     else
-        LLAMA_NGL=99
+        # VRAM_GB is 0/unknown here for any non-NVIDIA GPU (the rocm-smi and
+        # lspci detection branches below never populate it, and Apple Metal
+        # doesn't either) -- this used to fall through to `99`,
+        # llama.cpp's "offload every layer" sentinel, which blindly tries to
+        # offload everything with zero idea whether there's VRAM to fit it
+        # in. Degrade to CPU-only instead, matching
+        # NativeEngineClient::get_ngl()'s own equivalent tier in
+        # crates/ghost-link/src/native_engine.rs (Rust and this shell
+        # tiering are independent, hand-duplicated implementations -- this
+        # regression was already fixed on the Rust side but never carried
+        # over here).
+        LLAMA_NGL=0
     fi
 
     if [ "$BACKEND" = "rocm" ]; then
@@ -1052,12 +1063,42 @@ start_services() {
         fi
         MODEL_ALIAS=$(basename "$MODEL_FILE" .gguf)
 
+        # Model file size in GB, used below to cap ngl/ctx down for large
+        # models on an integrated GPU regardless of the VRAM tier -- `stat`'s
+        # flag differs between GNU (Linux) and BSD (macOS) coreutils, hence
+        # trying both.
+        MODEL_SIZE_GB=0
+        MODEL_SIZE_BYTES=$(stat -c%s "$MODEL_FILE" 2>/dev/null || stat -f%z "$MODEL_FILE" 2>/dev/null || echo 0)
+        if [ "${MODEL_SIZE_BYTES:-0}" -gt 0 ] 2>/dev/null; then
+            MODEL_SIZE_GB=$(( MODEL_SIZE_BYTES / 1073741824 ))
+        fi
+
+        # A large model on the Vulkan backend (lspci-detected AMD/Intel iGPU,
+        # unified host/device memory) doesn't get a real memory win from
+        # offload the way a discrete GPU does: llama.cpp's Vulkan backend
+        # duplicates offloaded weights into a separate device-local
+        # allocation instead of moving them out of host RAM. Verified
+        # directly on a Windows AMD Radeon 860M (same Vulkan backend, same
+        # duplication mechanism): loading a 13.6GB model left a 27.6GB host
+        # under 1GB free at ngl=-1, vs ~18GB free at ngl=0, for well under 2x
+        # the speed. CUDA (real discrete NVIDIA VRAM) and ROCm don't have
+        # this problem, so the cap is scoped to Vulkan only -- and an
+        # explicit GHOSTLINK_LLAMA_NGL still wins outright either way.
+        if [ "$BACKEND" = "vulkan" ] && [ -z "${GHOSTLINK_LLAMA_NGL:-}" ] \
+            && [ "${MODEL_SIZE_GB:-0}" -ge 10 ] 2>/dev/null; then
+            LLAMA_NGL=0
+        fi
+
         progress_bar 3 3
         echo " ${GREEN}Native stack ready${NC}            "
         echo ""
         # Context size: never leave model default (often 128k) on consumer GPUs.
         if [ -n "${GHOSTLINK_CTX_SIZE:-}" ]; then
             CTX_SIZE=$GHOSTLINK_CTX_SIZE
+        elif [ "$BACKEND" = "vulkan" ] && [ "${MODEL_SIZE_GB:-0}" -ge 10 ] 2>/dev/null; then
+            CTX_SIZE=4096
+        elif [ "$BACKEND" = "vulkan" ] && [ "${MODEL_SIZE_GB:-0}" -ge 5 ] 2>/dev/null; then
+            CTX_SIZE=8192
         elif [ "${VRAM_GB:-0}" -ge 16 ] 2>/dev/null; then
             CTX_SIZE=16384
         elif [ "${VRAM_GB:-0}" -ge 12 ] 2>/dev/null; then


### PR DESCRIPTION
## Summary

Follow-up to #262/#263 (both merged before this was found). Those fixed `native_engine.rs`'s `get_ngl()`/`get_ctx_size()` and the Windows `launch-native.ps1` path, but never touched `launch.sh` — turns out it doesn't delegate to that Rust logic at all. It spawns `llama-server` directly with its own **independently hand-duplicated** shell tiering, which has drifted out of sync with the Rust side over time.

## What was found

1. **Real, active regression**: `launch.sh`'s ngl tiering defaulted to `LLAMA_NGL=99` (llama.cpp's "offload every layer" sentinel) for the `<8GB` and unknown-VRAM cases. This is *exactly* the bug `NativeEngineClient::get_ngl()`'s own test (`get_ngl_tiers_taper_down_with_less_vram`) guards against on the Rust side — its comment literally says *"the <8GB tier previously returned 99 ... which would OOM low-VRAM cards"* — just never carried over to this script.

   This matters more than it might look: `VRAM_GB` is **never populated** for any non-NVIDIA GPU on this path — the `rocm-smi`, `lspci` (AMD/Intel iGPU detection), and Apple Metal branches in `detect_gpu()` don't set it, only the `nvidia-smi` branch does. So any non-NVIDIA Linux/Mac user was silently hitting `ngl=99` by default.

2. **Missing the model-size-aware capping** added to `get_ngl()`/`get_ctx_size()` in #263: `launch.sh` already resolves the model file before spawning `llama-server` (it needs the path either way), so it can apply the same cap. Large (≥10GB) models now default to `ngl=0`/`ctx=4096` on the Vulkan backend (the `lspci`-detected AMD/Intel iGPU path) — scoped there specifically, since CUDA and ROCm have real separate VRAM and don't have the duplication problem this cap exists for (see #263 for the measured numbers). `GHOSTLINK_LLAMA_NGL`/`GHOSTLINK_CTX_SIZE` still win outright as explicit overrides.

## Also updated

- `docs/LOCAL_INFERENCE_TUNING.md`: new section with the measured comparison table and reasoning (previously didn't mention the large-model capping at all).
- `README.md`'s local-tuning section: brief pointer to the same.

## Scope check — other launch paths

Audited the rest of the launch surface for the same "never got the fix" gap:
- `launch.bat` / `launch-ollama.bat` — thin dispatchers to `launch-native.ps1`/`launch.sh`, no duplicated logic, nothing to fix.
- `launch-complete.sh` — `exec`s `launch.sh` directly, inherits this fix automatically.
- `scripts/run_native_llama_server_stack.sh` — CI/test helper defaulting to the tiny `stories15M` model only, not exposed to the large-model risk.
- `docker-compose.rpc-fabric*.yml` — already deliberately pins `ngl=0` for the CI gate, documented as intentional, unrelated.
- `docs/BENCHMARKS.md` — a dated historical record of specific runs, not living guidance; left alone rather than rewriting historical entries.

## Validation

```
bash -n launch.sh   # syntax OK
```

No Linux/Mac iGPU hardware available in this environment to run it live — verified by inspection against the same regression test's documented expectations on the Rust side (`get_ngl_tiers_taper_down_with_less_vram` in `native_engine.rs`), and the new logic mirrors that already-tested Rust code path structurally (same threshold, same override precedence).

## Risk

Shell script + docs only, no Rust/GUI changes. The regression fix (99 → tiered/0) is strictly safer than before for every VRAM tier. The new model-size cap only activates for the Vulkan backend specifically, so CUDA/ROCm users' behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)