### PR TITLE
⚡ Bolt: RwLock-based parallel index for local RAG

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
+## 2026-08-10 - [RwLock-based Parallel Index for Local RAG]
+**Learning:** Using `tokio::sync::Mutex` to synchronize access to an in-process RAG index causes unnecessary serialization of concurrent read/search queries. Since the read paths do not yield (have no `.await` boundaries), they do not need to hold locks across async points. Replacing the async `Mutex` with a synchronous `std::sync::RwLock` enables fully concurrent, parallel search operations and eliminates the task-scheduling and allocation overhead of futures-based locking on CPU-bound paths.
+**Action:** Always use synchronous `RwLock` instead of async `Mutex` for synchronizing state that does not need to span across `.await` points, especially when read concurrency is desired.
+
 ## 2026-08-09 - [Hardware-Accelerated CRC32 for API Cache ETags]
 **Learning:** Using the default standard library `DefaultHasher` (which compiles to SipHash 1-3) to hash API response bodies for ETag generation introduces significant, unnecessary cryptographic-strength CPU overhead on cache misses/populates. Since conditional-GET ETags only require identifying if a response has changed rather than preventing hash collision/flooding attacks, replacing `DefaultHasher` with a hardware-accelerated CRC32 checksum (utilizing `crc32fast` instructions) combined with body length dramatically speeds up ETag calculation, especially on multi-megabyte payloads.
 **Action:** Prefer non-cryptographic, hardware-accelerated checksums (like CRC32 or FxHash) over SipHash for fast, non-security-critical fingerprinting/ETag tasks.

--- a/crates/mcp-rag/src/main.rs
+++ b/crates/mcp-rag/src/main.rs
@@ -12,7 +12,7 @@ use rmcp::{
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use tokio::sync::Mutex;
+use std::sync::RwLock;
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct IndexDocumentRequest {
@@ -251,7 +251,7 @@ struct Rag {
     embed_model: String,
     client: reqwest::Client,
     index_path: PathBuf,
-    index: std::sync::Arc<Mutex<RagIndex>>,
+    index: std::sync::Arc<RwLock<RagIndex>>,
 }
 
 impl Rag {
@@ -267,7 +267,7 @@ impl Rag {
                 .unwrap_or_else(|_| "nomic-embed-text".to_string()),
             client: reqwest::Client::new(),
             index_path,
-            index: std::sync::Arc::new(Mutex::new(index)),
+            index: std::sync::Arc::new(RwLock::new(index)),
         }
     }
 
@@ -344,7 +344,9 @@ impl Rag {
         }
 
         let indexed = new_entries.len();
-        let mut index = self.index.lock().await;
+        // Optimize: Use write lock on std::sync::RwLock instead of tokio::sync::Mutex to completely
+        // bypass tokio's task scheduling, futures allocation, and synchronization overhead on hot/read-heavy paths.
+        let mut index = self.index.write().unwrap();
         replace_document_entries(&mut index.entries, &doc_id, new_entries);
         if let Err(err) = index.save(&self.index_path) {
             return format!(
@@ -366,7 +368,10 @@ impl Rag {
             Ok(e) => e,
             Err(err) => return err,
         };
-        let index = self.index.lock().await;
+        // Optimize: Use read lock on std::sync::RwLock instead of tokio::sync::Mutex.
+        // This enables fully concurrent read/search queries to run in parallel without blocking each other,
+        // and eliminates the CPU and allocation overhead of futures-based tokio locking.
+        let index = self.index.read().unwrap();
         if index.entries.is_empty() {
             return "error: the retrieval index is empty — call index_document first".to_string();
         }


### PR DESCRIPTION
Migrated the RAG Index lock in the local RAG MCP server (`crates/mcp-rag/src/main.rs`) from `tokio::sync::Mutex` to `std::sync::RwLock` to enable parallel search operations and eliminate async locking overhead in CPU-bound read/write operations.

---
*PR created automatically by Jules for task [17222172797447106021](https://jules.google.com/task/17222172797447106021) started by @rwilliamspbg-ops*