### PR TITLE
🎨 Palette: Add keyboard focus visible ring to toaster dismiss button

### DIFF
--- a/ghostlink_gui_modern/src/components/Toaster.tsx
+++ b/ghostlink_gui_modern/src/components/Toaster.tsx
@@ -30,7 +30,7 @@ const ToastItem: React.FC<Toast> = ({ id, type, message }) => {
       <p className="text-sm flex-1 min-w-0 break-words">{message}</p>
       <button
         onClick={() => removeToast(id)}
-        className="text-current opacity-60 hover:opacity-100 transition shrink-0"
+        className="text-current opacity-60 hover:opacity-100 transition shrink-0 rounded focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
         aria-label="Dismiss notification"
       >
         <X size={14} aria-hidden="true" />


### PR DESCRIPTION
🎨 Palette: Add keyboard focus visible ring to toaster dismiss button

💡 What: Added high-contrast focus-visible ring styling (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none rounded`) to the notification dismiss button in `Toaster.tsx`.
🎯 Why: Ensures keyboard and assistive technology users navigating interactive toast popups receive clear visual focus indicators when navigating to the dismiss action button.
♿ Accessibility: Improves keyboard navigation visibility for interactive toast alerts without cluttering the UI for mouse/touch users.

---
*PR created automatically by Jules for task [15967358471952851005](https://jules.google.com/task/15967358471952851005) started by @rwilliamspbg-ops*