### PR TITLE
🎨 Palette: Keyboard focus visual accessibility improvements and model selector download redirect

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal
 
+## 2026-08-10 - [Model Selector Download Redirection & Focus Visibility]
+**Learning:** Custom drop-down popups (like the Model Selector dropdown) that contain helpful quick-links (like "+ Download Models") are highly frustrating when they act as non-functional static links. Making them interactive by wiring them to programmatically switch tabs (`setActiveTab(1)`) greatly reduces cognitive friction. Additionally, aligning standard form inputs (like the MCP 'requires_confirmation' checkbox and popular model card buttons) with high-contrast, accessible `focus-visible:` keyboard rings guarantees keyboard and screen-reader navigators do not lose context in dark-theme interfaces.
+**Action:** Always ensure helper actions in dropdowns are functional and correctly redirect to their corresponding full interface tab, and verify all checkboxes/buttons have consistent, high-contrast focus rings.
+
 ## 2026-08-09 - [MCP Dialog Input Forms Accessibility & Micro-UX]
 **Learning:** Dialog entry forms (such as the MCP server creation and edit form) that have dense parameters benefit immensely from explicit required marks (`*`), contextual placeholders, clear tooltips via `title` attributes, and `cursor-pointer` label target enhancement for checkboxes and radio fields. Providing clear `focus-visible:` keyboard rings across all text inputs, textareas, radios, and checkboxes ensures users are never visually lost during dense forms setup.
 **Action:** Always mark mandatory form inputs explicitly, widen interactive click targets, and add detailed placeholders, informative tooltips, and high-visibility keyboard focus rings to interactive forms.

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -242,6 +242,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     chatStreamingId: streamingId, setChatStreamingId: setStreamingId,
     chatError: error, setChatError: setError,
     addToast,
+    setActiveTab,
   } = useAppStore();
   const [input, setInput] = useState('');
   const [copiedId, setCopiedId] = useState<string | null>(null);
@@ -924,7 +925,10 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                             )}
                         </div>
                         <div className="p-2 border-t border-slate-800 bg-slate-900/50">
-                            <button className="flex items-center gap-2 w-full px-3 py-2 rounded-xl text-xs font-bold text-slate-400 hover:text-white hover:bg-slate-800 transition">
+                            <button
+                                onClick={() => setActiveTab(1)}
+                                className="flex items-center gap-2 w-full px-3 py-2 rounded-xl text-xs font-bold text-slate-400 hover:text-white hover:bg-slate-800 transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+                            >
                                 <Plus size={14} aria-hidden="true" /> Download Models
                             </button>
                         </div>
@@ -1100,7 +1104,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                       <button
                         onClick={handleSaveSession}
                         disabled={!sessionName.trim() || messages.length === 0}
-                        className="flex items-center gap-2 w-full px-3 py-2 rounded-xl text-xs font-bold transition disabled:opacity-50 disabled:cursor-not-allowed bg-blue-600 text-white hover:bg-blue-500"
+                        className="flex items-center gap-2 w-full px-3 py-2 rounded-xl text-xs font-bold transition disabled:opacity-50 disabled:cursor-not-allowed bg-blue-600 text-white hover:bg-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                       >
                         <Save size={14} /> Save Current Chat
                       </button>

--- a/ghostlink_gui_modern/src/components/McpTab.tsx
+++ b/ghostlink_gui_modern/src/components/McpTab.tsx
@@ -534,7 +534,7 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                     type="checkbox"
                     checked={form.requires_confirmation}
                     onChange={(e) => setForm((f) => ({ ...f, requires_confirmation: e.target.checked }))}
-                    className="accent-blue-600"
+                    className="accent-blue-600 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   />
                   Require confirmation before tool calls
                 </label>

--- a/ghostlink_gui_modern/src/components/ModelsTab.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.tsx
@@ -765,7 +765,7 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                             : isPending
                               ? 'bg-blue-900/30 border border-blue-700 cursor-wait'
                               : 'bg-slate-800 hover:bg-blue-900/30 border border-slate-700'
-                        }`}
+                        } focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`}
                       >
                         <div className="flex items-center gap-2 mb-2">
                           <span className="font-bold text-slate-200 truncate w-full">{m.name}</span>


### PR DESCRIPTION
This pull request implements key keyboard navigation and accessibility improvements across ChatTab, ModelsTab, and McpTab to ensure focus states are clearly visible for keyboard/AT users on dark-theme UI layers. Additionally, it implements a helpful micro-UX helper by converting the non-functional "+ Download Models" static button inside the Model Selector dropdown into an interactive control that programmatically switches to the Models tab (`setActiveTab(1)`), significantly easing user onboarding.

---
*PR created automatically by Jules for task [18235736290520991442](https://jules.google.com/task/18235736290520991442) started by @rwilliamspbg-ops*