### PR TITLE
🎨 Palette: Add Worker Semantic Form Submission & Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -63,3 +63,7 @@
 ## 2026-08-11 - [Settings Save and Reset Toast Notifications Feedback]
 **Learning:** Forms managing critical application-wide or cluster settings must provide prominent, high-fidelity feedback (such as transient toast alerts) for both success and failure outcomes during actions like "Save" and "Reset to Defaults". Failing to do so can result in silent errors when API requests fail, leaving users completely unaware that their modifications or resets were rejected.
 **Action:** Always integrate standard configuration-saving and state-reset operations with global/app-wide toast notification systems to guarantee visibility of results.
+
+## 2026-08-13 - [Semantic Form Ergonomics on Cluster Workers Tab]
+**Learning:** Form structures managing external worker node connections in cluster setup tabs benefit immensely from semantic `<form>` containers instead of non-interactive nested wrappers. This allows users to press "Enter" from any text input field to submit the form cleanly without needing manual mouse interaction. Visually marking mandatory fields (such as Host and Port) with clear asterisks and explicit `required` validation keeps setup straightforward.
+**Action:** Always implement configuration input blocks using semantic `<form>` containers with standard validation and input submission ergonomics.

--- a/ghostlink_gui_modern/src/components/WorkersTab.tsx
+++ b/ghostlink_gui_modern/src/components/WorkersTab.tsx
@@ -197,16 +197,22 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
       </div>
 
       {showAddForm && (
-        // eslint-disable-next-line jsx-a11y/no-static-element-interactions -- wrapper only delegates Escape from the real interactive inputs/buttons inside, not a control itself
-        <div
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleAddWorker();
+          }}
           className="px-6 py-4 border-b border-slate-800 bg-slate-900/30"
           onKeyDown={(e) => { if (e.key === 'Escape') setShowAddForm(false); }}
         >
           <div className="flex items-end gap-3 max-w-lg">
             <div className="flex-1">
-              <label htmlFor="host" className="block text-[10px] font-bold uppercase tracking-wider text-slate-400 mb-1">Host</label>
+              <label htmlFor="host" className="block text-[10px] font-bold uppercase tracking-wider text-slate-400 mb-1">
+                Host <span className="text-red-500" title="Required">*</span>
+              </label>
               <input
                 type="text"
+                required
                 value={addHost}
                 onChange={(e) => setAddHost(e.target.value)}
                 placeholder="192.168.1.100"
@@ -216,9 +222,12 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
               />
             </div>
             <div className="w-24">
-              <label htmlFor="port" className="block text-[10px] font-bold uppercase tracking-wider text-slate-400 mb-1">Port</label>
+              <label htmlFor="port" className="block text-[10px] font-bold uppercase tracking-wider text-slate-400 mb-1">
+                Port <span className="text-red-500" title="Required">*</span>
+              </label>
               <input
                 type="number"
+                required
                 value={addPort}
                 onChange={(e) => setAddPort(e.target.value)}
                 placeholder="8003"
@@ -228,14 +237,14 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
               />
             </div>
             <button
-              onClick={handleAddWorker}
+              type="submit"
               className="px-4 py-1.5 bg-green-600 hover:bg-green-500 text-white text-xs font-bold rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             >
               Connect
             </button>
           </div>
           {addError && <p role="alert" className="text-red-400 text-xs mt-2">{addError}</p>}
-        </div>
+        </form>
       )}
 
       <div className="flex-1 overflow-y-auto p-6" tabIndex={0} role="region" aria-label="Workers">


### PR DESCRIPTION
Converts the "Add Worker" form on the Workers Tab from a generic non-semantic div wrapper to a semantic `<form>` block. This enables users to submit the connection details naturally by pressing the Enter key from the Host or Port fields. Additionally, configures HTML inputs with `required` validation attributes and visual indicators (*).

---
*PR created automatically by Jules for task [12219801325180346670](https://jules.google.com/task/12219801325180346670) started by @rwilliamspbg-ops*