### PR TITLE
🎨 Palette: Add toast notifications for settings save and reset actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,7 @@
 ## 2026-08-01 - [Interactive Controls Keyboard Visibility]
 **Learning:** Interactive controls like tab lists (e.g., in the Models Dashboard) and control action buttons/inputs (e.g., inside the Cluster Workers dashboard) must use high-contrast focus-visible rings. Relying on default focus styles leads to invisible focused items during tab traversal on dark-theme UI panels, leaving keyboard and screen-reader users completely blind.
 **Action:** Always style all dashboards' custom buttons, tab toggles, and input elements with `focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`.
+
+## 2026-08-11 - [Settings Save and Reset Toast Notifications Feedback]
+**Learning:** Forms managing critical application-wide or cluster settings must provide prominent, high-fidelity feedback (such as transient toast alerts) for both success and failure outcomes during actions like "Save" and "Reset to Defaults". Failing to do so can result in silent errors when API requests fail, leaving users completely unaware that their modifications or resets were rejected.
+**Action:** Always integrate standard configuration-saving and state-reset operations with global/app-wide toast notification systems to guarantee visibility of results.

--- a/ghostlink_gui_modern/src/components/SettingsTab.tsx
+++ b/ghostlink_gui_modern/src/components/SettingsTab.tsx
@@ -17,7 +17,7 @@ import {
   Loader2,
   Layers,
 } from 'lucide-react';
-import { Settings as SettingsType } from '../store';
+import { Settings as SettingsType, useAppStore } from '../store';
 import { GhostlinkAPI } from '../api';
 import { useInferenceEngines } from '../hooks/useInferenceEngines';
 
@@ -31,6 +31,7 @@ type BackendInfo = {
 };
 
 export const SettingsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
+  const addToast = useAppStore((s) => s.addToast);
   const [settings, setSettings] = useState<SettingsType | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -67,9 +68,12 @@ export const SettingsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     const result = await api.updateSettings(settings);
     if (result.success) {
       setSaved(true);
+      addToast({ type: 'success', message: 'Runtime settings saved successfully.' });
       setTimeout(() => setSaved(false), 2000);
     } else {
-      setError(result.error || 'Save failed');
+      const errMsg = result.error || 'Save failed';
+      setError(errMsg);
+      addToast({ type: 'error', message: `Failed to save settings: ${errMsg}` });
     }
     setSaving(false);
   };
@@ -130,7 +134,11 @@ export const SettingsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     if (result.success && result.settings) {
       setSettings(result.settings);
       setSaved(true);
+      addToast({ type: 'success', message: 'Settings reset to defaults.' });
       setTimeout(() => setSaved(false), 2000);
+    } else {
+      const errMsg = result.error || 'Reset failed';
+      addToast({ type: 'error', message: `Failed to reset settings: ${errMsg}` });
     }
     setSaving(false);
   };


### PR DESCRIPTION
🎨 Palette: Add toast notifications on settings save/reset

### 💡 What:
Integrated settings save and reset actions on the SettingsTab with the global toast system (`useAppStore`'s `addToast`). Users now receive transient, informative toast notifications indicating when their configurations have been successfully saved or reset, as well as clear error toasts if any backend issues arise.

### 🎯 Why:
Previously, forms managing critical application-wide or cluster settings lacked clear success/error toast alerts, meaning that if saving or resetting failed on the backend, the user had no feedback (or error message) shown on their loaded configurations screen. Now, the user receives precise visual feedback, improving usability and reducing cognitive load.

### ♿ Accessibility:
Toast notifications are fully keyboard-accessible, have the correct ARIA role of "alert" or "status", and provide screen-readers with immediate, localized context of the outcomes. Also updated the critical UX findings journal.

---
*PR created automatically by Jules for task [12837942706450954857](https://jules.google.com/task/12837942706450954857) started by @rwilliamspbg-ops*