### PR TITLE
Enterprise Trust Track: RBAC, RPC peer auth, durable audit log, monitoring, OTel tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,9 @@ dependencies = [
  "hmac",
  "http",
  "jsonwebtoken",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rand 0.8.6",
  "rcgen",
  "reqwest 0.12.28",
@@ -1043,6 +1046,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tower_governor",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -1878,6 +1882,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2138,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2442,6 +2539,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -3376,6 +3474,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3466,6 +3565,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "chrono",
  "futures",
  "ghostlink-core",
+ "hmac",
  "http",
  "jsonwebtoken",
  "rand 0.8.6",

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -79,3 +79,5 @@ rcgen = "0.14.7"
 
 # API key hashing for the RBAC key store (already a workspace dependency via ghostlink-core)
 sha2 = "0.10"
+# HMAC-SHA256 for the RPC peer auth handshake (rpc_cluster::admit_via_secret)
+hmac = "0.12"

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -41,7 +41,7 @@ toml = "0.8"
 axum = { version = "0.7", features = ["macros"] }
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.5", features = ["cors"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
 tower_governor = { version = "0.4.3", features = ["axum"] }
 
 # Object-safe async trait for the custom inference backend plugin system
@@ -81,3 +81,12 @@ rcgen = "0.14.7"
 sha2 = "0.10"
 # HMAC-SHA256 for the RPC peer auth handshake (rpc_cluster::admit_via_secret)
 hmac = "0.12"
+# Optional OpenTelemetry tracing export (otel.rs) — the blocking reqwest
+# client (not the async one) is deliberate: spans are exported via the SDK's
+# synchronous SimpleSpanProcessor, called from main() before any tokio
+# runtime exists (main() dispatches several non-serve subcommands too), so
+# the underlying HTTP client must not depend on an ambient async reactor.
+opentelemetry = "0.32.0"
+opentelemetry_sdk = "0.32.1"
+tracing-opentelemetry = "0.33.0"
+opentelemetry-otlp = { version = "0.32.0", features = ["http-proto", "reqwest-blocking-client"] }

--- a/crates/ghost-link/Cargo.toml
+++ b/crates/ghost-link/Cargo.toml
@@ -76,3 +76,6 @@ rustls = { version = "0.23.42", features = ["prefer-post-quantum"] }
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 rcgen = "0.14.7"
+
+# API key hashing for the RBAC key store (already a workspace dependency via ghostlink-core)
+sha2 = "0.10"

--- a/crates/ghost-link/src/audit_log.rs
+++ b/crates/ghost-link/src/audit_log.rs
@@ -1,0 +1,345 @@
+//! Durable, exportable audit trail.
+//!
+//! The in-memory capped `VecDeque` (`push_audit_entry`, owned by
+//! `BackendState.audit_log` in `main.rs`) still serves the GUI's live
+//! Security-tab feed exactly as before — fast, restart-reset, capped at
+//! `AUDIT_LOG_CAP`. This module adds what it was missing: an append-only,
+//! on-disk trail (`append_durable`/`read_all_durable`) that survives a
+//! restart and isn't capped, plus a CEF (Common Event Format) export path
+//! for SIEM ingestion, matching `docs/ROADMAP.md`'s Enterprise Trust Track
+//! item #3.
+
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, Write};
+use std::path::PathBuf;
+
+/// One row for the GUI's Security tab audit log — field names/shape match
+/// what `SecurityTab.tsx` already expects (it predates a real backend for
+/// this and was rendering against a permanently-empty list).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditLogEntry {
+    pub event: String,
+    /// "SUCCESS"/"AUTHENTICATED" render green in the GUI; anything else
+    /// (e.g. "FAILED", "DENIED") renders as a yellow warning badge.
+    pub status: String,
+    pub ip: String,
+    /// RFC3339 — the GUI does `new Date(e.time)` on this directly.
+    pub time: String,
+    pub detail: Option<String>,
+}
+
+pub const AUDIT_LOG_CAP: usize = 500;
+
+/// Appends one entry and trims from the front once over `AUDIT_LOG_CAP` —
+/// split out from `record_audit_event` (`main.rs`) so it's unit-testable
+/// against a bare `VecDeque` without needing to construct a full
+/// `BackendState`.
+pub fn push_audit_entry(log: &mut std::collections::VecDeque<AuditLogEntry>, entry: AuditLogEntry) {
+    log.push_back(entry);
+    while log.len() > AUDIT_LOG_CAP {
+        log.pop_front();
+    }
+}
+
+fn audit_log_path() -> PathBuf {
+    std::env::var("GHOSTLINK_AUDIT_LOG_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("audit_log.jsonl"))
+}
+
+/// Appends one entry to the durable, append-only, restart-surviving audit
+/// trail — one JSON object per line (JSONL: trivial to append to, trivial
+/// to `tail`/`grep`, no schema-migration machinery needed). Best-effort:
+/// warns rather than failing the caller's request on a write error, the
+/// same tradeoff every other persistence function in this codebase makes
+/// (`save_settings`, `save_api_keys`, ...).
+pub fn append_durable(entry: &AuditLogEntry) {
+    let line = match serde_json::to_string(entry) {
+        Ok(l) => l,
+        Err(err) => {
+            tracing::warn!("audit_log: failed to serialize entry for the durable trail: {err}");
+            return;
+        }
+    };
+    let path = audit_log_path();
+    let result = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut file| writeln!(file, "{line}"));
+    if let Err(err) = result {
+        tracing::warn!(
+            "audit_log: failed to append to the durable trail at {}: {err}",
+            path.display()
+        );
+    }
+}
+
+/// Reads the full durable audit trail (not just the capped in-memory live
+/// view). A line that fails to parse (a truncated write, a manual edit, a
+/// future format change) is skipped with a warning rather than failing the
+/// whole read — one bad line shouldn't hide the rest of a real security
+/// trail. No file yet is not an error: an empty trail, not a failure.
+pub fn read_all_durable() -> Vec<AuditLogEntry> {
+    let path = audit_log_path();
+    let file = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
+    };
+    std::io::BufReader::new(file)
+        .lines()
+        .filter_map(|line| match line {
+            Ok(l) if l.trim().is_empty() => None,
+            Ok(l) => match serde_json::from_str::<AuditLogEntry>(&l) {
+                Ok(entry) => Some(entry),
+                Err(err) => {
+                    tracing::warn!("audit_log: skipping unparseable line in durable trail: {err}");
+                    None
+                }
+            },
+            Err(err) => {
+                tracing::warn!("audit_log: skipping unreadable line in durable trail: {err}");
+                None
+            }
+        })
+        .collect()
+}
+
+/// CEF severity (0-10 scale): a successful event is informational,
+/// anything else (FAILED/DENIED/...) is worth an analyst's attention.
+fn cef_severity(status: &str) -> u8 {
+    if status.eq_ignore_ascii_case("success") {
+        1
+    } else {
+        7
+    }
+}
+
+/// Escapes a CEF header field (Signature ID / Name) per the CEF spec:
+/// backslash and pipe are the only characters requiring escaping there.
+fn cef_escape_header(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('|', "\\|")
+}
+
+/// Escapes a CEF extension value (the part after `key=`): backslash and
+/// equals sign must be escaped per the CEF spec, and a newline is replaced
+/// (not escaped) since CEF is one event per line — an embedded newline
+/// would otherwise split one audit entry into two lines for a naive
+/// line-based ingester. This is not cosmetic: several real `detail`
+/// strings already in this codebase contain a raw `=` (e.g.
+/// `"name='{}' id={}"` on the key-revocation event), which would otherwise
+/// corrupt the extension field boundary for any real CEF parser.
+fn cef_escape_extension(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('=', "\\=")
+        .replace(['\n', '\r'], " ")
+}
+
+/// Formats one entry as a single CEF (Common Event Format) line — the
+/// SIEM-standard export format `docs/ROADMAP.md` names. `event` doubles as
+/// both the CEF Signature ID and Name fields: this codebase's event names
+/// (e.g. `"security.key.created"`, `"authz"`) are already stable,
+/// descriptive identifiers, so a separate signature-id scheme would be
+/// redundant.
+pub fn to_cef_line(entry: &AuditLogEntry) -> String {
+    let signature = cef_escape_header(&entry.event);
+    let severity = cef_severity(&entry.status);
+    let mut extension = format!(
+        "rt={} src={} outcome={}",
+        cef_escape_extension(&entry.time),
+        cef_escape_extension(&entry.ip),
+        cef_escape_extension(&entry.status),
+    );
+    if let Some(detail) = &entry.detail {
+        extension.push_str(&format!(" msg={}", cef_escape_extension(detail)));
+    }
+    format!(
+        "CEF:0|Ghostlink|ghost-link|{}|{signature}|{signature}|{severity}|{extension}",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+/// Formats a full list of entries as newline-separated CEF lines, ready to
+/// hand a SIEM ingester or write straight to a response body.
+pub fn export_cef(entries: &[AuditLogEntry]) -> String {
+    entries
+        .iter()
+        .map(to_cef_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    // Real filesystem + real env var mutation — serialized like every other
+    // env-var-mutating test in this codebase (see auth.rs's own env_lock),
+    // since GHOSTLINK_AUDIT_LOG_PATH is process-global and `cargo test`
+    // runs in parallel by default.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn sample(event: &str, status: &str, detail: Option<&str>) -> AuditLogEntry {
+        AuditLogEntry {
+            event: event.to_string(),
+            status: status.to_string(),
+            ip: "127.0.0.1".to_string(),
+            time: "2026-08-15T00:00:00+00:00".to_string(),
+            detail: detail.map(|d| d.to_string()),
+        }
+    }
+
+    #[test]
+    fn push_audit_entry_appends_in_order() {
+        let mut log = std::collections::VecDeque::new();
+        push_audit_entry(&mut log, sample("first", "SUCCESS", None));
+        push_audit_entry(&mut log, sample("second", "SUCCESS", None));
+        assert_eq!(log.len(), 2);
+        assert_eq!(log[0].event, "first");
+        assert_eq!(log[1].event, "second");
+    }
+
+    #[test]
+    fn push_audit_entry_trims_oldest_once_over_cap() {
+        let mut log = std::collections::VecDeque::new();
+        for i in 0..(AUDIT_LOG_CAP + 10) {
+            push_audit_entry(&mut log, sample(&format!("event-{i}"), "SUCCESS", None));
+        }
+        assert_eq!(log.len(), AUDIT_LOG_CAP, "must never grow past the cap");
+        assert_eq!(log.front().unwrap().event, "event-10");
+        assert_eq!(
+            log.back().unwrap().event,
+            format!("event-{}", AUDIT_LOG_CAP + 9)
+        );
+    }
+
+    #[test]
+    fn append_then_read_all_durable_round_trips() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let path =
+            std::env::temp_dir().join(format!("ghostlink-test-audit-{}.jsonl", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_PATH", &path);
+
+        append_durable(&sample("auth", "FAILED", Some("GET /api/models")));
+        append_durable(&sample(
+            "security.key.created",
+            "SUCCESS",
+            Some("name='ci' id=key_abc"),
+        ));
+
+        let read_back = read_all_durable();
+        assert_eq!(read_back.len(), 2);
+        assert_eq!(read_back[0].event, "auth");
+        assert_eq!(read_back[1].event, "security.key.created");
+
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_all_durable_skips_a_malformed_line_without_failing_the_rest() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let path = std::env::temp_dir().join(format!(
+            "ghostlink-test-audit-malformed-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_PATH", &path);
+
+        append_durable(&sample("first", "SUCCESS", None));
+        {
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
+            writeln!(file, "{{ this is not valid json").unwrap();
+        }
+        append_durable(&sample("third", "SUCCESS", None));
+
+        let read_back = read_all_durable();
+        assert_eq!(
+            read_back.len(),
+            2,
+            "the malformed middle line must be skipped, not fail the whole read"
+        );
+        assert_eq!(read_back[0].event, "first");
+        assert_eq!(read_back[1].event, "third");
+
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_all_durable_returns_empty_when_no_file_exists_yet() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let path = std::env::temp_dir().join(format!(
+            "ghostlink-test-audit-missing-{}.jsonl",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_PATH", &path);
+
+        assert!(read_all_durable().is_empty());
+
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+    }
+
+    #[test]
+    fn cef_severity_maps_success_low_and_everything_else_high() {
+        assert_eq!(cef_severity("SUCCESS"), 1);
+        assert_eq!(cef_severity("success"), 1);
+        assert_eq!(cef_severity("FAILED"), 7);
+        assert_eq!(cef_severity("DENIED"), 7);
+    }
+
+    #[test]
+    fn to_cef_line_escapes_every_equals_sign_in_the_detail_extension_value() {
+        // Real-world case: several existing audit `detail` strings already
+        // contain a raw '=' (e.g. "name='dashboard' id=key_9a0c17cfa3ee" has
+        // two: after "name" and after "id"). Per the CEF spec, only '\' and
+        // '=' require escaping inside an extension value ('|' does NOT --
+        // unlike the pipe-delimited header fields, extension is
+        // space-separated key=value pairs, so a literal '|' in a value is
+        // unambiguous). An unescaped '=' would corrupt the field boundary
+        // for any real SIEM parser -- every occurrence must be escaped, not
+        // just one.
+        let entry = sample(
+            "security.key.revoked",
+            "SUCCESS",
+            Some("name='dashboard' id=key_9a0c17cfa3ee | extra"),
+        );
+        let line = to_cef_line(&entry);
+        assert!(line.starts_with("CEF:0|Ghostlink|ghost-link|"));
+        assert!(
+            line.contains("msg=name\\='dashboard' id\\=key_9a0c17cfa3ee | extra"),
+            "every raw '=' inside the detail must be escaped (the literal '|' is left alone, \
+             valid inside an extension value): {line}"
+        );
+    }
+
+    #[test]
+    fn cef_escape_header_escapes_pipe_and_backslash() {
+        assert_eq!(cef_escape_header("a|b"), "a\\|b");
+        assert_eq!(cef_escape_header(r"a\b"), r"a\\b");
+    }
+
+    #[test]
+    fn to_cef_line_omits_msg_when_detail_is_none() {
+        let entry = sample("auth", "SUCCESS", None);
+        let line = to_cef_line(&entry);
+        assert!(!line.contains("msg="));
+    }
+
+    #[test]
+    fn export_cef_joins_multiple_entries_with_newlines() {
+        let entries = vec![sample("a", "SUCCESS", None), sample("b", "FAILED", None)];
+        let out = export_cef(&entries);
+        assert_eq!(out.lines().count(), 2);
+    }
+}

--- a/crates/ghost-link/src/auth.rs
+++ b/crates/ghost-link/src/auth.rs
@@ -1,19 +1,79 @@
-//! Real bearer-token auth: a persisted API key generated once on first
-//! run, and short-lived JWTs (`jsonwebtoken`, HS256, signed with that same
-//! key) issued by exchanging it — replacing the previous hardcoded
-//! `"new-token-123"` JWT-refresh stub. Independent of whether TLS (see
-//! `tls.rs`) is on, though obviously weaker without it: a bearer token
-//! sent over plaintext HTTP can be observed in transit.
+//! Real bearer-token auth: a persisted, hashed API-key store (each key
+//! carrying a role — Admin/Operator/Viewer) and short-lived JWTs
+//! (`jsonwebtoken`, HS256) issued by exchanging a valid key — replacing
+//! both the previous hardcoded `"new-token-123"` JWT-refresh stub and the
+//! single-shared-key-with-no-roles model that preceded this file.
+//! Independent of whether TLS (see `tls.rs`) is on, though obviously
+//! weaker without it: a bearer token sent over plaintext HTTP can be
+//! observed in transit.
 
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 static ACTIVE_API_KEY: OnceLock<String> = OnceLock::new();
+static JWT_SIGNING_SECRET: OnceLock<String> = OnceLock::new();
 
 const JWT_LIFETIME_SECS: u64 = 3600;
+
+/// The bootstrap key's fixed id — deterministic so `load_api_keys` always
+/// adopts an existing `api_key.txt` as the same stable Admin record across
+/// restarts rather than minting a new id every time one is synthesized.
+pub const BOOTSTRAP_KEY_ID: &str = "key_bootstrap";
+
+/// A key's permission level. Ordered `Admin > Operator > Viewer` — see
+/// `Role::satisfies`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    Admin,
+    Operator,
+    Viewer,
+}
+
+impl Role {
+    fn rank(self) -> u8 {
+        match self {
+            Role::Viewer => 0,
+            Role::Operator => 1,
+            Role::Admin => 2,
+        }
+    }
+
+    /// Whether a key with this role may access a route requiring `required`.
+    pub fn satisfies(self, required: Role) -> bool {
+        self.rank() >= required.rank()
+    }
+}
+
+/// One persisted, hashed API key. The raw key value is never stored —
+/// only its SHA-256 hash (for lookup) and a display-safe preview (last 4
+/// chars, so an operator can tell keys apart in a list without either of
+/// them being able to reconstruct the real value).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyRecord {
+    pub id: String,
+    pub name: String,
+    pub role: Role,
+    pub key_hash: String,
+    pub key_preview: String,
+    pub created_at: String,
+    pub last_used_at: Option<String>,
+}
+
+/// The identity attached to an authenticated request — resolved once by
+/// `authenticate` and reused by both the role check and (for
+/// `/api/security/jwt/refresh`) the handler that needs to know who's
+/// asking.
+#[derive(Debug, Clone)]
+pub struct AuthContext {
+    pub key_id: String,
+    pub name: String,
+    pub role: Role,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
@@ -28,9 +88,45 @@ fn api_key_path() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from("api_key.txt"))
 }
 
-fn generate_api_key() -> String {
+fn jwt_secret_path() -> PathBuf {
+    std::env::var("GHOSTLINK_JWT_SECRET_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("jwt_secret.txt"))
+}
+
+/// Generates a fresh 256-bit secret, hex-encoded — used for both API keys
+/// and the JWT signing secret, which need the same entropy/format shape
+/// but must never be the same value as each other (see `jwt_signing_secret`).
+fn generate_secret() -> String {
     let bytes: [u8; 32] = rand::random();
     bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn generate_api_key() -> String {
+    generate_secret()
+}
+
+/// SHA-256 hex digest of a raw key/token — what's actually persisted and
+/// compared, never the raw value itself.
+fn hash_key(raw: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(raw.as_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// Last 4 characters of a raw key, for display in key-list responses —
+/// never enough to reconstruct or brute-force the real value from.
+fn key_preview(raw: &str) -> String {
+    let len = raw.len();
+    if len <= 4 {
+        raw.to_string()
+    } else {
+        raw[len - 4..].to_string()
+    }
 }
 
 /// Loads the persisted API key, generating and persisting a new one on
@@ -62,62 +158,149 @@ fn load_or_create_api_key() -> String {
     println!("  {key}");
     println!("Send it as `Authorization: Bearer {key}` on every API request, or");
     println!("exchange it for a short-lived token via POST /api/security/jwt/refresh.");
+    println!("This key is now the 'bootstrap' Admin entry in your key store — see");
+    println!("GET /api/security/keys to create additional, more narrowly-scoped keys.");
     println!("=======================================================================");
     key
 }
 
-/// The process-wide API key, loaded (or generated) once and cached —
-/// every auth check and the JWT signing secret both derive from this
-/// single value.
+/// The process-wide bootstrap API key, loaded (or generated) once and
+/// cached. Only used to (a) seed the bootstrap `ApiKeyRecord` the first
+/// time `api_keys.json` doesn't exist yet, and (b) print the first-run
+/// banner above — actual auth checks go through the key *store*
+/// (`authenticate`), not this value directly, once the store exists.
 pub fn active_api_key() -> &'static str {
     ACTIVE_API_KEY.get_or_init(load_or_create_api_key)
 }
 
-/// Issues a short-lived JWT for the given subject, signed with the active
-/// API key. Real issuance/verification, not the previous
-/// `"new-token-123"` stub.
-pub fn issue_jwt(subject: &str) -> Result<String, String> {
+/// Loads (or generates + persists) the JWT signing secret. Deliberately a
+/// distinct value from any individual API key: with multiple, independently
+/// revocable keys, signing JWTs with one specific key's value would mean
+/// rotating that unrelated key silently invalidated every other key's
+/// outstanding JWTs.
+fn jwt_signing_secret() -> &'static str {
+    JWT_SIGNING_SECRET.get_or_init(|| {
+        let path = jwt_secret_path();
+        if let Ok(existing) = std::fs::read_to_string(&path) {
+            let trimmed = existing.trim().to_string();
+            if !trimmed.is_empty() {
+                return trimmed;
+            }
+        }
+        let secret = generate_secret();
+        if let Err(err) = std::fs::write(&path, &secret) {
+            eprintln!(
+                "warning: failed to persist JWT signing secret to {}: {err} (a new one will be generated next restart, invalidating outstanding JWTs)",
+                path.display()
+            );
+        }
+        secret
+    })
+}
+
+/// Builds the bootstrap `ApiKeyRecord` from the existing (or freshly
+/// generated) `active_api_key()` value — the migration path that makes an
+/// existing `api_key.txt` keep working, unchanged, as the sole Admin key
+/// once the key store exists.
+pub fn bootstrap_key_record() -> ApiKeyRecord {
+    let raw = active_api_key();
+    ApiKeyRecord {
+        id: BOOTSTRAP_KEY_ID.to_string(),
+        name: "bootstrap".to_string(),
+        role: Role::Admin,
+        key_hash: hash_key(raw),
+        key_preview: key_preview(raw),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        last_used_at: None,
+    }
+}
+
+/// Creates a new key record with a freshly generated raw value. Returns
+/// both the record (to persist) and the raw key (to return to the caller
+/// exactly once — it's never recoverable after this call returns, since
+/// only its hash is kept).
+pub fn create_key(name: String, role: Role) -> (ApiKeyRecord, String) {
+    let raw = generate_api_key();
+    let id = format!(
+        "key_{}",
+        rand::random::<[u8; 6]>()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>()
+    );
+    let record = ApiKeyRecord {
+        id,
+        name,
+        role,
+        key_hash: hash_key(&raw),
+        key_preview: key_preview(&raw),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        last_used_at: None,
+    };
+    (record, raw)
+}
+
+/// Issues a short-lived JWT for the given key id, signed with the
+/// server-wide JWT signing secret (not any individual key's value — see
+/// `jwt_signing_secret`).
+pub fn issue_jwt(key_id: &str) -> Result<String, String> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|e| format!("system clock error: {e}"))?
         .as_secs();
     let claims = Claims {
-        sub: subject.to_string(),
+        sub: key_id.to_string(),
         iat: now,
         exp: now + JWT_LIFETIME_SECS,
     };
     encode(
         &Header::default(),
         &claims,
-        &EncodingKey::from_secret(active_api_key().as_bytes()),
+        &EncodingKey::from_secret(jwt_signing_secret().as_bytes()),
     )
     .map_err(|e| format!("failed to sign JWT: {e}"))
 }
 
-fn verify_jwt(token: &str) -> bool {
+fn verify_jwt(token: &str) -> Option<String> {
     decode::<Claims>(
         token,
-        &DecodingKey::from_secret(active_api_key().as_bytes()),
+        &DecodingKey::from_secret(jwt_signing_secret().as_bytes()),
         &Validation::default(),
     )
-    .is_ok()
+    .ok()
+    .map(|data| data.claims.sub)
 }
 
-/// Accepts either the raw API key itself as a bearer token (simplest path
-/// for a script or `curl`) or a JWT issued by `issue_jwt` that hasn't
-/// expired — both derive from the same secret, so either proves the
-/// caller knows the API key.
-pub fn verify_bearer_token(token: &str) -> bool {
+/// Resolves a bearer token (raw API key or a JWT issued by `issue_jwt`)
+/// against the live key store, returning the matching key's identity and
+/// current role. A JWT is only honored if its subject key id is *still
+/// present* in `keys` — this is what makes revoking a key also invalidate
+/// any outstanding JWT for it immediately, rather than waiting out the
+/// JWT's lifetime. Role is always read fresh from the current record, not
+/// from JWT claims, so a role change also takes effect immediately.
+pub fn authenticate(token: &str, keys: &[ApiKeyRecord]) -> Option<AuthContext> {
     let token = token.trim();
     if token.is_empty() {
-        return false;
+        return None;
     }
-    // Constant-time-ish compare isn't critical here (the key is 256 bits
-    // of real entropy — timing side channels aren't the realistic threat
-    // for a locally-generated secret), but avoid the obviously-wrong
-    // early-exit shape anyway.
-    let matches_raw_key = token.len() == active_api_key().len() && token == active_api_key();
-    matches_raw_key || verify_jwt(token)
+
+    let hashed = hash_key(token);
+    if let Some(record) = keys.iter().find(|k| k.key_hash == hashed) {
+        return Some(AuthContext {
+            key_id: record.id.clone(),
+            name: record.name.clone(),
+            role: record.role,
+        });
+    }
+
+    let subject = verify_jwt(token)?;
+    keys.iter()
+        .find(|k| k.id == subject)
+        .map(|record| AuthContext {
+            key_id: record.id.clone(),
+            name: record.name.clone(),
+            role: record.role,
+        })
 }
 
 /// Extracts the bearer token from an `Authorization: Bearer <token>`
@@ -178,32 +361,110 @@ mod tests {
     }
 
     #[test]
-    fn verify_bearer_token_accepts_raw_key_and_issued_jwt_rejects_garbage() {
+    fn role_satisfies_is_a_strict_hierarchy() {
+        assert!(Role::Admin.satisfies(Role::Admin));
+        assert!(Role::Admin.satisfies(Role::Operator));
+        assert!(Role::Admin.satisfies(Role::Viewer));
+        assert!(Role::Operator.satisfies(Role::Operator));
+        assert!(Role::Operator.satisfies(Role::Viewer));
+        assert!(!Role::Operator.satisfies(Role::Admin));
+        assert!(Role::Viewer.satisfies(Role::Viewer));
+        assert!(!Role::Viewer.satisfies(Role::Operator));
+        assert!(!Role::Viewer.satisfies(Role::Admin));
+    }
+
+    #[test]
+    fn hash_key_is_deterministic_and_distinct_per_input() {
+        assert_eq!(hash_key("abc"), hash_key("abc"));
+        assert_ne!(hash_key("abc"), hash_key("abd"));
+        assert_eq!(hash_key("abc").len(), 64);
+    }
+
+    #[test]
+    fn key_preview_never_exposes_more_than_the_last_four_chars() {
+        assert_eq!(key_preview("abcdefgh"), "efgh");
+        assert_eq!(key_preview("ab"), "ab");
+    }
+
+    #[test]
+    fn create_key_returns_a_record_whose_hash_matches_the_raw_value_and_never_stores_it() {
+        let (record, raw) = create_key("ci-bot".to_string(), Role::Operator);
+        assert_eq!(record.name, "ci-bot");
+        assert_eq!(record.role, Role::Operator);
+        assert_eq!(record.key_hash, hash_key(&raw));
+        assert_eq!(record.key_preview, key_preview(&raw));
+        assert!(record.id.starts_with("key_"));
+    }
+
+    #[test]
+    fn authenticate_matches_raw_key_and_rejects_unknown_or_empty_tokens() {
+        let (record, raw) = create_key("tester".to_string(), Role::Admin);
+        let keys = vec![record.clone()];
+
+        let ctx = authenticate(&raw, &keys).expect("raw key should authenticate");
+        assert_eq!(ctx.key_id, record.id);
+        assert_eq!(ctx.role, Role::Admin);
+
+        assert!(authenticate("not-a-real-key", &keys).is_none());
+        assert!(authenticate("", &keys).is_none());
+    }
+
+    #[test]
+    fn authenticate_honors_a_jwt_only_while_its_key_id_still_exists_in_the_store() {
         let _guard = env_lock().lock().expect("env lock poisoned");
         let path = std::env::temp_dir().join(format!(
-            "ghostlink-test-api-key-verify-{}.txt",
+            "ghostlink-test-jwt-secret-{}.txt",
             std::process::id()
         ));
         let _ = std::fs::remove_file(&path);
-        std::env::set_var("GHOSTLINK_API_KEY_PATH", &path);
-        // Reset the OnceLock's effective value for this test process by
-        // reading the key freshly through the same path the real code
-        // uses — `active_api_key()` is a OnceLock so it can only be
-        // initialized once per test binary run; this test therefore
-        // exercises whatever key was already cached, not a fresh one. That
-        // is fine: it still proves round-trip correctness, just not
-        // isolation across tests within this one process.
-        let key = active_api_key().to_string();
+        std::env::set_var("GHOSTLINK_JWT_SECRET_PATH", &path);
 
-        assert!(verify_bearer_token(&key));
-        assert!(!verify_bearer_token("not-the-key"));
-        assert!(!verify_bearer_token(""));
+        let (record, _raw) = create_key("jwt-holder".to_string(), Role::Operator);
+        let jwt = issue_jwt(&record.id).expect("issue_jwt should succeed");
 
-        let jwt = issue_jwt("test-subject").expect("issue_jwt should succeed");
-        assert!(verify_bearer_token(&jwt));
-        assert!(!verify_bearer_token(&format!("{jwt}tampered")));
+        let keys_with_record = vec![record.clone()];
+        let ctx =
+            authenticate(&jwt, &keys_with_record).expect("JWT for a live key should authenticate");
+        assert_eq!(ctx.key_id, record.id);
+        assert_eq!(ctx.role, Role::Operator);
 
-        std::env::remove_var("GHOSTLINK_API_KEY_PATH");
+        // Simulate revocation: the key id is no longer in the store.
+        let keys_without_record: Vec<ApiKeyRecord> = vec![];
+        assert!(
+            authenticate(&jwt, &keys_without_record).is_none(),
+            "a JWT for a revoked key must be rejected even though it hasn't expired"
+        );
+
+        assert!(authenticate(&format!("{jwt}tampered"), &keys_with_record).is_none());
+
+        std::env::remove_var("GHOSTLINK_JWT_SECRET_PATH");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn authenticate_reflects_a_live_role_change_not_a_stale_jwt_claim() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let path = std::env::temp_dir().join(format!(
+            "ghostlink-test-jwt-secret-role-{}.txt",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        std::env::set_var("GHOSTLINK_JWT_SECRET_PATH", &path);
+
+        let (mut record, _raw) = create_key("role-change".to_string(), Role::Viewer);
+        let jwt = issue_jwt(&record.id).expect("issue_jwt should succeed");
+
+        record.role = Role::Admin;
+        let keys = vec![record];
+        let ctx =
+            authenticate(&jwt, &keys).expect("JWT should still authenticate after a role change");
+        assert_eq!(
+            ctx.role,
+            Role::Admin,
+            "role must be read fresh from the store, not from the JWT claims"
+        );
+
+        std::env::remove_var("GHOSTLINK_JWT_SECRET_PATH");
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1892,6 +1892,19 @@ struct RuntimeSettings {
     /// allow-all empty vec, not full-struct defaults).
     #[serde(default)]
     rpc_allowed_peers: Vec<String>,
+    /// Shared secret for the RPC-auth handshake (see `rpc_cluster`'s
+    /// top-of-file SECURITY doc) — closes the specific gap `rpc_allowed_peers`
+    /// alone can't: a device already inside an allowlisted range, or one
+    /// able to spoof a source IP, isn't stopped by IP allowlisting, but
+    /// can't complete this handshake without the real secret. Manually
+    /// distributed across every node in the cluster, same operational model
+    /// as `rpc_allowed_peers`. Empty (the default) means no handshake is
+    /// required and no auth-port listener is started — the exact same
+    /// behavior as before this field existed. `#[serde(default)]` so
+    /// settings.json files saved before this field existed still
+    /// deserialize.
+    #[serde(default)]
+    rpc_shared_secret: String,
 
     // -- Model-load performance tuning (GUI "Model Performance" section) --
     //
@@ -2081,6 +2094,7 @@ impl Default for RuntimeSettings {
             contribute_compute: false,
             rpc_port: default_rpc_port(),
             rpc_allowed_peers: Vec::new(),
+            rpc_shared_secret: String::new(),
             ngl_auto: true,
             ctx_size_auto: true,
             threads_auto: true,
@@ -5257,16 +5271,89 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             requested_model.clone()
         };
 
+        // Distributed-inference RPC peer discovery + rpc_shared_secret
+        // admission (see `rpc_cluster` module docs). Computed here, before
+        // the main state lock below, since `rpc_cluster::admit_via_secret`
+        // does real async network I/O and this codebase never holds a std
+        // Mutex guard across an `.await`. Empty when disabled, no
+        // qualifying peers, or (once `rpc_shared_secret` is set) every peer
+        // fails the handshake — all of which reproduce single-node
+        // behavior exactly.
+        let (rpc_servers, tensor_split) = {
+            let (peers, local_vram, local_system_memory, shared_secret) = {
+                let backend = lock_state(&state);
+                if backend.settings.distributed_inference {
+                    let local_build_id = native_engine::NativeEngineClient::get_llama_build_id();
+                    let peers = rpc_cluster::discover_rpc_peers(
+                        &backend.cluster,
+                        &backend.local_node_id,
+                        local_build_id.as_deref(),
+                    );
+                    let local_metrics = backend.cluster.get_metrics(&backend.local_node_id);
+                    let local_vram = local_metrics.as_ref().map(|m| m.vram_gb).unwrap_or(0.0);
+                    let local_system_memory = local_metrics
+                        .as_ref()
+                        .map(|m| m.system_memory_gb)
+                        .unwrap_or(0.0);
+                    (
+                        peers,
+                        local_vram,
+                        local_system_memory,
+                        backend.settings.rpc_shared_secret.clone(),
+                    )
+                } else {
+                    (Vec::new(), 0.0, 0.0, String::new())
+                }
+            }; // <-- short-lived discovery lock dropped here, before any .await
+
+            // When a shared secret is configured, each discovered peer must
+            // complete the RPC-auth handshake before it's trusted enough to
+            // route real layers through — see `rpc_cluster`'s top-of-file
+            // SECURITY doc. Best-effort per peer: a peer that fails
+            // (wrong/missing secret, unreachable, timeout) is excluded and
+            // warned about, not a hard failure for the whole request.
+            let peers = if peers.is_empty() || shared_secret.is_empty() {
+                peers
+            } else {
+                let admitted_flags =
+                    futures::future::join_all(peers.iter().map(|p| {
+                        let secret = shared_secret.clone();
+                        let addr = p.addr;
+                        async move {
+                            rpc_cluster::admit_via_secret(addr.ip(), addr.port(), &secret).await
+                        }
+                    }))
+                    .await;
+                let admitted: Vec<_> = peers
+                    .into_iter()
+                    .zip(admitted_flags)
+                    .filter_map(|(peer, ok)| ok.then_some(peer))
+                    .collect();
+                if admitted.is_empty() {
+                    tracing::warn!(
+                        "rpc_cluster: every distributed-inference peer failed the \
+                         rpc_shared_secret handshake \u{2014} falling back to single-node for \
+                         this request"
+                    );
+                }
+                admitted
+            };
+
+            if peers.is_empty() {
+                (None, None)
+            } else {
+                let split =
+                    rpc_cluster::compute_tensor_split(local_vram, local_system_memory, &peers);
+                (
+                    Some(rpc_cluster::rpc_flag_value(&peers)),
+                    Some(rpc_cluster::tensor_split_flag_value(&split)),
+                )
+            }
+        };
+
         // Extract model info and settings under the lock, then drop it before
         // the potentially-long blocking load_model_into_slot call.
-        let (
-            native_engine_client,
-            local_path,
-            native_engine,
-            selected_model,
-            rpc_servers,
-            tensor_split,
-        ) = {
+        let (native_engine_client, local_path, native_engine, selected_model) = {
             let mut backend = lock_state(&state);
 
             // Must run before `load_model_into_slot` reads any
@@ -5274,38 +5361,6 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             // var below — see `apply_native_engine_tuning_env`'s doc
             // comment for why it only ever sets, never clears, one of them.
             apply_native_engine_tuning_env(&backend.settings);
-
-            // Real cross-process model-parallel inference via llama.cpp's
-            // own RPC backend when enabled and the cluster has other nodes
-            // contributing compute — see `rpc_cluster` module docs. Empty
-            // when disabled or no qualifying peers, which reproduces
-            // single-node behavior exactly.
-            let (rpc_servers, tensor_split) = if backend.settings.distributed_inference {
-                let local_build_id = native_engine::NativeEngineClient::get_llama_build_id();
-                let peers = rpc_cluster::discover_rpc_peers(
-                    &backend.cluster,
-                    &backend.local_node_id,
-                    local_build_id.as_deref(),
-                );
-                if peers.is_empty() {
-                    (None, None)
-                } else {
-                    let local_metrics = backend.cluster.get_metrics(&backend.local_node_id);
-                    let local_vram = local_metrics.as_ref().map(|m| m.vram_gb).unwrap_or(0.0);
-                    let local_system_memory = local_metrics
-                        .as_ref()
-                        .map(|m| m.system_memory_gb)
-                        .unwrap_or(0.0);
-                    let split =
-                        rpc_cluster::compute_tensor_split(local_vram, local_system_memory, &peers);
-                    (
-                        Some(rpc_cluster::rpc_flag_value(&peers)),
-                        Some(rpc_cluster::tensor_split_flag_value(&split)),
-                    )
-                }
-            } else {
-                (None, None)
-            };
 
             // Merge local scans so we can find local_path for locally-downloaded models
             let local = scan_local_models_dir(&backend.settings.models_dir);
@@ -5374,8 +5429,6 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 local_path,
                 backend.settings.native_engine.clone(),
                 selected,
-                rpc_servers,
-                tensor_split,
             )
         }; // <-- state lock dropped here
 
@@ -8494,6 +8547,20 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                                 .collect();
                         }
                     }
+                    "rpc_shared_secret" => {
+                        if let Some(s) = value.as_str() {
+                            // Same next-restart caveat as rpc_allowed_peers:
+                            // the auth-port listener (if any) is only stood
+                            // up once, at startup, in `rpc_cluster::
+                            // ensure_contributing`. The *coordinator* side
+                            // (admit_via_secret at model-load time) does
+                            // read this live from `backend.settings`, so a
+                            // coordinator-side change takes effect on the
+                            // next distributed model load without a restart
+                            // — only the receiving/contributing side needs one.
+                            current.rpc_shared_secret = s.to_string();
+                        }
+                    }
                     "ngl_auto" => {
                         if let Some(v) = value.as_bool() {
                             current.ngl_auto = v;
@@ -8731,6 +8798,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             host,
             settings.rpc_port,
             &settings.rpc_allowed_peers,
+            &settings.rpc_shared_secret,
             &rt_handle,
         );
 
@@ -8748,6 +8816,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         let contribute_host = host.to_string();
         let contribute_port = settings.rpc_port;
         let contribute_allowed_peers = settings.rpc_allowed_peers.clone();
+        let contribute_shared_secret = settings.rpc_shared_secret.clone();
         let contribute_rt_handle = rt_handle.clone();
         thread::spawn(move || loop {
             thread::sleep(Duration::from_secs(30));
@@ -8755,6 +8824,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                 &contribute_host,
                 contribute_port,
                 &contribute_allowed_peers,
+                &contribute_shared_secret,
                 &contribute_rt_handle,
             );
         });

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1654,6 +1654,12 @@ struct BackendState {
     /// would need an append-only file, which is a bigger step than this
     /// first real version takes.
     audit_log: std::collections::VecDeque<AuditLogEntry>,
+    /// The live RBAC key store — every `auth_middleware` check and the new
+    /// `/api/security/keys` admin endpoints read/write this. Loaded once at
+    /// startup via `load_api_keys()` (which handles the bootstrap migration
+    /// from a pre-RBAC `api_key.txt`) and persisted to `api_keys.json` on
+    /// every create/revoke.
+    api_keys: Vec<auth::ApiKeyRecord>,
     /// Caches `scan_local_models_dir`'s result — a real `fs::read_dir` +
     /// `fs::metadata`-per-file disk scan `handle_gui_models` previously did
     /// on every single `GET /api/models` call. Short TTL (see
@@ -1707,6 +1713,87 @@ fn record_audit_event(
             detail,
         },
     );
+}
+
+/// Minimum role required to access a route. A method-based default
+/// (GET/HEAD need only `Viewer`, every mutation needs `Operator`) plus two
+/// named `Admin`-only carve-outs — not a per-route table, so it stays
+/// correct as new routes are added without a matching new entry each time.
+/// `/health` is exempted from auth entirely in `auth_middleware`, never
+/// reaching this function. `/api/security/jwt/refresh` is a deliberate
+/// carve-out below the GET-only `Viewer` default: proving identity isn't a
+/// mutation of server state, so every authenticated key — including
+/// `Viewer` — may exchange its key for a JWT.
+fn required_role(method: &axum::http::Method, path: &str) -> auth::Role {
+    if path.starts_with("/api/security/keys") || path == "/api/security/pqc/enable" {
+        return auth::Role::Admin;
+    }
+    if path == "/api/security/jwt/refresh" {
+        return auth::Role::Viewer;
+    }
+    if method == axum::http::Method::GET || method == axum::http::Method::HEAD {
+        auth::Role::Viewer
+    } else {
+        auth::Role::Operator
+    }
+}
+
+/// The JSON-safe view of a key record for list/create responses — never
+/// includes `key_hash` (the only thing that can authenticate as this key).
+fn key_record_public_json(record: &auth::ApiKeyRecord) -> serde_json::Value {
+    serde_json::json!({
+        "id": record.id,
+        "name": record.name,
+        "role": record.role,
+        "key_preview": record.key_preview,
+        "created_at": record.created_at,
+        "last_used_at": record.last_used_at,
+    })
+}
+
+/// Whether removing `id` from `keys` would leave zero `Admin`-role keys —
+/// the lockout condition `delete_key_from_store` refuses.
+fn would_remove_last_admin(keys: &[auth::ApiKeyRecord], id: &str) -> bool {
+    let target_is_admin = keys
+        .iter()
+        .any(|k| k.id == id && k.role == auth::Role::Admin);
+    if !target_is_admin {
+        return false;
+    }
+    keys.iter()
+        .filter(|k| k.role == auth::Role::Admin && k.id != id)
+        .count()
+        == 0
+}
+
+/// Removes a key by id from `keys` in place. Returns an error (status +
+/// message, matching the shape the handler returns directly) if the key
+/// doesn't exist or removing it would leave the store with no `Admin` key
+/// at all — split out from the handler so both conditions are unit-testable
+/// against a bare `Vec`, matching this file's existing
+/// `push_audit_entry`/`record_audit_event` split.
+fn delete_key_from_store(
+    keys: &mut Vec<auth::ApiKeyRecord>,
+    id: &str,
+) -> Result<auth::ApiKeyRecord, (axum::http::StatusCode, String)> {
+    if !keys.iter().any(|k| k.id == id) {
+        return Err((
+            axum::http::StatusCode::NOT_FOUND,
+            format!("no API key with id '{id}'"),
+        ));
+    }
+    if would_remove_last_admin(keys, id) {
+        return Err((
+            axum::http::StatusCode::BAD_REQUEST,
+            "cannot delete the last remaining Admin key — create another Admin key first"
+                .to_string(),
+        ));
+    }
+    let idx = keys
+        .iter()
+        .position(|k| k.id == id)
+        .expect("existence already checked above");
+    Ok(keys.remove(idx))
 }
 
 /// Real byte-level progress for an in-flight (or just-finished) model download.
@@ -3234,6 +3321,47 @@ fn save_persistent_sessions(sessions: &[SessionRecord]) {
     }
 }
 
+fn api_keys_path() -> PathBuf {
+    std::env::var("GHOSTLINK_API_KEYS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("api_keys.json"))
+}
+
+/// Loads the persisted key store, migrating a fresh or pre-RBAC deployment
+/// on the fly: if `api_keys.json` doesn't exist yet (or somehow parses to
+/// zero keys — never persist a store no one can authenticate against), a
+/// single bootstrap `Admin` record is synthesized from the existing
+/// `auth::active_api_key()` value and persisted. An existing deployment's
+/// `api_key.txt` therefore keeps working completely unchanged after this
+/// feature ships — no manual migration step.
+fn load_api_keys() -> Vec<auth::ApiKeyRecord> {
+    let path = api_keys_path();
+    if path.exists() {
+        if let Ok(data) = fs::read_to_string(&path) {
+            if let Ok(keys) = serde_json::from_str::<Vec<auth::ApiKeyRecord>>(&data) {
+                if !keys.is_empty() {
+                    return keys;
+                }
+            }
+        }
+    }
+    let bootstrap = vec![auth::bootstrap_key_record()];
+    save_api_keys(&bootstrap);
+    bootstrap
+}
+
+fn save_api_keys(keys: &[auth::ApiKeyRecord]) {
+    if let Ok(data) = serde_json::to_string_pretty(keys) {
+        let _ = fs::write(api_keys_path(), data);
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateApiKeyRequest {
+    name: String,
+    role: auth::Role,
+}
+
 fn load_settings() -> RuntimeSettings {
     let path = settings_path();
     let mut settings = if path.exists() {
@@ -3846,7 +3974,7 @@ fn detect_node_id() -> String {
 
 fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     use axum::{
-        extract::{ConnectInfo, Path, Query, Request, State},
+        extract::{ConnectInfo, Extension, Path, Query, Request, State},
         http::StatusCode,
         middleware::{self, Next},
         response::{
@@ -3868,13 +3996,18 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         state.lock().unwrap_or_else(|poison| poison.into_inner())
     }
 
-    /// Guards every route except `/health` behind a real bearer token
-    /// (the persisted API key itself, or a JWT issued from it — see
-    /// `auth.rs`). Replaces having no auth check anywhere on this server.
+    /// Guards every route except `/health` behind a real bearer token —
+    /// resolved to an `AuthContext` (`auth::authenticate`) against the live
+    /// key store, then checked against `required_role`. A key without
+    /// sufficient role gets a 403, not a silent downgrade or a 401 (which
+    /// would misleadingly suggest the credential itself was invalid).
+    /// Successfully-authorized requests carry their `AuthContext` forward
+    /// via request extensions — see `handle_gui_jwt_refresh` for the one
+    /// handler in this pass that reads it.
     async fn auth_middleware(
         State(state): State<Arc<Mutex<BackendState>>>,
         ConnectInfo(addr): ConnectInfo<SocketAddr>,
-        req: Request,
+        mut req: Request,
         next: Next,
     ) -> axum::response::Response {
         if req.uri().path() == "/health" {
@@ -3887,28 +4020,68 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             .and_then(|v| v.to_str().ok());
         let token = auth::extract_bearer_token(header);
 
-        match token {
-            Some(t) if auth::verify_bearer_token(t) => next.run(req).await,
-            _ => {
-                record_audit_event(
-                    &mut lock_state(&state),
-                    "auth",
-                    "FAILED",
-                    addr.ip().to_string(),
-                    Some(format!("{} {}", req.method(), req.uri().path())),
-                );
-                (
-                    StatusCode::UNAUTHORIZED,
-                    Json(serde_json::json!({
-                        "error": {
-                            "message": "missing or invalid Authorization: Bearer <token> — see the API key printed at server startup, or POST /api/security/jwt/refresh with it to get a short-lived token",
-                            "type": "unauthorized"
-                        }
-                    })),
-                )
-                    .into_response()
+        let ctx = token.and_then(|t| auth::authenticate(t, &lock_state(&state).api_keys));
+
+        let Some(ctx) = ctx else {
+            record_audit_event(
+                &mut lock_state(&state),
+                "auth",
+                "FAILED",
+                addr.ip().to_string(),
+                Some(format!("{} {}", req.method(), req.uri().path())),
+            );
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": "missing or invalid Authorization: Bearer <token> — see the API key printed at server startup, or POST /api/security/jwt/refresh with it to get a short-lived token",
+                        "type": "unauthorized"
+                    }
+                })),
+            )
+                .into_response();
+        };
+
+        let needed = required_role(req.method(), req.uri().path());
+        if !ctx.role.satisfies(needed) {
+            record_audit_event(
+                &mut lock_state(&state),
+                "authz",
+                "DENIED",
+                addr.ip().to_string(),
+                Some(format!(
+                    "{} {} — key '{}' has role {:?}, needs {:?}",
+                    req.method(),
+                    req.uri().path(),
+                    ctx.name,
+                    ctx.role,
+                    needed
+                )),
+            );
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": format!(
+                            "key '{}' does not have sufficient permissions for this route",
+                            ctx.name
+                        ),
+                        "type": "forbidden"
+                    }
+                })),
+            )
+                .into_response();
+        }
+
+        {
+            let mut backend = lock_state(&state);
+            if let Some(record) = backend.api_keys.iter_mut().find(|k| k.id == ctx.key_id) {
+                record.last_used_at = Some(chrono::Utc::now().to_rfc3339());
             }
         }
+
+        req.extensions_mut().insert(ctx);
+        next.run(req).await
     }
 
     /// Waits for Ctrl+C, then force-tears-down every connected MCP server before
@@ -6530,23 +6703,26 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         }))
     }
 
-    /// Real JWT issuance (was a hardcoded `"new-token-123"`). Reaching this
-    /// handler at all already proves the caller presented a valid bearer
-    /// token (`auth_middleware` gates every route but `/health`) — no
-    /// separate credential to check here, just mint a fresh short-lived
-    /// token signed with the same API key that got them past the gate.
+    /// Real JWT issuance (was a hardcoded `"new-token-123"`, then a
+    /// hardcoded `"ghostlink-client"` subject once real signing landed).
+    /// Reaching this handler at all already proves the caller presented a
+    /// valid bearer token — `auth_middleware` resolved it to the
+    /// `AuthContext` extracted below before this handler ever runs — so the
+    /// issued JWT's subject is the caller's real key id, not a shared
+    /// placeholder every client's tokens would be indistinguishable under.
     async fn handle_gui_jwt_refresh(
         State(state): State<Arc<Mutex<BackendState>>>,
         ConnectInfo(addr): ConnectInfo<SocketAddr>,
+        Extension(ctx): Extension<auth::AuthContext>,
     ) -> Json<serde_json::Value> {
-        match auth::issue_jwt("ghostlink-client") {
+        match auth::issue_jwt(&ctx.key_id) {
             Ok(token) => {
                 record_audit_event(
                     &mut lock_state(&state),
                     "jwt_refresh",
                     "SUCCESS",
                     addr.ip().to_string(),
-                    None,
+                    Some(format!("key='{}'", ctx.name)),
                 );
                 Json(serde_json::json!({ "status": "ok", "token": token }))
             }
@@ -6623,6 +6799,98 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         // Most-recent-first — a log feed reads top-to-bottom as newest-first.
         let entries: Vec<&AuditLogEntry> = backend.audit_log.iter().rev().collect();
         Json(serde_json::json!({ "entries": entries }))
+    }
+
+    /// Lists every key in the RBAC store — `Admin`-gated by
+    /// `required_role`, since even a hash-free preview of who holds access
+    /// is sensitive. Never includes `key_hash` or a raw key value.
+    async fn handle_security_keys_list(
+        State(state): State<Arc<Mutex<BackendState>>>,
+    ) -> Json<serde_json::Value> {
+        let backend = lock_state(&state);
+        let entries: Vec<serde_json::Value> = backend
+            .api_keys
+            .iter()
+            .map(key_record_public_json)
+            .collect();
+        Json(serde_json::json!({ "keys": entries }))
+    }
+
+    /// Creates a new API key with the given name/role and returns its raw
+    /// value exactly once — the same "shown once, never recoverable again"
+    /// convention `auth::load_or_create_api_key`'s first-run banner already
+    /// uses, since only the key's hash is ever persisted.
+    async fn handle_security_keys_create(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
+        Json(req): Json<CreateApiKeyRequest>,
+    ) -> (StatusCode, Json<serde_json::Value>) {
+        let (record, raw) = auth::create_key(req.name.clone(), req.role);
+        let backend = &mut *lock_state(&state);
+        backend.api_keys.push(record.clone());
+        save_api_keys(&backend.api_keys);
+        record_audit_event(
+            backend,
+            "security.key.created",
+            "SUCCESS",
+            addr.ip().to_string(),
+            Some(format!(
+                "name='{}' role={:?} id={}",
+                record.name, record.role, record.id
+            )),
+        );
+        (
+            StatusCode::CREATED,
+            Json(serde_json::json!({
+                "id": record.id,
+                "name": record.name,
+                "role": record.role,
+                "key": raw,
+                "note": "this raw key is shown once and cannot be retrieved again — store it now"
+            })),
+        )
+    }
+
+    /// Revokes a key by id. Refuses (400) to remove the last remaining
+    /// `Admin` key — see `would_remove_last_admin` — since that would
+    /// permanently lock every caller out of key management with no
+    /// recovery path short of deleting `api_keys.json` and re-bootstrapping
+    /// from `api_key.txt`.
+    async fn handle_security_keys_delete(
+        State(state): State<Arc<Mutex<BackendState>>>,
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
+        Path(id): Path<String>,
+    ) -> (StatusCode, Json<serde_json::Value>) {
+        let backend = &mut *lock_state(&state);
+        match delete_key_from_store(&mut backend.api_keys, &id) {
+            Ok(removed) => {
+                save_api_keys(&backend.api_keys);
+                record_audit_event(
+                    backend,
+                    "security.key.revoked",
+                    "SUCCESS",
+                    addr.ip().to_string(),
+                    Some(format!("name='{}' id={}", removed.name, removed.id)),
+                );
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({ "status": "ok", "id": removed.id })),
+                )
+            }
+            Err((status, message)) => {
+                record_audit_event(
+                    backend,
+                    "security.key.revoke_failed",
+                    "FAILED",
+                    addr.ip().to_string(),
+                    Some(format!("id={id}: {message}")),
+                );
+                (
+                    status,
+                    Json(serde_json::json!({ "error": { "message": message } })),
+                )
+            }
+        }
     }
 
     async fn handle_gui_runtime_select(
@@ -8629,12 +8897,14 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     // choice below and `BackendState.enable_tls_active` (read by
     // `/api/security/pqc/state`) share one source of truth.
     let use_tls = settings.enable_tls || !tls::is_loopback_host(host);
-    // Eagerly generate/load (and, on first run, print) the API key here —
-    // `active_api_key()` is otherwise lazy-initialized on first use, which
-    // would mean the one-time "here's your key" banner never prints at
-    // all unless some request happens to trigger it first, leaving a
-    // fresh install with no way to discover the key it needs.
-    auth::active_api_key();
+    // Eagerly load (and, on first run, print) the API key store here —
+    // `load_api_keys()` is otherwise only reached from `BackendState`
+    // construction below, which would mean the one-time "here's your key"
+    // banner (fired the first time `auth::active_api_key()` runs, inside
+    // the bootstrap-migration path) never prints at all unless something
+    // triggers it first, leaving a fresh install with no way to discover
+    // the key it needs.
+    let api_keys = load_api_keys();
     let inference_backend = InferenceEngine::parse(&settings.inference_backend);
     let native_engine_client = native_engine::NativeEngineClient::new();
     let ollama_client = ollama::OllamaClient::new(ollama_url);
@@ -8718,6 +8988,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
         enable_tls_active: use_tls,
         audit_log: std::collections::VecDeque::new(),
+        api_keys,
         models_scan_cache: ApiResponseCache::new(),
     }));
 
@@ -8881,6 +9152,14 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             .route("/api/security/pqc/enable", post(handle_gui_pqc_enable))
             .route("/api/security/pqc/state", get(handle_gui_pqc_state))
             .route("/api/security/audit-log", get(handle_gui_audit_log))
+            .route(
+                "/api/security/keys",
+                get(handle_security_keys_list).post(handle_security_keys_create),
+            )
+            .route(
+                "/api/security/keys/:id",
+                delete(handle_security_keys_delete),
+            )
             .route("/api/inference/chat", post(handle_gui_chat))
             .route(
                 "/api/inference/chat/tool-confirm",
@@ -11271,6 +11550,7 @@ mod tests {
             enable_tls_active: false,
             plugin_registry: backend_plugin::BackendPluginRegistry::from_env(),
             audit_log: std::collections::VecDeque::new(),
+            api_keys: vec![auth::create_key("test-admin".to_string(), auth::Role::Admin).0],
             models_scan_cache: ApiResponseCache::new(),
         }))
     }
@@ -11382,6 +11662,144 @@ mod tests {
             2,
             "clearing the cache (as the download/delete handlers do) must force a rescan"
         );
+    }
+
+    #[test]
+    fn required_role_gates_key_management_and_pqc_enable_to_admin_only() {
+        use axum::http::Method;
+        assert_eq!(
+            required_role(&Method::GET, "/api/security/keys"),
+            auth::Role::Admin
+        );
+        assert_eq!(
+            required_role(&Method::POST, "/api/security/keys"),
+            auth::Role::Admin
+        );
+        assert_eq!(
+            required_role(&Method::DELETE, "/api/security/keys/key_abc"),
+            auth::Role::Admin
+        );
+        assert_eq!(
+            required_role(&Method::POST, "/api/security/pqc/enable"),
+            auth::Role::Admin
+        );
+    }
+
+    #[test]
+    fn required_role_allows_jwt_refresh_below_the_get_only_viewer_default() {
+        use axum::http::Method;
+        assert_eq!(
+            required_role(&Method::POST, "/api/security/jwt/refresh"),
+            auth::Role::Viewer
+        );
+    }
+
+    #[test]
+    fn required_role_defaults_reads_to_viewer_and_mutations_to_operator() {
+        use axum::http::Method;
+        assert_eq!(
+            required_role(&Method::GET, "/api/models"),
+            auth::Role::Viewer
+        );
+        assert_eq!(
+            required_role(&Method::HEAD, "/api/security/audit-log"),
+            auth::Role::Viewer
+        );
+        assert_eq!(
+            required_role(&Method::GET, "/api/security/pqc/state"),
+            auth::Role::Viewer,
+            "reading PQC state is a GET, distinct from POST .../pqc/enable which is Admin-only"
+        );
+        assert_eq!(
+            required_role(&Method::POST, "/api/models/load"),
+            auth::Role::Operator
+        );
+        assert_eq!(
+            required_role(&Method::DELETE, "/api/models/foo"),
+            auth::Role::Operator
+        );
+        assert_eq!(
+            required_role(&Method::PUT, "/api/settings"),
+            auth::Role::Operator
+        );
+    }
+
+    #[test]
+    fn delete_key_from_store_refuses_to_remove_the_last_admin() {
+        let (admin, _raw) = auth::create_key("only-admin".to_string(), auth::Role::Admin);
+        let mut keys = vec![admin.clone()];
+
+        let err = delete_key_from_store(&mut keys, &admin.id).expect_err("must refuse");
+        assert_eq!(err.0, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(keys.len(), 1, "the last admin key must remain in the store");
+    }
+
+    #[test]
+    fn delete_key_from_store_allows_removing_a_non_last_admin_or_any_non_admin() {
+        let (admin_a, _) = auth::create_key("admin-a".to_string(), auth::Role::Admin);
+        let (admin_b, _) = auth::create_key("admin-b".to_string(), auth::Role::Admin);
+        let (viewer, _) = auth::create_key("viewer".to_string(), auth::Role::Viewer);
+        let mut keys = vec![admin_a.clone(), admin_b.clone(), viewer.clone()];
+
+        let removed = delete_key_from_store(&mut keys, &viewer.id)
+            .expect("removing a non-admin should succeed");
+        assert_eq!(removed.id, viewer.id);
+        assert_eq!(keys.len(), 2);
+
+        let removed = delete_key_from_store(&mut keys, &admin_a.id)
+            .expect("removing one of two admins should succeed");
+        assert_eq!(removed.id, admin_a.id);
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].id, admin_b.id);
+    }
+
+    #[test]
+    fn delete_key_from_store_returns_not_found_for_an_unknown_id() {
+        let mut keys: Vec<auth::ApiKeyRecord> = vec![];
+        let err =
+            delete_key_from_store(&mut keys, "key_does_not_exist").expect_err("must not find it");
+        assert_eq!(err.0, axum::http::StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn load_api_keys_migrates_a_pre_rbac_deployment_to_a_single_bootstrap_admin() {
+        // Only `GHOSTLINK_API_KEYS_PATH` is set here, deliberately —
+        // `GHOSTLINK_API_KEY_PATH` (the legacy single-key file) is also
+        // mutated by `auth.rs`'s own tests under a separate, module-private
+        // lock, so touching it here would race across modules. `auth::
+        // active_api_key()`'s value is cached process-wide in a `OnceLock`
+        // by the time any test reaches it anyway (see auth.rs's own test
+        // comments on this) — this test only asserts the structural
+        // properties `load_api_keys` guarantees regardless of which raw
+        // key value ends up hashed into the bootstrap record: exactly one
+        // record, the fixed bootstrap id/role, persisted, idempotent reload.
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let api_keys_path = std::env::temp_dir().join(format!(
+            "ghostlink-test-rbac-migrate-{}.json",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&api_keys_path);
+        std::env::set_var("GHOSTLINK_API_KEYS_PATH", &api_keys_path);
+
+        let keys = load_api_keys();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].id, auth::BOOTSTRAP_KEY_ID);
+        assert_eq!(keys[0].role, auth::Role::Admin);
+        assert!(
+            api_keys_path.exists(),
+            "the migrated store must be persisted"
+        );
+
+        let reloaded = load_api_keys();
+        assert_eq!(
+            reloaded.len(),
+            1,
+            "a second load must reuse the persisted store, not synthesize a second bootstrap key"
+        );
+        assert_eq!(reloaded[0].id, keys[0].id);
+
+        std::env::remove_var("GHOSTLINK_API_KEYS_PATH");
+        let _ = std::fs::remove_file(&api_keys_path);
     }
 
     #[tokio::test]

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -1653,7 +1653,7 @@ struct BackendState {
     /// restart) and capped at `AUDIT_LOG_CAP`; a genuinely persistent trail
     /// would need an append-only file, which is a bigger step than this
     /// first real version takes.
-    audit_log: std::collections::VecDeque<AuditLogEntry>,
+    audit_log: std::collections::VecDeque<audit_log::AuditLogEntry>,
     /// The live RBAC key store — every `auth_middleware` check and the new
     /// `/api/security/keys` admin endpoints read/write this. Loaded once at
     /// startup via `load_api_keys()` (which handles the bootstrap migration
@@ -1669,33 +1669,6 @@ struct BackendState {
     models_scan_cache: ApiResponseCache,
 }
 
-/// One row for the GUI's Security tab audit log — field names/shape match
-/// what `SecurityTab.tsx` already expects (it predates a real backend for
-/// this and was rendering against a permanently-empty list).
-#[derive(Debug, Clone, Serialize)]
-struct AuditLogEntry {
-    event: String,
-    /// "SUCCESS"/"AUTHENTICATED" render green in the GUI; anything else
-    /// (e.g. "FAILED", "DENIED") renders as a yellow warning badge.
-    status: String,
-    ip: String,
-    /// RFC3339 — the GUI does `new Date(e.time)` on this directly.
-    time: String,
-    detail: Option<String>,
-}
-
-const AUDIT_LOG_CAP: usize = 500;
-
-/// Appends one entry and trims from the front once over `AUDIT_LOG_CAP` —
-/// split out from `record_audit_event` so it's unit-testable against a bare
-/// `VecDeque` without needing to construct a full `BackendState`.
-fn push_audit_entry(log: &mut std::collections::VecDeque<AuditLogEntry>, entry: AuditLogEntry) {
-    log.push_back(entry);
-    while log.len() > AUDIT_LOG_CAP {
-        log.pop_front();
-    }
-}
-
 fn record_audit_event(
     backend: &mut BackendState,
     event: &str,
@@ -1703,20 +1676,24 @@ fn record_audit_event(
     ip: String,
     detail: Option<String>,
 ) {
-    push_audit_entry(
-        &mut backend.audit_log,
-        AuditLogEntry {
-            event: event.to_string(),
-            status: status.to_string(),
-            ip,
-            time: chrono::Utc::now().to_rfc3339(),
-            detail,
-        },
-    );
+    let entry = audit_log::AuditLogEntry {
+        event: event.to_string(),
+        status: status.to_string(),
+        ip,
+        time: chrono::Utc::now().to_rfc3339(),
+        detail,
+    };
+    audit_log::push_audit_entry(&mut backend.audit_log, entry.clone());
+    // Durable, restart-surviving trail — the in-memory VecDeque above stays
+    // capped and fast for the GUI's live feed; this is the complete history
+    // `GET /api/security/audit-log/export` reads from. Best-effort: a write
+    // failure is warned, not propagated, matching every other persistence
+    // function in this codebase.
+    audit_log::append_durable(&entry);
 }
 
 /// Minimum role required to access a route. A method-based default
-/// (GET/HEAD need only `Viewer`, every mutation needs `Operator`) plus two
+/// (GET/HEAD need only `Viewer`, every mutation needs `Operator`) plus
 /// named `Admin`-only carve-outs — not a per-route table, so it stays
 /// correct as new routes are added without a matching new entry each time.
 /// `/health` is exempted from auth entirely in `auth_middleware`, never
@@ -1724,8 +1701,15 @@ fn record_audit_event(
 /// carve-out below the GET-only `Viewer` default: proving identity isn't a
 /// mutation of server state, so every authenticated key — including
 /// `Viewer` — may exchange its key for a JWT.
+/// `/api/security/audit-log/export` is `Admin`-only despite being a GET,
+/// unlike the plain (capped, in-memory) `/api/security/audit-log`, which
+/// stays `Viewer`-readable: a bulk historical export is a materially
+/// different exposure than a live tail of the last 500 events.
 fn required_role(method: &axum::http::Method, path: &str) -> auth::Role {
-    if path.starts_with("/api/security/keys") || path == "/api/security/pqc/enable" {
+    if path.starts_with("/api/security/keys")
+        || path == "/api/security/pqc/enable"
+        || path.starts_with("/api/security/audit-log/export")
+    {
         return auth::Role::Admin;
     }
     if path == "/api/security/jwt/refresh" {
@@ -6850,8 +6834,35 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     ) -> Json<serde_json::Value> {
         let backend = lock_state(&state);
         // Most-recent-first — a log feed reads top-to-bottom as newest-first.
-        let entries: Vec<&AuditLogEntry> = backend.audit_log.iter().rev().collect();
+        let entries: Vec<&audit_log::AuditLogEntry> = backend.audit_log.iter().rev().collect();
         Json(serde_json::json!({ "entries": entries }))
+    }
+
+    /// Exports the **full** durable audit trail (`audit_log::read_all_durable`),
+    /// not just the capped, in-memory, most-recent-500 view
+    /// `handle_gui_audit_log` serves — this is the SIEM-integration path
+    /// `docs/ROADMAP.md`'s Enterprise Trust Track names. `Admin`-gated in
+    /// `required_role` (a bulk historical export is a materially different
+    /// exposure than the existing capped live tail, which stays
+    /// `Viewer`-readable). `?format=json` (default) returns the same
+    /// `{"entries": [...]}` shape as the live endpoint; `?format=cef`
+    /// returns newline-separated CEF lines as `text/plain`.
+    async fn handle_security_audit_log_export(
+        Query(params): Query<HashMap<String, String>>,
+    ) -> axum::response::Response {
+        let entries = audit_log::read_all_durable();
+        match params.get("format").map(String::as_str) {
+            Some("cef") => (
+                StatusCode::OK,
+                [(
+                    axum::http::header::CONTENT_TYPE,
+                    "text/plain; charset=utf-8",
+                )],
+                audit_log::export_cef(&entries),
+            )
+                .into_response(),
+            _ => Json(serde_json::json!({ "entries": entries })).into_response(),
+        }
     }
 
     /// Lists every key in the RBAC store — `Admin`-gated by
@@ -9223,6 +9234,10 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             .route("/api/security/pqc/state", get(handle_gui_pqc_state))
             .route("/api/security/audit-log", get(handle_gui_audit_log))
             .route(
+                "/api/security/audit-log/export",
+                get(handle_security_audit_log_export),
+            )
+            .route(
                 "/api/security/keys",
                 get(handle_security_keys_list).post(handle_security_keys_create),
             )
@@ -11349,6 +11364,7 @@ fn run_gui_preflight_checks() -> Result<()> {
     Ok(())
 }
 
+mod audit_log;
 mod auth;
 mod backend_api;
 mod backend_config;
@@ -11636,40 +11652,8 @@ mod tests {
         std::env::remove_var("GHOSTLINK_NODE_ID");
     }
 
-    fn audit_entry(event: &str) -> AuditLogEntry {
-        AuditLogEntry {
-            event: event.to_string(),
-            status: "SUCCESS".to_string(),
-            ip: "127.0.0.1".to_string(),
-            time: chrono::Utc::now().to_rfc3339(),
-            detail: None,
-        }
-    }
-
-    #[test]
-    fn push_audit_entry_appends_in_order() {
-        let mut log = std::collections::VecDeque::new();
-        push_audit_entry(&mut log, audit_entry("first"));
-        push_audit_entry(&mut log, audit_entry("second"));
-        assert_eq!(log.len(), 2);
-        assert_eq!(log[0].event, "first");
-        assert_eq!(log[1].event, "second");
-    }
-
-    #[test]
-    fn push_audit_entry_trims_oldest_once_over_cap() {
-        let mut log = std::collections::VecDeque::new();
-        for i in 0..(AUDIT_LOG_CAP + 10) {
-            push_audit_entry(&mut log, audit_entry(&format!("event-{i}")));
-        }
-        assert_eq!(log.len(), AUDIT_LOG_CAP, "must never grow past the cap");
-        // The oldest 10 were pushed out; the front is now event-10.
-        assert_eq!(log.front().unwrap().event, "event-10");
-        assert_eq!(
-            log.back().unwrap().event,
-            format!("event-{}", AUDIT_LOG_CAP + 9)
-        );
-    }
+    // `push_audit_entry`/`AUDIT_LOG_CAP` tests moved to `audit_log.rs`
+    // alongside the durable-trail/CEF-export code they now live next to.
 
     #[test]
     fn test_parse_usize_arg() {

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -150,8 +150,8 @@ struct FlowOptions<'a> {
 }
 
 fn main() -> Result<()> {
-    // Initialize logging
-    tracing_subscriber::fmt().init();
+    // Initialize logging (+ optional OTel trace export — see otel.rs)
+    otel::init_tracing();
 
     let raw_args = std::env::args().skip(1).collect::<Vec<_>>();
     let bootstrap = extract_bootstrap_args(raw_args)?;
@@ -3989,6 +3989,8 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
     use std::sync::{Arc, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
     use tower_http::cors::CorsLayer;
+    use tower_http::trace::TraceLayer;
+    use tracing::Instrument;
 
     fn lock_state(state: &Arc<Mutex<BackendState>>) -> std::sync::MutexGuard<'_, BackendState> {
         state.lock().unwrap_or_else(|poison| poison.into_inner())
@@ -5263,7 +5265,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         // qualifying peers, or (once `rpc_shared_secret` is set) every peer
         // fails the handshake — all of which reproduce single-node
         // behavior exactly.
-        let (rpc_servers, tensor_split) = {
+        let (rpc_servers, tensor_split) = async {
             let (peers, local_vram, local_system_memory, shared_secret) = {
                 let backend = lock_state(&state);
                 if backend.settings.distributed_inference {
@@ -5333,7 +5335,9 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
                     Some(rpc_cluster::tensor_split_flag_value(&split)),
                 )
             }
-        };
+        }
+        .instrument(tracing::info_span!("rpc_peer_discovery_and_admission"))
+        .await;
 
         // Extract model info and settings under the lock, then drop it before
         // the potentially-long blocking load_model_into_slot call.
@@ -5435,12 +5439,22 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             // `load_model_into_slot` is about to tear down and rebind, and
             // serializes this against any other concurrent load/unload.
             let _model_swap_guard = model_lifecycle_lock.write().await;
-            let result = tokio::task::spawn_blocking(move || {
-                native_engine_client.load_model_into_slot(
-                    &path,
-                    rpc_servers.as_deref(),
-                    tensor_split.as_deref(),
-                )
+            // Span entered *inside* the spawn_blocking closure, not just
+            // wrapped around the outer .await — spawn_blocking runs on a
+            // separate OS thread, so tracing::Instrument on the future alone
+            // wouldn't attribute the actual load work (which happens on
+            // that other thread) to this span.
+            let load_span = tracing::info_span!("model_load", model = %selected_model);
+            let result = tokio::task::spawn_blocking({
+                let load_span = load_span.clone();
+                move || {
+                    let _guard = load_span.enter();
+                    native_engine_client.load_model_into_slot(
+                        &path,
+                        rpc_servers.as_deref(),
+                        tensor_split.as_deref(),
+                    )
+                }
             })
             .await
             .map_err(|e| format!("task join error: {}", e))
@@ -5455,12 +5469,17 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         } else if let Some(path) = local_path.clone() {
             if native_engine == "llama_server" || native_engine == "llama-server" {
                 let _model_swap_guard = model_lifecycle_lock.write().await;
-                let result = tokio::task::spawn_blocking(move || {
-                    native_engine_client.load_model_into_slot(
-                        &path,
-                        rpc_servers.as_deref(),
-                        tensor_split.as_deref(),
-                    )
+                let load_span = tracing::info_span!("model_load", model = %selected_model);
+                let result = tokio::task::spawn_blocking({
+                    let load_span = load_span.clone();
+                    move || {
+                        let _guard = load_span.enter();
+                        native_engine_client.load_model_into_slot(
+                            &path,
+                            rpc_servers.as_deref(),
+                            tensor_split.as_deref(),
+                        )
+                    }
                 })
                 .await
                 .map_err(|e| format!("task join error: {}", e))
@@ -7543,6 +7562,14 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         (kept, truncated)
     }
 
+    // `inference_generate` span covers the whole chat turn (including any
+    // tool-calling round trips, not just the raw generate call) — this
+    // handler has multiple `.generate()` call sites across its
+    // native/Ollama/vLLM/tool-loop branches, so a function-level
+    // `#[instrument]` is the safer, still-accurate placement rather than
+    // wrapping each call site individually. `skip_all` since several of the
+    // captured backend clients/registries aren't `Debug`.
+    #[tracing::instrument(name = "inference_generate", skip_all)]
     async fn handle_gui_chat(
         State(state): State<Arc<Mutex<BackendState>>>,
         Json(req): Json<GuiChatRequest>,
@@ -9304,7 +9331,14 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
             .layer(CorsLayer::permissive())
             .layer(tower_governor::GovernorLayer {
                 config: governor_conf,
-            });
+            })
+            // Outermost — the automatic root span (method/URI/status/latency)
+            // this creates per request should cover everything below it,
+            // including rate-limiting and CORS. Exported as a real OTel
+            // trace when otel::init_tracing() registered the export layer
+            // (see otel.rs); otherwise it's just a normal tracing event, no
+            // behavior change from before this existed.
+            .layer(TraceLayer::new_for_http());
 
         // addr already parsed above; `use_tls` computed earlier alongside
         // `BackendState.enable_tls_active`.
@@ -11375,6 +11409,7 @@ mod inference_engine;
 mod mcp;
 mod native_engine;
 mod ollama;
+mod otel;
 mod rpc_cluster;
 mod runtime;
 mod runtime_switcher;

--- a/crates/ghost-link/src/otel.rs
+++ b/crates/ghost-link/src/otel.rs
@@ -1,0 +1,167 @@
+//! Optional OpenTelemetry tracing export.
+//!
+//! `tracing` is used elsewhere in this codebase purely as a logging facade
+//! (`tracing::warn!`/`info!`) — this module adds real span export on top,
+//! entirely opt-in. When `GHOSTLINK_OTEL_EXPORTER_ENDPOINT` is unset, this
+//! reproduces the exact plain-text console logging this codebase has always
+//! had (`tracing_subscriber::fmt().init()`), byte-for-byte, zero behavior
+//! change. When set, spans — the HTTP root span from `tower-http`'s
+//! `TraceLayer`, plus the hand-instrumented phase spans in the
+//! distributed-inference model-load path — are additionally exported via
+//! OTLP/HTTP to whatever collector/backend the endpoint points at.
+//!
+//! Real cross-process trace propagation through the actual `ggml-rpc` TCP
+//! hop is **not** attempted — upstream llama.cpp's `--rpc` client speaks a
+//! raw binary protocol with no header/metadata slot for W3C trace-context
+//! propagation, the same hard constraint `rpc_cluster.rs` hit building RPC
+//! peer auth. A trace ends at "launched llama-server, here's how long it
+//! took," not a per-remote-device breakdown of an RPC hop.
+//!
+//! Deliberately uses the SDK's **synchronous** `SimpleSpanProcessor`
+//! (`reqwest-blocking-client`, not the async reqwest client) rather than
+//! the batched processor: this is initialized in `main()` before any tokio
+//! runtime exists (`main()` dispatches several non-`serve` subcommands too,
+//! e.g. `flow`/`stage-worker`/`probe`), so the exporter's HTTP client must
+//! not depend on an ambient async reactor. At the span volumes this first
+//! pass produces — a handful of spans per request, not per-token —
+//! synchronous export is a non-issue; a batched upgrade is a fine future
+//! optimization if trace volume ever grows.
+
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::Resource;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Reads `GHOSTLINK_OTEL_EXPORTER_ENDPOINT` — `None`/empty means tracing
+/// export is off. An env var, not a `settings.json` field: the subscriber
+/// has to be initialized before `settings.json` is even loaded.
+pub fn otel_endpoint() -> Option<String> {
+    std::env::var("GHOSTLINK_OTEL_EXPORTER_ENDPOINT")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// `service.name` resource attribute — `GHOSTLINK_OTEL_SERVICE_NAME`
+/// override, defaulting to `"ghost-link"`.
+fn service_name() -> String {
+    std::env::var("GHOSTLINK_OTEL_SERVICE_NAME")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "ghost-link".to_string())
+}
+
+/// Initializes the global `tracing` subscriber — the single call site
+/// `main()` makes, replacing the previous bare
+/// `tracing_subscriber::fmt().init()`. Console logging (`fmt`) is always
+/// active; the OTel export layer is added alongside it only when
+/// `otel_endpoint()` returns `Some`, so console output is identical either
+/// way. A failure to build the OTLP exporter (a bad endpoint URL, etc.) is
+/// best-effort — warns and falls back to console-only logging rather than
+/// failing the whole process over a misconfigured trace endpoint, matching
+/// every other optional-feature failure mode in this codebase.
+pub fn init_tracing() {
+    let fmt_layer = tracing_subscriber::fmt::layer();
+
+    let Some(endpoint) = otel_endpoint() else {
+        tracing_subscriber::registry().with(fmt_layer).init();
+        return;
+    };
+
+    match build_tracer(&endpoint) {
+        Ok(tracer) => {
+            let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+            tracing_subscriber::registry()
+                .with(fmt_layer)
+                .with(otel_layer)
+                .init();
+            tracing::info!("otel: exporting traces to {endpoint}");
+        }
+        Err(err) => {
+            tracing_subscriber::registry().with(fmt_layer).init();
+            tracing::warn!(
+                "otel: failed to initialize OTLP export to {endpoint}: {err} — continuing with \
+                 console logging only"
+            );
+        }
+    }
+}
+
+fn build_tracer(endpoint: &str) -> Result<opentelemetry_sdk::trace::SdkTracer, String> {
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint)
+        .build()
+        .map_err(|err| err.to_string())?;
+
+    let resource = Resource::builder()
+        .with_service_name(service_name())
+        .with_attribute(opentelemetry::KeyValue::new(
+            "service.version",
+            env!("CARGO_PKG_VERSION"),
+        ))
+        .build();
+
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter)
+        .with_resource(resource)
+        .build();
+
+    Ok(provider.tracer("ghost-link"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    // Real env var mutation — serialized like every other env-var-mutating
+    // test in this codebase (see auth.rs's own env_lock), since these vars
+    // are process-global and `cargo test` runs in parallel by default.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn otel_endpoint_is_none_when_unset_or_whitespace_only() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        std::env::remove_var("GHOSTLINK_OTEL_EXPORTER_ENDPOINT");
+        assert_eq!(otel_endpoint(), None);
+
+        std::env::set_var("GHOSTLINK_OTEL_EXPORTER_ENDPOINT", "   ");
+        assert_eq!(
+            otel_endpoint(),
+            None,
+            "whitespace-only must count as unset, not a literal '   ' endpoint"
+        );
+
+        std::env::remove_var("GHOSTLINK_OTEL_EXPORTER_ENDPOINT");
+    }
+
+    #[test]
+    fn otel_endpoint_returns_trimmed_value_when_set() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        std::env::set_var(
+            "GHOSTLINK_OTEL_EXPORTER_ENDPOINT",
+            "  http://localhost:4318  ",
+        );
+        assert_eq!(otel_endpoint(), Some("http://localhost:4318".to_string()));
+        std::env::remove_var("GHOSTLINK_OTEL_EXPORTER_ENDPOINT");
+    }
+
+    #[test]
+    fn service_name_defaults_and_honors_override() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        std::env::remove_var("GHOSTLINK_OTEL_SERVICE_NAME");
+        assert_eq!(service_name(), "ghost-link");
+
+        std::env::set_var("GHOSTLINK_OTEL_SERVICE_NAME", "my-service");
+        assert_eq!(service_name(), "my-service");
+
+        std::env::remove_var("GHOSTLINK_OTEL_SERVICE_NAME");
+    }
+}

--- a/crates/ghost-link/src/rpc_cluster.rs
+++ b/crates/ghost-link/src/rpc_cluster.rs
@@ -37,17 +37,132 @@
 //! a source IP on the local network, is not stopped by this. Only enable
 //! `contribute_compute` (allowlisted or not) on a network you trust, same
 //! assumption the existing UDP/mDNS discovery already makes.
+//!
+//! `rpc_shared_secret` (settings.json) closes that specific gap: a real
+//! pre-connection handshake, not just a source-address check. When
+//! configured, a contributing node also listens on a small dedicated **auth
+//! port** (`rpc_port + RPC_AUTH_PORT_OFFSET`). Before a coordinator opens
+//! the real `--rpc` connection, it first connects there, receives a fresh
+//! random nonce, and sends back `HMAC-SHA256(rpc_shared_secret, nonce)`. A
+//! match temporarily admits that source IP (`admit_peer`, `RPC_ADMISSION_TTL`)
+//! — the allowlist proxy then requires a *live* admission in addition to
+//! the static IP allowlist for that source before splicing the real
+//! connection through. A fresh nonce per handshake means a captured
+//! response can't be replayed against a later connection.
+//!
+//! `llama-server`'s own `--rpc` connection code (upstream llama.cpp) speaks
+//! zero custom handshake — it starts sending raw `ggml-rpc` binary protocol
+//! the instant it connects. So this handshake cannot live inside that same
+//! TCP stream; it's a separate connection, done by Ghostlink's own processes
+//! on both ends, purely to admit a source IP before `llama-server` ever
+//! dials the real port.
+//!
+//! Scope, honestly stated: this proves the connecting node held the secret
+//! *at admission time* and temporarily authorizes its current source IP —
+//! it does **not** encrypt or authenticate the actual `ggml-rpc` byte stream
+//! itself (still plain TCP, the same upstream limitation as above), and an
+//! on-path attacker able to inject traffic from the same source IP during
+//! the admission window isn't stopped by it. True wire-level confidentiality
+//! would need a dual-proxy TLS tunnel on both ends (reusing `tls.rs`'s
+//! existing cert infra) — a larger follow-up, not attempted here. Empty (the
+//! default), no auth port is started and the allowlist proxy's behavior is
+//! completely unchanged from before this existed.
 
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use tokio::io::copy_bidirectional;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Handle;
 
 use ghostlink_core::cluster::{ClusterState, NodeStatus};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Offset added to the publicly-advertised `rpc_port` to derive the port
+/// the RPC-auth handshake listener binds to, when `rpc_shared_secret` is
+/// configured. Distinct from `RPC_INTERNAL_PORT_OFFSET` (a different
+/// mechanism, the loopback `ggml-rpc-server` bind).
+const RPC_AUTH_PORT_OFFSET: u16 = 2000;
+
+/// How long a successful handshake admits a source IP for. Long enough to
+/// cover the real `--rpc` connection immediately following it, short enough
+/// to keep the exposure window narrow.
+const RPC_ADMISSION_TTL: Duration = Duration::from_secs(30);
+
+/// Server-side per-step timeout for the auth handshake (write nonce, read
+/// MAC) — bounds how long a slow or hung connection can occupy a task.
+const RPC_AUTH_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Client-side timeout for the whole `admit_via_secret` attempt (connect +
+/// full handshake) — kept short so one unreachable/misconfigured peer can't
+/// meaningfully delay a distributed model load.
+const RPC_AUTH_CLIENT_TIMEOUT: Duration = Duration::from_secs(3);
+
+const RPC_NONCE_LEN: usize = 16;
+const RPC_MAC_LEN: usize = 32; // HMAC-SHA256 output size
+
+/// Computes `HMAC-SHA256(secret, nonce)` — shared by the server-side
+/// handshake handler (verifying a client's response) and `admit_via_secret`
+/// (producing one). HMAC accepts a key of any length per RFC 2104 (long
+/// keys are hashed down internally), so this never fails in practice.
+fn compute_hmac(secret: &str, nonce: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .expect("HMAC-SHA256 accepts a key of any length, per RFC 2104");
+    mac.update(nonce);
+    mac.finalize().into_bytes().to_vec()
+}
+
+static RPC_ADMISSIONS: OnceLock<Arc<Mutex<HashMap<IpAddr, Instant>>>> = OnceLock::new();
+
+fn admissions_registry() -> Arc<Mutex<HashMap<IpAddr, Instant>>> {
+    RPC_ADMISSIONS
+        .get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+        .clone()
+}
+
+/// Pure expiry check, split out from the process-global registry so it's
+/// unit-testable against constructed `Instant` values without waiting on
+/// real wall-clock time — matching this file's existing
+/// `run_rpc_allowlist_proxy`/`serve_rpc_allowlist_proxy` split.
+fn admission_is_valid(expiry: Instant, now: Instant) -> bool {
+    now < expiry
+}
+
+/// Records `ip` as admitted for `RPC_ADMISSION_TTL` from now. Called by the
+/// auth-port handshake handler on a successful HMAC match.
+fn admit_peer(ip: IpAddr) {
+    let registry = admissions_registry();
+    let mut guard = registry.lock().unwrap_or_else(|p| p.into_inner());
+    guard.insert(ip, Instant::now() + RPC_ADMISSION_TTL);
+}
+
+/// Whether `ip` currently holds a live admission grant. Opportunistically
+/// prunes expired entries on every check — the registry only ever holds as
+/// many entries as recently-handshaking peers, so this stays cheap.
+fn is_admitted(ip: &IpAddr) -> bool {
+    let registry = admissions_registry();
+    let mut guard = registry.lock().unwrap_or_else(|p| p.into_inner());
+    let now = Instant::now();
+    guard.retain(|_, expiry| admission_is_valid(*expiry, now));
+    guard.contains_key(ip)
+}
+
+/// Pure gating decision for one inbound proxy connection, split out from
+/// `serve_rpc_allowlist_proxy` so it's unit-testable directly — without
+/// real sockets or the process-global admissions registry, which every
+/// loopback-socket test in this file's suite shares a single source IP
+/// against (127.0.0.1), making "is NOT admitted" unreliable to assert from
+/// a real connection once any other test has legitimately admitted it.
+fn connection_allowed(ip_ok: bool, require_admission: bool, admitted: bool) -> bool {
+    ip_ok && (!require_admission || admitted)
+}
 
 /// Offset added to the publicly-advertised `rpc_port` to derive the
 /// loopback-only port `ggml-rpc-server` actually binds to when the
@@ -136,18 +251,22 @@ pub fn get_rpc_server_bin() -> String {
 /// a failure to start is logged, not fatal, mirroring how UDP/mDNS discovery
 /// failures never block server startup elsewhere in this codebase.
 ///
-/// When `allowed_peers` is non-empty, `ggml-rpc-server` is bound
-/// loopback-only and an allowlist proxy (spawned onto `rt_handle`, since
-/// this function itself isn't async and may be called before the tokio
-/// runtime's `block_on` starts) is stood up on the publicly-advertised
-/// `bind_host:port` in front of it — see this module's top-of-file SECURITY
-/// doc. When `allowed_peers` is empty, `ggml-rpc-server` binds
-/// `bind_host:port` directly, exactly as before this allowlist existed: no
-/// proxy, no extra hop, no behavior change for the default case.
+/// When `allowed_peers` and/or `shared_secret` is configured,
+/// `ggml-rpc-server` is bound loopback-only and an allowlist proxy (spawned
+/// onto `rt_handle`, since this function itself isn't async and may be
+/// called before the tokio runtime's `block_on` starts) is stood up on the
+/// publicly-advertised `bind_host:port` in front of it — see this module's
+/// top-of-file SECURITY doc. A non-empty `shared_secret` also starts the
+/// RPC-auth handshake listener and makes the proxy require a live admission
+/// grant, not just allowlist membership. When both are empty,
+/// `ggml-rpc-server` binds `bind_host:port` directly, exactly as before
+/// either existed: no proxy, no extra hop, no behavior change for the
+/// default case.
 pub fn ensure_contributing(
     bind_host: &str,
     port: u16,
     allowed_peers: &[String],
+    shared_secret: &str,
     rt_handle: &Handle,
 ) {
     let handle = contributor_handle();
@@ -158,33 +277,50 @@ pub fn ensure_contributing(
         }
     }
 
-    let (spawn_host, spawn_port): (String, u16) = if allowed_peers.is_empty() {
+    let use_proxy = !allowed_peers.is_empty() || !shared_secret.is_empty();
+    let (spawn_host, spawn_port): (String, u16) = if !use_proxy {
         (bind_host.to_string(), port)
     } else {
         let internal_port = port.saturating_add(RPC_INTERNAL_PORT_OFFSET);
-        maybe_start_allowlist_proxy(bind_host, port, internal_port, allowed_peers, rt_handle);
+        maybe_start_allowlist_proxy(
+            bind_host,
+            port,
+            internal_port,
+            allowed_peers,
+            shared_secret,
+            rt_handle,
+        );
         ("127.0.0.1".to_string(), internal_port)
     };
+    maybe_start_auth_port(bind_host, port, shared_secret, rt_handle);
 
     let bin = get_rpc_server_bin();
-    if allowed_peers.is_empty() {
+    if !use_proxy {
         tracing::warn!(
             "rpc_cluster: starting ggml-rpc-server on {spawn_host}:{spawn_port} \u{2014} this \
              exposes local compute (GPU/CPU) to the network with NO AUTHENTICATION (an upstream \
-             llama.cpp limitation, not Ghostlink's) and NO IP ALLOWLIST (rpc_allowed_peers is \
-             empty). Only enable contribute_compute on a network you trust, the same assumption \
-             UDP/mDNS discovery already makes. Set rpc_allowed_peers in settings to restrict \
-             which hosts may submit compute jobs."
+             llama.cpp limitation, not Ghostlink's), NO IP ALLOWLIST (rpc_allowed_peers is \
+             empty), and NO SHARED-SECRET HANDSHAKE (rpc_shared_secret is empty). Only enable \
+             contribute_compute on a network you trust, the same assumption UDP/mDNS discovery \
+             already makes. Set rpc_allowed_peers and/or rpc_shared_secret in settings to \
+             restrict which hosts may submit compute jobs."
         );
     } else {
         tracing::warn!(
             "rpc_cluster: starting ggml-rpc-server on loopback ({spawn_host}:{spawn_port}), \
              fronted by an allowlist proxy on {bind_host}:{port} restricted to {} \
-             rpc_allowed_peers entries \u{2014} ggml-rpc-server itself still has NO \
-             AUTHENTICATION (an upstream llama.cpp limitation), so this is access control, not \
-             protocol-level auth. A device already inside an allowlisted range isn't stopped by \
-             this.",
-            allowed_peers.len()
+             rpc_allowed_peers entries{} \u{2014} ggml-rpc-server itself still has NO \
+             AUTHENTICATION of its own (an upstream llama.cpp limitation).",
+            allowed_peers.len(),
+            if shared_secret.is_empty() {
+                ", with NO rpc_shared_secret handshake required \u{2014} a device already \
+                 inside an allowlisted range isn't stopped by IP allowlisting alone"
+                    .to_string()
+            } else {
+                ", and requiring a live rpc_shared_secret handshake admission before splicing \
+                 any connection through"
+                    .to_string()
+            }
         );
     }
 
@@ -275,6 +411,7 @@ fn maybe_start_allowlist_proxy(
     public_port: u16,
     internal_port: u16,
     allowed_peers: &[String],
+    shared_secret: &str,
     rt_handle: &Handle,
 ) {
     if RPC_ALLOWLIST_PROXY_STARTED.get().is_some() {
@@ -295,6 +432,7 @@ fn maybe_start_allowlist_proxy(
     };
     let backend_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), internal_port);
     let allowed = allowed_peers.to_vec();
+    let require_admission = !shared_secret.is_empty();
 
     // Only the thread whose `set()` succeeds spawns — race-free without an
     // extra Mutex, and cheap even under the (practically impossible, given
@@ -302,7 +440,9 @@ fn maybe_start_allowlist_proxy(
     // `contributor_handle()` lock) case of concurrent first calls.
     if RPC_ALLOWLIST_PROXY_STARTED.set(()).is_ok() {
         rt_handle.spawn(async move {
-            if let Err(err) = run_rpc_allowlist_proxy(public_addr, backend_addr, allowed).await {
+            if let Err(err) =
+                run_rpc_allowlist_proxy(public_addr, backend_addr, allowed, require_admission).await
+            {
                 tracing::warn!(
                     "rpc_cluster: rpc_allowed_peers proxy on {public_addr} exited with error: \
                      {err} \u{2014} the node will stop accepting distributed-inference compute \
@@ -321,28 +461,34 @@ async fn run_rpc_allowlist_proxy(
     public_addr: SocketAddr,
     backend_addr: SocketAddr,
     allowed_peers: Vec<String>,
+    require_admission: bool,
 ) -> std::io::Result<()> {
     let listener = TcpListener::bind(public_addr).await?;
     tracing::info!(
         "rpc_cluster: rpc_allowed_peers proxy listening on {public_addr}, forwarding allowed \
-         peers to ggml-rpc-server at {backend_addr} ({} allowlist entries)",
-        allowed_peers.len()
+         peers to ggml-rpc-server at {backend_addr} ({} allowlist entries, require_admission={})",
+        allowed_peers.len(),
+        require_admission
     );
-    serve_rpc_allowlist_proxy(listener, backend_addr, allowed_peers).await
+    serve_rpc_allowlist_proxy(listener, backend_addr, allowed_peers, require_admission).await
 }
 
 /// Accept loop shared by `run_rpc_allowlist_proxy` and its tests: for each
 /// inbound connection, checks the peer's source IP against `allowed_peers`
-/// (`ip_allowed`) and either splices it through to `backend_addr` via
-/// `tokio::io::copy_bidirectional`, or drops it immediately with a
-/// `tracing::warn!` naming the rejected IP. Split out from
-/// `run_rpc_allowlist_proxy` so tests can bind an ephemeral loopback port
-/// themselves (avoiding a bind/rebind race) instead of going through a
+/// (`ip_allowed`) and, when `require_admission` is set, also requires a
+/// live `rpc_shared_secret` handshake admission (`is_admitted`) for that
+/// source IP — see this module's top-of-file SECURITY doc. A connection
+/// passing both checks is spliced through to `backend_addr` via
+/// `tokio::io::copy_bidirectional`; anything else is dropped immediately
+/// with a `tracing::warn!` naming the rejected IP and reason. Split out
+/// from `run_rpc_allowlist_proxy` so tests can bind an ephemeral loopback
+/// port themselves (avoiding a bind/rebind race) instead of going through a
 /// fixed `SocketAddr`.
 async fn serve_rpc_allowlist_proxy(
     listener: TcpListener,
     backend_addr: SocketAddr,
     allowed_peers: Vec<String>,
+    require_admission: bool,
 ) -> std::io::Result<()> {
     loop {
         let (inbound, peer_addr) = match listener.accept().await {
@@ -353,11 +499,17 @@ async fn serve_rpc_allowlist_proxy(
             }
         };
 
-        if !ip_allowed(&peer_addr.ip(), &allowed_peers) {
+        let ip_ok = ip_allowed(&peer_addr.ip(), &allowed_peers);
+        let admitted = is_admitted(&peer_addr.ip());
+        if !connection_allowed(ip_ok, require_admission, admitted) {
             tracing::warn!(
-                "rpc_cluster: rejected ggml-rpc-server connection from {} \u{2014} not in \
-                 rpc_allowed_peers",
-                peer_addr.ip()
+                "rpc_cluster: rejected ggml-rpc-server connection from {} \u{2014} {}",
+                peer_addr.ip(),
+                if !ip_ok {
+                    "not in rpc_allowed_peers"
+                } else {
+                    "no live rpc_shared_secret admission for this source IP"
+                }
             );
             continue; // dropping `inbound` closes the connection
         }
@@ -380,6 +532,178 @@ async fn serve_rpc_allowlist_proxy(
                 }
             }
         });
+    }
+}
+
+/// Starts the RPC-auth handshake listener exactly once per process, the
+/// first time `ensure_contributing` sees a non-empty `secret` — mirrors
+/// `maybe_start_allowlist_proxy`'s `OnceLock`-guarded, `rt_handle`-spawned
+/// pattern for the same reason (this function isn't async, may run before
+/// the tokio runtime's `block_on` starts, and the periodic 30s
+/// respawn-supervision loop must not try to rebind every call).
+static RPC_AUTH_PORT_STARTED: OnceLock<()> = OnceLock::new();
+
+fn maybe_start_auth_port(bind_host: &str, rpc_port: u16, secret: &str, rt_handle: &Handle) {
+    if secret.is_empty() || RPC_AUTH_PORT_STARTED.get().is_some() {
+        return;
+    }
+
+    let auth_port = rpc_port.saturating_add(RPC_AUTH_PORT_OFFSET);
+    let addr_str = format!("{bind_host}:{auth_port}");
+    let addr: SocketAddr = match addr_str.parse() {
+        Ok(addr) => addr,
+        Err(err) => {
+            tracing::warn!(
+                "rpc_cluster: cannot start the RPC auth-port listener \u{2014} invalid bind \
+                 address '{addr_str}': {err}. rpc_shared_secret admission will never succeed \
+                 until this is fixed."
+            );
+            return;
+        }
+    };
+    let secret = secret.to_string();
+
+    if RPC_AUTH_PORT_STARTED.set(()).is_ok() {
+        rt_handle.spawn(async move {
+            if let Err(err) = run_rpc_auth_port(addr, secret).await {
+                tracing::warn!(
+                    "rpc_cluster: RPC auth-port listener on {addr} exited with error: {err} \
+                     \u{2014} this node will stop admitting new rpc_shared_secret handshakes \
+                     until it restarts."
+                );
+            }
+        });
+    }
+}
+
+/// Binds `addr` and runs the auth-port accept loop forever. Returns only on
+/// a bind failure. Intended to be spawned as a background task.
+async fn run_rpc_auth_port(addr: SocketAddr, secret: String) -> std::io::Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    tracing::info!(
+        "rpc_cluster: RPC auth-port listener on {addr} (rpc_shared_secret configured, \
+         RPC_ADMISSION_TTL={RPC_ADMISSION_TTL:?})"
+    );
+    serve_rpc_auth_port(listener, secret).await
+}
+
+/// Accept loop shared by `run_rpc_auth_port` and its tests — mirrors
+/// `serve_rpc_allowlist_proxy`'s split for the same reason (tests bind an
+/// ephemeral loopback port themselves, avoiding a bind/rebind race).
+async fn serve_rpc_auth_port(listener: TcpListener, secret: String) -> std::io::Result<()> {
+    loop {
+        let (stream, peer_addr) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(err) => {
+                tracing::warn!("rpc_cluster: RPC auth-port accept() failed: {err}");
+                continue;
+            }
+        };
+        let secret = secret.clone();
+        tokio::spawn(async move {
+            match handle_auth_handshake(stream, &secret).await {
+                Ok(true) => {
+                    admit_peer(peer_addr.ip());
+                    tracing::info!("rpc_cluster: admitted RPC peer {}", peer_addr.ip());
+                }
+                Ok(false) => {
+                    tracing::warn!(
+                        "rpc_cluster: rejected RPC auth-port handshake from {} \u{2014} MAC did \
+                         not match (wrong or missing rpc_shared_secret on the connecting side)",
+                        peer_addr.ip()
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "rpc_cluster: RPC auth-port handshake with {} failed: {err}",
+                        peer_addr.ip()
+                    );
+                }
+            }
+        });
+    }
+}
+
+/// One handshake, server side: send a fresh random nonce, read back the
+/// client's `HMAC-SHA256(secret, nonce)`, compare. Returns `Ok(true/false)`
+/// for a completed handshake (match or mismatch) so the caller can log each
+/// case at the right severity; `Err` only for a real I/O or timeout
+/// failure. Never logs the secret, nonce, or MAC.
+async fn handle_auth_handshake(mut stream: TcpStream, secret: &str) -> std::io::Result<bool> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let nonce: [u8; RPC_NONCE_LEN] = rand::random();
+    tokio::time::timeout(RPC_AUTH_HANDSHAKE_TIMEOUT, stream.write_all(&nonce))
+        .await
+        .map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "timed out sending nonce")
+        })??;
+
+    let mut response = [0u8; RPC_MAC_LEN];
+    tokio::time::timeout(RPC_AUTH_HANDSHAKE_TIMEOUT, stream.read_exact(&mut response))
+        .await
+        .map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "timed out reading MAC")
+        })??;
+
+    let expected = compute_hmac(secret, &nonce);
+    let matched = expected == response;
+
+    let ack = [u8::from(matched)];
+    // Best-effort ack — if the client already hung up, the outcome (and the
+    // admission it may have already triggered) is unaffected either way.
+    let _ = tokio::time::timeout(RPC_AUTH_HANDSHAKE_TIMEOUT, stream.write_all(&ack)).await;
+
+    Ok(matched)
+}
+
+/// Attempts the RPC-auth handshake against `peer_ip`'s auth port (derived
+/// from `peer_rpc_port`), proving this node holds `secret`. Best-effort:
+/// any failure (peer doesn't have the auth port running — no
+/// `rpc_shared_secret` configured there, wrong secret, timeout) returns
+/// `false` rather than propagating an error, matching
+/// `discover_rpc_peers`'s existing "warn and exclude this peer, don't fail
+/// the whole request" pattern for build-mismatch/low-health peers.
+pub async fn admit_via_secret(peer_ip: IpAddr, peer_rpc_port: u16, secret: &str) -> bool {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let auth_addr = SocketAddr::new(peer_ip, peer_rpc_port.saturating_add(RPC_AUTH_PORT_OFFSET));
+
+    let attempt = async {
+        let mut stream = TcpStream::connect(auth_addr).await?;
+        let mut nonce = [0u8; RPC_NONCE_LEN];
+        stream.read_exact(&mut nonce).await?;
+        let mac = compute_hmac(secret, &nonce);
+        stream.write_all(&mac).await?;
+        let mut ack = [0u8; 1];
+        stream.read_exact(&mut ack).await?;
+        Ok::<bool, std::io::Error>(ack[0] == 1)
+    };
+
+    match tokio::time::timeout(RPC_AUTH_CLIENT_TIMEOUT, attempt).await {
+        Ok(Ok(true)) => true,
+        Ok(Ok(false)) => {
+            tracing::warn!(
+                "rpc_cluster: RPC peer {peer_ip} rejected our rpc_shared_secret \u{2014} \
+                 excluding it from this distributed-inference request"
+            );
+            false
+        }
+        Ok(Err(err)) => {
+            tracing::warn!(
+                "rpc_cluster: could not complete RPC auth handshake with {peer_ip}: {err} \
+                 \u{2014} excluding it from this distributed-inference request"
+            );
+            false
+        }
+        Err(_) => {
+            tracing::warn!(
+                "rpc_cluster: RPC auth handshake with {peer_ip} timed out after \
+                 {RPC_AUTH_CLIENT_TIMEOUT:?} \u{2014} excluding it from this \
+                 distributed-inference request"
+            );
+            false
+        }
     }
 }
 
@@ -1156,6 +1480,7 @@ mod tests {
             listener,
             backend_addr,
             allowed_peers,
+            false,
         ));
 
         let mut client = TcpStream::connect(proxy_addr).await.unwrap();
@@ -1181,6 +1506,7 @@ mod tests {
             listener,
             backend_addr,
             allowed_peers,
+            false,
         ));
 
         let mut client = TcpStream::connect(proxy_addr).await.unwrap();
@@ -1191,5 +1517,168 @@ mod tests {
             n, 0,
             "disallowed peer's connection must be closed with no data forwarded"
         );
+    }
+
+    #[test]
+    fn connection_allowed_requires_both_ip_allowlist_and_admission_when_required() {
+        // Deliberately a pure test against `connection_allowed`, not a real
+        // socket against the process-global admissions registry: every
+        // loopback-socket test in this suite shares the same source IP
+        // (127.0.0.1), so asserting "not admitted" from a real connection
+        // is order-dependent on whatever else in the suite has already
+        // called `admit_peer` for that same IP.
+        assert!(
+            connection_allowed(true, false, false),
+            "allowlisted, no admission required at all"
+        );
+        assert!(
+            !connection_allowed(true, true, false),
+            "allowlisted but admission required and not yet granted"
+        );
+        assert!(
+            connection_allowed(true, true, true),
+            "allowlisted, admission required and granted"
+        );
+        assert!(
+            !connection_allowed(false, false, false),
+            "not on the allowlist at all, regardless of admission"
+        );
+        assert!(
+            !connection_allowed(false, true, true),
+            "admitted but not on the allowlist \u{2014} both checks must pass"
+        );
+    }
+
+    #[tokio::test]
+    async fn allowlist_proxy_forwards_allowlisted_ip_once_admitted() {
+        let backend_addr = spawn_echo_backend().await;
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        let allowed_peers = vec!["127.0.0.1".to_string()];
+        admit_peer(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        tokio::spawn(serve_rpc_allowlist_proxy(
+            listener,
+            backend_addr,
+            allowed_peers,
+            true,
+        ));
+
+        let mut client = TcpStream::connect(proxy_addr).await.unwrap();
+        client.write_all(b"hello").await.unwrap();
+        let mut resp = [0u8; 5];
+        client.read_exact(&mut resp).await.unwrap();
+        assert_eq!(
+            &resp, b"hello",
+            "a previously-admitted, allowlisted source must be spliced through"
+        );
+    }
+
+    #[test]
+    fn admission_is_valid_true_before_expiry_false_at_and_after() {
+        let base = Instant::now();
+        let expiry = base + Duration::from_millis(50);
+        assert!(admission_is_valid(expiry, base));
+        assert!(!admission_is_valid(expiry, expiry));
+        assert!(!admission_is_valid(
+            expiry,
+            expiry + Duration::from_millis(1)
+        ));
+    }
+
+    #[test]
+    fn admit_peer_then_is_admitted_round_trips_for_a_fresh_ip() {
+        // A distinct, unlikely-to-collide-with-other-tests address, since
+        // the admissions registry is process-global (OnceLock) like
+        // RPC_CONTRIBUTOR_PROCESS elsewhere in this file.
+        let ip = v4(198, 51, 100, 77);
+        assert!(!is_admitted(&ip), "must not be admitted before admit_peer");
+        admit_peer(ip);
+        assert!(
+            is_admitted(&ip),
+            "must be admitted immediately after admit_peer"
+        );
+    }
+
+    #[test]
+    fn is_admitted_false_for_an_ip_that_was_never_admitted() {
+        let ip = v4(198, 51, 100, 78);
+        assert!(!is_admitted(&ip));
+    }
+
+    #[test]
+    fn compute_hmac_is_deterministic_and_distinguishes_secret_and_nonce() {
+        let nonce = [1u8; RPC_NONCE_LEN];
+        let a = compute_hmac("secret-a", &nonce);
+        let b = compute_hmac("secret-a", &nonce);
+        let c = compute_hmac("secret-b", &nonce);
+        let other_nonce = [2u8; RPC_NONCE_LEN];
+        let d = compute_hmac("secret-a", &other_nonce);
+
+        assert_eq!(a, b, "same secret + nonce must produce the same MAC");
+        assert_ne!(a, c, "different secret must change the MAC");
+        assert_ne!(a, d, "different nonce must change the MAC");
+        assert_eq!(a.len(), RPC_MAC_LEN);
+    }
+
+    #[tokio::test]
+    async fn auth_handshake_admits_correct_secret_and_rejects_wrong_secret() {
+        // Talks to `serve_rpc_auth_port` directly via the same raw
+        // handshake primitives `admit_via_secret` uses internally, rather
+        // than through `admit_via_secret` itself — that function derives
+        // the auth port from `peer_rpc_port + RPC_AUTH_PORT_OFFSET`, and an
+        // ephemeral (`:0`) bind here has no such fixed relationship to
+        // exercise. `admit_via_secret_applies_the_auth_port_offset_and_admits_on_match`
+        // below covers that offset math end-to-end instead.
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let auth_addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_rpc_auth_port(listener, "correct-horse".to_string()));
+
+        let mut client = TcpStream::connect(auth_addr).await.unwrap();
+        let mut nonce = [0u8; RPC_NONCE_LEN];
+        client.read_exact(&mut nonce).await.unwrap();
+        let correct_mac = compute_hmac("correct-horse", &nonce);
+        client.write_all(&correct_mac).await.unwrap();
+        let mut ack = [0u8; 1];
+        client.read_exact(&mut ack).await.unwrap();
+        assert_eq!(
+            ack[0], 1,
+            "the correct secret must be acknowledged as a match"
+        );
+
+        let mut client2 = TcpStream::connect(auth_addr).await.unwrap();
+        let mut nonce2 = [0u8; RPC_NONCE_LEN];
+        client2.read_exact(&mut nonce2).await.unwrap();
+        let wrong_mac = compute_hmac("totally-wrong", &nonce2);
+        client2.write_all(&wrong_mac).await.unwrap();
+        let mut ack2 = [0u8; 1];
+        client2.read_exact(&mut ack2).await.unwrap();
+        assert_eq!(
+            ack2[0], 0,
+            "a wrong secret must not be acknowledged as a match"
+        );
+    }
+
+    #[tokio::test]
+    async fn admit_via_secret_applies_the_auth_port_offset_and_admits_on_match() {
+        // Bind the *real* auth port relative to an arbitrary rpc_port so
+        // `admit_via_secret`'s own offset math is exercised end-to-end, not
+        // bypassed like the previous test.
+        let rpc_port: u16 = 40000 + (std::process::id() % 5000) as u16;
+        let auth_port = rpc_port.saturating_add(RPC_AUTH_PORT_OFFSET);
+        let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), auth_port);
+        let listener = match TcpListener::bind(bind_addr).await {
+            Ok(l) => l,
+            Err(_) => return, // port already in use on this host; not this test's concern
+        };
+        tokio::spawn(serve_rpc_auth_port(listener, "cluster-secret".to_string()));
+
+        let ok =
+            admit_via_secret(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port, "cluster-secret").await;
+        assert!(
+            ok,
+            "matching secret via the real offset-derived port must succeed"
+        );
+        assert!(is_admitted(&IpAddr::V4(Ipv4Addr::LOCALHOST)));
     }
 }

--- a/deploy/grafana/dashboards/ghostlink.json
+++ b/deploy/grafana/dashboards/ghostlink.json
@@ -1,0 +1,131 @@
+{
+  "title": "Ghostlink",
+  "uid": "ghostlink-overview",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "timezone": "browser",
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "tags": ["ghostlink"],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Uptime",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value" },
+      "targets": [
+        { "expr": "ghostlink_uptime_seconds", "refId": "A" }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Active Cluster Nodes",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value" },
+      "targets": [
+        { "expr": "ghostlink_cluster_active_nodes", "refId": "A" }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Cluster Total VRAM",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "decgbytes" }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value" },
+      "targets": [
+        { "expr": "ghostlink_cluster_total_vram_gb", "refId": "A" }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Inference Backend",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "name" },
+      "targets": [
+        { "expr": "ghostlink_build_info", "legendFormat": "{{inference_backend}}", "refId": "A" }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Inference Throughput (tokens/sec)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "tps" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "ghostlink_inference_throughput_tokens_per_second",
+          "legendFormat": "tokens/sec",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Inference Latency (p50 / p95)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        { "expr": "ghostlink_inference_latency_p50_milliseconds", "legendFormat": "p50", "refId": "A" },
+        { "expr": "ghostlink_inference_latency_p95_milliseconds", "legendFormat": "p95", "refId": "B" }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Host CPU / Memory / GPU Utilization",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "percent", "min": 0, "max": 100 },
+        "overrides": []
+      },
+      "targets": [
+        { "expr": "ghostlink_cpu_utilization_percent", "legendFormat": "CPU", "refId": "A" },
+        { "expr": "ghostlink_memory_utilization_percent", "legendFormat": "Memory", "refId": "B" },
+        { "expr": "ghostlink_gpu_utilization_percent", "legendFormat": "GPU", "refId": "C" }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Host Memory (Used / Total)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "decgbytes" }, "overrides": [] },
+      "targets": [
+        { "expr": "ghostlink_host_used_memory_gb", "legendFormat": "Used", "refId": "A" },
+        { "expr": "ghostlink_host_total_memory_gb", "legendFormat": "Total", "refId": "B" }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Inference Samples Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "ghostlink-prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "rate(ghostlink_inference_samples_total[5m])",
+          "legendFormat": "samples/sec",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,14 @@
+# Auto-provisions every dashboard JSON under /var/lib/grafana/dashboards
+# (mounted from deploy/grafana/dashboards/ in docker-compose.yml) on Grafana
+# startup — no manual import needed.
+apiVersion: 1
+
+providers:
+  - name: Ghostlink
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/grafana/provisioning/datasources/datasource.yml
+++ b/deploy/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,16 @@
+# Auto-provisions the Prometheus datasource on Grafana startup — no manual
+# "Add data source" click needed for `docker compose up --profile monitoring`
+# to produce a working dashboard immediately.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    # Fixed uid so the checked-in dashboard JSON (deploy/grafana/dashboards/
+    # ghostlink.json) can reference this datasource reliably instead of
+    # depending on whatever uid Grafana would otherwise auto-generate.
+    uid: ghostlink-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,33 @@
+# Prometheus scrape config for the `monitoring` docker-compose profile.
+#
+# ghostlink-api's /metrics is behind the same RBAC bearer-token auth as
+# every other route except /health (crates/ghost-link/src/main.rs's
+# auth_middleware) — a plain scrape without credentials gets a 401, not
+# metrics. `authorization.credentials_file` reads the token from the
+# `ghostlink-api-key` named volume this container shares (read-only) with
+# ghostlink-api and control-plane, the same file both of those already use
+# to find the live API key — see docker-compose.yml's GHOSTLINK_API_KEY_PATH
+# comments for why a shared volume, not a hardcoded value, is required here
+# (each service is its own container with its own filesystem, and the key
+# is generated fresh on first boot).
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: ghostlink-api
+    metrics_path: /metrics
+    # ghostlink-api runs `serve 0.0.0.0 8003` (docker-compose.yml) — binding
+    # a non-loopback host unconditionally forces HTTPS regardless of the
+    # enable_tls setting (tls::is_loopback_host("0.0.0.0") is false by
+    # design, see its own test), with a self-signed cert (tls.rs). There's
+    # no CA to validate that cert against in this deployment, hence
+    # insecure_skip_verify — the same trust model the container's own
+    # localhost-bound tooling already assumes.
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
+    authorization:
+      credentials_file: /shared/api_key.txt
+    static_configs:
+      - targets: ["ghostlink-api:8003"]

--- a/docker-compose.launch.yml
+++ b/docker-compose.launch.yml
@@ -46,7 +46,10 @@ services:
         condition: service_healthy
     command: serve 0.0.0.0 8003
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
+      # -k: binding 0.0.0.0 forces ghost-link's TLS-on-non-loopback rule
+      # (crates/ghost-link/src/tls.rs's is_loopback_host / main.rs's
+      # use_tls), so this serves a self-signed HTTPS cert, not plain HTTP.
+      test: ["CMD", "curl", "-fk", "https://localhost:8003/health"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -29,8 +29,3 @@ services:
     #   - ./ghostlink_gui_modern:/app
     #   - /app/node_modules
     # command: npm run dev -- --host 127.0.0.1 --port 3000
-
-  mcp-gateway:
-    # For local development, you may want to run MCP gateway separately
-    # profiles:
-    #   - mcp

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -44,7 +44,10 @@ services:
       - ./models.json:/app/models.json
     command: serve 0.0.0.0 8003
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
+      # -k: binding 0.0.0.0 forces ghost-link's TLS-on-non-loopback rule
+      # (crates/ghost-link/src/tls.rs's is_loopback_host / main.rs's
+      # use_tls), so this serves a self-signed HTTPS cert, not plain HTTP.
+      test: ["CMD", "curl", "-fk", "https://localhost:8003/health"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,49 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # ─── Monitoring (opt-in: `docker compose up --profile monitoring`) ───
+  # Prometheus scrapes ghostlink-api's existing /metrics; Grafana comes up
+  # pre-wired to it (datasource + dashboard auto-provisioned from
+  # deploy/grafana/provisioning) — no manual setup click needed. Neither
+  # service starts on a plain `docker compose up`.
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: ghostlink-prometheus
+    profiles: ["monitoring"]
+    volumes:
+      - ./deploy/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # Read-only access to the same API key ghostlink-api/control-plane
+      # already share (see ghostlink-api's GHOSTLINK_API_KEY_PATH comment
+      # above) — /metrics needs a bearer token like every other route
+      # except /health, and prometheus.yml's authorization.credentials_file
+      # reads it from here.
+      - ghostlink-api-key:/shared:ro
+    ports:
+      - "9090:9090"
+    networks:
+      - ghostlink-network
+    depends_on:
+      ghostlink-api:
+        condition: service_healthy
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: ghostlink-grafana
+    profiles: ["monitoring"]
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./deploy/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3001:3000"
+    networks:
+      - ghostlink-network
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
 networks:
   ghostlink-network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,11 @@ services:
         condition: service_healthy
     command: serve 0.0.0.0 8003
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8003/health"]
+      # -k: binding 0.0.0.0 forces ghost-link's TLS-on-non-loopback rule
+      # (crates/ghost-link/src/tls.rs's is_loopback_host / main.rs's
+      # use_tls), so this serves a self-signed HTTPS cert, not plain HTTP —
+      # same reasoning as docker-compose.rpc-fabric.yml's healthcheck.
+      test: ["CMD", "curl", "-fk", "https://localhost:8003/health"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -78,7 +82,13 @@ services:
       - "8000:8000"
     environment:
       PORT: "8000"
-      GHOSTLINK_BACKEND_URL: http://ghostlink-api:8003
+      # https:// (not http://): ghostlink-api binds 0.0.0.0, which forces
+      # its self-signed-TLS listener on (see the matching comment on its
+      # healthcheck above) — proxy.go's NewChatProxy already skips cert
+      # verification for an https:// backend URL specifically to handle
+      # this, so plain http:// here would make every proxied request fail,
+      # not just the healthcheck.
+      GHOSTLINK_BACKEND_URL: https://ghostlink-api:8003
       # See the matching comment on ghostlink-api's GHOSTLINK_API_KEY_PATH
       # above — without this, control-plane's edge auth check silently
       # no-ops (empty key = skip), which also means requests that should

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -489,6 +489,27 @@ speculative gold-plating.
    capped log (`AUDIT_LOG_CAP`) to append-only persistent storage plus a
    JSON/CEF export path. This extends what already shipped rather than
    building a new system, and is a prerequisite for any real SIEM story.
+   **Status check (2026-08-15): shipped.** New `audit_log.rs` module: every
+   `record_audit_event` call now also appends the entry as one JSON line to
+   an append-only `audit_log.jsonl` (`GHOSTLINK_AUDIT_LOG_PATH` override) —
+   the in-memory capped `VecDeque` is untouched and still serves the GUI's
+   live feed exactly as before. New `GET /api/security/audit-log/export`
+   (`?format=json|cef`, default json) reads the *full* durable history,
+   gated `Admin`-only (stricter than the existing capped live endpoint,
+   which stays `Viewer`-readable) since a bulk historical export is a
+   different exposure than a live tail. CEF output is real Common Event
+   Format with correct extension-value escaping — not a cosmetic detail:
+   several existing audit `detail` strings already contain raw `=`
+   characters (e.g. `"name='{}' id={}"` on the key-revocation event), which
+   would otherwise corrupt the field boundary for any real SIEM parser.
+   Verified live: durable file confirmed on disk with real events including
+   one deliberately containing both `=` and `|`; in-memory feed correctly
+   empties on restart while the durable export still returns the
+   pre-restart history; CEF export correctly escapes every `=` in the
+   stress-test event while leaving the literal `|` alone (valid inside an
+   extension value, unlike the pipe-delimited CEF header). Log
+   rotation/retention policy remains a deliberate fast-follow, not
+   attempted here — the file is append-only and unbounded.
 4. **OpenTelemetry tracing**, layered on top of the *already-real*
    Prometheus metrics, plus finally checking in the Grafana dashboard JSON
    that Horizon 1 item 4 has called for since before v1.17 and that's

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -295,7 +295,37 @@ make the Priority Zero fix land on solid ground.
    `/metrics` endpoint — `docker-compose.yml` already exists; add a
    Prometheus + Grafana profile so `docker compose up --profile monitoring`
    gives a working dashboard immediately. Zero-config observability is a
-   real gap vs. every competitor here.
+   real gap vs. every competitor here. **Status check (2026-08-15):
+   shipped.** `deploy/prometheus/prometheus.yml` + `deploy/grafana/` (a
+   provisioned datasource and a real dashboard JSON covering every metric
+   `/metrics` exposes — throughput, p50/p95 latency, CPU/memory/GPU,
+   cluster node count and VRAM, uptime, sample rate); `docker-compose.yml`
+   gained `prometheus`/`grafana` services under `profiles: ["monitoring"]`,
+   so a plain `docker compose up` is unaffected and
+   `docker compose up --profile monitoring` brings both up pre-wired, no
+   manual "add datasource"/"import dashboard" click needed. One real,
+   non-obvious correctness catch along the way: `ghostlink-api` binds
+   `0.0.0.0` (`docker-compose.yml`'s `command: serve 0.0.0.0 8003`), and
+   `tls::is_loopback_host("0.0.0.0")` is deliberately `false` (it has its
+   own test asserting exactly that) — so the container unconditionally
+   forces HTTPS with a self-signed cert regardless of the `enable_tls`
+   setting. A first pass at the scrape config assumed plain HTTP and would
+   have silently scraped nothing; `prometheus.yml` now scrapes
+   `https://` with `insecure_skip_verify` (no CA to validate a self-signed
+   cert against in this deployment). Verified: YAML validated with
+   `docker compose config`, the dashboard JSON validated, and a real
+   locally-run `ghost-link serve 0.0.0.0` process confirmed to only answer
+   on HTTPS, not plain HTTP, exactly as the fix assumes. **Not verified**:
+   an actual live container scrape end-to-end — the Docker daemon wasn't
+   running in the environment this shipped from (CLI present, engine not
+   started), so this could only be validated statically plus against a
+   real non-containerized server process, not a genuine `docker compose up
+   --profile monitoring` run. The same 0.0.0.0-forces-HTTPS behavior also
+   surfaced a separate, likely pre-existing bug worth its own fix:
+   `ghostlink-api`'s Docker healthcheck curls plain `http://`, which this
+   same logic implies should already be failing — flagged separately
+   rather than fixed here, since confirming and fixing it needs a working
+   Docker daemon this environment didn't have.
 5. **One-line install script** (`curl | sh` / a signed installer per
    platform) using the now-multi-OS release artifacts. Ollama's biggest UX
    win is `curl -fsSL https://ollama.com/install.sh | sh`; Ghostlink should
@@ -513,7 +543,15 @@ speculative gold-plating.
 4. **OpenTelemetry tracing**, layered on top of the *already-real*
    Prometheus metrics, plus finally checking in the Grafana dashboard JSON
    that Horizon 1 item 4 has called for since before v1.17 and that's
-   still open.
+   still open. **Status check (2026-08-15): half done.** The Grafana
+   dashboard/monitoring-profile half shipped — see Horizon 1 item 4's own
+   status check for the full account. OpenTelemetry tracing itself has not
+   started: this is a genuinely separate, larger piece of work (choosing an
+   OTel crate and exporter, instrumenting spans across the request →
+   planning → RPC-hop path, and propagating trace context across process
+   boundaries for the RPC transport specifically — a real distributed-
+   tracing problem, not just adding a library) that deserves its own
+   focused pass rather than being folded into the dashboard work.
 5. Horizon 1 item 6 (config hot-reload) is a direct prerequisite for any
    of the above being usable in a headless/server deployment — still open,
    still worth doing first or alongside.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -355,7 +355,28 @@ Once Priority Zero is real and provable, these make it hard to copy.
    unconfirmed is whether anything calls `rebalance()` in response to a
    live node join/leave/health-degrade event today, or whether it's only
    invoked from a static planning pass — worth a quick read of the call
-   sites before scoping this as greenfield.
+   sites before scoping this as greenfield. **Status check (2026-08-15):
+   read the call sites — it's greenfield after all, for the path that
+   actually matters.** `execute_pipeline_with_rebalance*`/`rebalance()`
+   has exactly one real caller (`main.rs`'s `ghost-link flow` CLI command,
+   gated behind `GHOSTLINK_FLOW_ENABLE_REBALANCE`), and that command is the
+   *synthetic* pipeline-benchmark path this roadmap's Priority Zero section
+   already established doesn't run real model layers — `PipelinePlan`
+   built from a fabricated 60-layer/0.5GB-per-layer spec, not a real GGUF.
+   The real distributed-inference serving path (`handle_gui_model_load` →
+   `rpc_cluster::discover_rpc_peers` → a single `llama-server --rpc ...`
+   process launch, see Priority Zero and Enterprise Trust Track item #2)
+   has no rebalancing concept at all — it's one process invocation per
+   model load, not a per-token pipeline Ghostlink's own runtime coordinates
+   step-by-step the way `runtime.rs`'s synthetic path does. So: real
+   continuous rebalancing for real distributed inference is still fully
+   unbuilt, not "needs live-event wiring added to an existing mechanism."
+   The Risks section's own assessment stands — "mid-generation migration
+   without corrupting output is a real research-adjacent problem... a
+   simpler 'drain and restart the affected request' fallback is an
+   acceptable first cut" — and that first cut hasn't been attempted either.
+   Deliberately not attempted in this pass: this needs its own dedicated
+   scoping, not a fast-follow bolted onto an unrelated feature.
 2. **Speculative decoding across heterogeneous nodes** — a small/fast node
    (or NPU) drafts, a large/slow node verifies. This is a genuinely novel
    angle: nobody targets *consumer heterogeneous* hardware for this pattern

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -454,6 +454,37 @@ speculative gold-plating.
    protocol-level auth, only IP allowlisting and a version-mismatch check.
    IP allowlisting stops "anyone on the LAN"; it does not stop a device
    already inside an allowlisted range or one spoofing a source address.
+   **Status check (2026-08-15): shipped, as an equivalent handshake rather
+   than mTLS.** Real mTLS turned out to be structurally blocked: upstream
+   llama.cpp's `--rpc` client speaks zero custom handshake and starts
+   sending raw `ggml-rpc` binary protocol the instant it connects, so any
+   additional auth step has to live outside that TCP stream, done by
+   Ghostlink's own processes on both ends — not inside it. The shipped
+   design (`rpc_cluster.rs`): a new `rpc_shared_secret` setting (empty/off
+   by default, manually distributed across nodes like `rpc_allowed_peers`
+   already is) gates a dedicated auth port
+   (`rpc_port + RPC_AUTH_PORT_OFFSET`). Before opening the real `--rpc`
+   connection, the coordinator does a nonce-based HMAC-SHA256 handshake
+   there (`admit_via_secret`); success temporarily admits its source IP
+   (`RPC_ADMISSION_TTL`, 30s) and the allowlist proxy now requires a *live*
+   admission, not just allowlist membership, before splicing a connection
+   through. A fresh nonce per handshake means a captured response can't be
+   replayed. Verified live against a real running peer process: an
+   unadmitted connection to the real RPC port is reset; a wrong-secret
+   handshake is acked as a mismatch and leaves the port still rejecting;
+   the correct secret is acked as a match and the *same* connection the
+   proxy previously reset is then accepted and forwarded toward the local
+   `ggml-rpc-server` (confirmed via the proxy's own "could not reach
+   ggml-rpc-server" log line firing only because no real binary was present
+   in that dev checkout, not because gating failed). Honestly scoped, same
+   as the existing IP-allowlist caveat: this proves the connecting node held
+   the secret at admission time and authorizes its source IP for a short
+   window — it does **not** encrypt the actual `ggml-rpc` byte stream itself
+   (still plain TCP), and an on-path attacker riding the same source IP
+   during the admission window isn't stopped by it. True wire-level
+   confidentiality would need a dual-proxy TLS tunnel on both ends (reusing
+   `tls.rs`'s existing cert infra) — noted as a further follow-up, not
+   attempted here.
 3. **Durable, exportable audit log** — upgrade the existing in-memory
    capped log (`AUDIT_LOG_CAP`) to append-only persistent storage plus a
    JSON/CEF export path. This extends what already shipped rather than
@@ -640,4 +671,9 @@ lands.
   the Horizon 2 plugin-marketplace work rather than treating this as fully
   closed. **This is item #2 in the "Enterprise Trust Track" section above**,
   paired with RBAC as the two highest-priority security items on this
-  roadmap.
+  roadmap. **Status check (2026-08-15): shipped** — see that section's status
+  check for the `rpc_shared_secret` handshake design and what it does and
+  doesn't close (a device already inside an allowlisted range can no longer
+  ride through without the secret; the actual RPC byte stream itself is
+  still unencrypted plain TCP, an honestly-documented remaining gap, not a
+  silent one).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -354,7 +354,9 @@ Once Priority Zero is real and provable, these make it hard to copy.
    resets on restart and isn't a persistent append-only trail, but "empty"
    is no longer accurate. What's still genuinely missing: multi-user API
    keys with scoped permissions (RBAC) — that's the remaining piece for
-   any team/household deployment beyond a single operator.
+   any team/household deployment beyond a single operator. **This is the
+   #1 priority in the "Enterprise Trust Track" section below** — see that
+   section for scope and sequencing relative to RPC peer auth.
 6. **Plugin marketplace-lite**: a `plugins.toml`-style registry (mirroring
    the existing `mcp_servers.toml` pattern) so third-party
    `InferenceBackendPlugin`/MCP-tool implementations can be discovered and
@@ -386,6 +388,146 @@ Bigger, riskier, higher payoff if the moat above is already real.
    management/updates/telemetry across many Ghostlink clusters, monetizing
    the "commercial support path" the README already gestures at, without
    compromising the open-source, self-hosted core.
+
+---
+
+## Enterprise Trust Track: reviewing the "default enterprise harness" proposal (2026-08-15)
+
+An external review proposed hardening Ghostlink into "the system teams
+actually run production private LLM workloads on" — full RBAC/multi-tenancy,
+mTLS everywhere, SSO/OIDC/SAML, SIEM-exportable audit trails, OpenTelemetry,
+continuous rebalancing, model governance/canary promotion, WAN connectivity,
+and Terraform/Ansible IaC. Rather than bolt this on as a parallel plan, it's
+worth reconciling against what's actually in the tree and against this
+roadmap's own stated identity — because about half the proposal either
+duplicates something already tracked above, or cuts against the "zero-config,
+single binary" differentiator the Risks section already warns not to
+dilute.
+
+**Fact-check against the current codebase**, since the proposal was written
+from the outside without reading the code:
+
+| Proposal's claim | Actual state, verified 2026-08-15 |
+| --- | --- |
+| "Basic auth/JWT" | Confirmed as described — a single global API key (`auth.rs`) signs JWTs; no scoped keys, no tenancy |
+| "Optional PQC-hybrid TLS" | Undersold, not overstated — ML-KEM-768 hybrid TLS is real and implemented (`tls.rs`), not a stub |
+| "Prometheus metrics" | Real — `/metrics` in Prometheus text-exposition format exists (`handle_metrics_prometheus` in `main.rs`), Grafana already referenced in `.env.example`/compose files |
+| "Populate the real audit endpoint" | Already done as of the 2026-08-08 status check above — proposal was written against a stale picture |
+| RBAC / scoped multi-user keys | **Confirmed genuinely absent** — correctly identified as the top gap |
+| mTLS / authenticated node-to-node RPC | **Confirmed genuinely absent** — `ggml-rpc` has an IP allowlist and a build-version-mismatch check (see Risks below) but no protocol-level auth |
+| OpenTelemetry tracing | Not found anywhere in the crates — correctly identified as missing |
+| SSO/OIDC/SAML | Not found — correctly identified as missing |
+
+So the proposal's two most emphasized items — RBAC and node-to-node
+authentication — are exactly the two gaps this roadmap's own Horizon 2
+item 5 and Risks section already flag as the most severe open issues,
+arrived at independently. That convergence is the strongest signal in this
+whole review: treat those two as the actual next security work, not
+speculative gold-plating.
+
+### Fold into Horizon 1/2 as-is (no identity risk, closes gaps this doc already flagged)
+
+1. **Scoped API keys / RBAC** — teams/projects namespacing, least-privilege
+   MCP tool access, model-level permissions. This *is* Horizon 2 item 5's
+   remaining piece, not a new item; sequencing note below. **Status check
+   (2026-08-15): the core (3-role RBAC) shipped.** `auth.rs` now persists a
+   hashed, multi-key store (`api_keys.json`) instead of one shared global
+   key — each key carries a role (`Admin`/`Operator`/`Viewer`), checked by
+   `main.rs`'s `required_role()` against every route (GET/HEAD default to
+   `Viewer`, mutations to `Operator`, key management and
+   `POST /api/security/pqc/enable` to `Admin`). `/api/security/keys`
+   (GET/POST/DELETE) lets an Admin create and revoke narrowly-scoped keys
+   via the API, shown once at creation like the original bootstrap key. An
+   existing deployment's `api_key.txt` migrates automatically into the new
+   store as the sole Admin key on first run — zero manual steps, verified
+   live end-to-end (fresh boot, created an Operator and a Viewer key,
+   confirmed 403s land exactly where the role model says they should,
+   confirmed revoking a key invalidates its outstanding JWTs immediately
+   rather than waiting out the 1h token lifetime, confirmed deleting the
+   last Admin key is refused). Deliberately out of scope for this pass, and
+   still open: team/project namespacing, per-model and per-MCP-tool
+   permissions, and a GUI (Security tab) for key management — all
+   backend/API-only today, reachable via `curl` the same way the rest of
+   this server already is.
+2. **RPC peer authentication** (mTLS or an equivalent handshake) — closes
+   the Risks section's top-ranked gap directly: `ggml-rpc` today has zero
+   protocol-level auth, only IP allowlisting and a version-mismatch check.
+   IP allowlisting stops "anyone on the LAN"; it does not stop a device
+   already inside an allowlisted range or one spoofing a source address.
+3. **Durable, exportable audit log** — upgrade the existing in-memory
+   capped log (`AUDIT_LOG_CAP`) to append-only persistent storage plus a
+   JSON/CEF export path. This extends what already shipped rather than
+   building a new system, and is a prerequisite for any real SIEM story.
+4. **OpenTelemetry tracing**, layered on top of the *already-real*
+   Prometheus metrics, plus finally checking in the Grafana dashboard JSON
+   that Horizon 1 item 4 has called for since before v1.17 and that's
+   still open.
+5. Horizon 1 item 6 (config hot-reload) is a direct prerequisite for any
+   of the above being usable in a headless/server deployment — still open,
+   still worth doing first or alongside.
+
+### Fold into Horizon 2/3, but strictly as opt-in layers on top of the zero-config default
+
+6. **OIDC** as an *additional* auth provider layered on top of, not
+   replacing, the existing API-key/JWT path — a household user on a LAN
+   should never see this. Deliberately **not SAML**: SAML is legacy,
+   heavier to implement and audit than OIDC, and covers no realistic
+   near-term customer this project has; only build it if a specific buyer
+   asks for it by name.
+7. **Confirm/finish continuous rebalancing** (Horizon 2 item 1) —
+   prerequisite groundwork for treating this as production-grade multi-
+   tenant infrastructure at all; a node degrading mid-generation under a
+   real RBAC'd multi-team deployment is a much bigger deal than in a
+   single-operator lab.
+8. **Optional guardrail/policy middleware** (PII redaction, prompt/response
+   filtering, usage quotas) — pluggable and off by default, sitting in
+   front of the request path rather than inside the low-latency ring-buffer
+   transport the Risks section already protects from feature creep.
+9. **Lightweight model registry versioning** with pin/rollback — extends
+   the existing HF integration and `plugins.toml`-style registry pattern
+   (Horizon 2 items 3 and 6). Deliberately scoped down from the proposal's
+   "canary/blue-green promotion" language: that's k8s-deployment-shaped
+   machinery this project has no runtime to support without the
+   rearchitecture the Risks section explicitly rules out.
+10. **Usage attribution and quotas per tenant** — only meaningful once #1
+    (RBAC) exists to define what a "tenant" is; sequence strictly after it,
+    not in parallel.
+
+### Explicitly rejected, or descoped hard, from the proposal
+
+- **No re-architecting around Kubernetes.** The proposal's "Scale &
+  Connectivity" and "Operational Polish" sections lean on
+  Terraform/Ansible/canary-promotion language that implicitly assumes a
+  k8s-shaped deployment model. This directly contradicts the Risks
+  section's existing guardrail: *"Don't chase Kubernetes-based competitors
+  on their home turf... If enterprise demand for a k8s deployment mode
+  materializes, ship it as an optional deployment target, not a
+  rearchitecture."* Terraform/Ansible are fine as thin, optional,
+  Horizon-3-or-later wrappers around the existing single binary — never a
+  prerequisite for using it.
+- **No heavyweight approval-workflow engine** for model promotion — the
+  realistic Ghostlink deployment is a small team or a household, not an
+  org with a change-approval board. Pin/rollback (item 9 above) gets the
+  real safety property (bad model doesn't silently stay hot) without the
+  process overhead.
+- **No cost/power-aware scheduling as a near-term item** — real, and
+  already partially covered by Horizon 3 item 2's speculative-decoding
+  work and the planner-ABI item, but it's speculative distributed-systems
+  work layered on top of RBAC/tenancy that doesn't exist yet. Revisit once
+  item 10 lands.
+
+### Recommended sequencing
+
+RBAC (#1) and RPC peer auth (#2) first, in parallel if there's bandwidth —
+both are prerequisites for nearly everything else in this section (tenancy,
+quotas, cost attribution, even a meaningful audit export all assume scoped
+identity exists), and both are the two gaps this roadmap already flagged
+independently of the external review. Durable audit log (#3) and OTel (#4)
+are the natural next pair once identity exists to attribute events to.
+Everything under "fold into Horizon 2/3" should wait for that foundation
+rather than being started opportunistically — a policy engine or quota
+system built against a single global API key will need rework once RBAC
+lands.
 
 ---
 
@@ -496,4 +638,6 @@ Bigger, riskier, higher payoff if the moat above is already real.
   inviting more than a single trusted operator, genuine protocol-level
   auth (not just IP allowlisting) is still worth pulling forward alongside
   the Horizon 2 plugin-marketplace work rather than treating this as fully
-  closed.
+  closed. **This is item #2 in the "Enterprise Trust Track" section above**,
+  paired with RBAC as the two highest-priority security items on this
+  roadmap.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -564,15 +564,37 @@ speculative gold-plating.
 4. **OpenTelemetry tracing**, layered on top of the *already-real*
    Prometheus metrics, plus finally checking in the Grafana dashboard JSON
    that Horizon 1 item 4 has called for since before v1.17 and that's
-   still open. **Status check (2026-08-15): half done.** The Grafana
-   dashboard/monitoring-profile half shipped — see Horizon 1 item 4's own
-   status check for the full account. OpenTelemetry tracing itself has not
-   started: this is a genuinely separate, larger piece of work (choosing an
-   OTel crate and exporter, instrumenting spans across the request →
-   planning → RPC-hop path, and propagating trace context across process
-   boundaries for the RPC transport specifically — a real distributed-
-   tracing problem, not just adding a library) that deserves its own
-   focused pass rather than being folded into the dashboard work.
+   still open. **Status check (2026-08-15): both halves shipped.** The
+   Grafana dashboard/monitoring-profile half shipped first — see Horizon 1
+   item 4's own status check for the full account. OpenTelemetry tracing
+   followed: new `otel.rs` (`opentelemetry`/`opentelemetry_sdk`/
+   `opentelemetry-otlp`/`tracing-opentelemetry`), entirely opt-in via
+   `GHOSTLINK_OTEL_EXPORTER_ENDPOINT` — unset reproduces the exact
+   plain-text console logging this codebase has always had, byte-for-byte.
+   When set: `tower-http`'s `TraceLayer` gives an automatic root span per
+   HTTP request (method/URI/status/latency, zero hand-written span code),
+   plus three hand-instrumented phase spans in the distributed-inference
+   model-load path (`rpc_peer_discovery_and_admission`, `model_load`, and
+   `inference_generate` covering the whole chat turn including any
+   tool-calling round trips). **A real architectural limit surfaced and is
+   documented rather than glossed over**: the same class of constraint RPC
+   peer auth hit — upstream llama.cpp's `--rpc` client speaks a raw binary
+   protocol with no header/metadata slot for W3C trace-context propagation,
+   so a trace cannot span *across* the actual `ggml-rpc` TCP hop the way a
+   textbook distributed trace would; it ends at "launched llama-server,
+   here's how long it took," the same honest boundary `rpc_cluster.rs`
+   already draws. Per the user's explicit choice, no trace backend is
+   bundled (no Jaeger/Collector added to docker-compose) — an operator
+   points the endpoint at whatever they already run. Uses the SDK's
+   synchronous `SimpleSpanProcessor` with a blocking HTTP client rather
+   than the batched async one, deliberately: this initializes in `main()`
+   before any tokio runtime exists (`main()` also dispatches non-`serve`
+   subcommands like `flow`/`stage-worker`/`probe`), so the exporter can't
+   depend on an ambient async reactor. Verified live: a real stub OTLP/HTTP
+   receiver confirmed genuine `application/x-protobuf` POST bodies arriving
+   from a running server issuing real requests — the full span-creation →
+   OTel-layer → OTLP-exporter → HTTP-POST pipeline proven end-to-end, not
+   just compiled.
 5. Horizon 1 item 6 (config hot-reload) is a direct prerequisite for any
    of the above being usable in a headless/server deployment — still open,
    still worth doing first or alongside.


### PR DESCRIPTION
## Summary

Implements the full Enterprise Trust Track from `docs/ROADMAP.md` — the security/observability hardening pass identified after reviewing an external "make this enterprise-ready" proposal against the actual codebase. Each item was scoped, planned, implemented, and verified live (real running server processes, real requests) rather than just unit-tested.

- **RBAC + scoped API keys** (`auth.rs`) — replaces the single shared API key with a persisted, hashed multi-key store. Each key carries a role (`Admin`/`Operator`/`Viewer`) enforced on every route. New `/api/security/keys` endpoints for key lifecycle management. An existing deployment's `api_key.txt` migrates automatically as the sole Admin key — zero breaking change.
- **RPC peer authentication** (`rpc_cluster.rs`) — closes the top-ranked gap in the roadmap's own Risks section: `ggml-rpc-server` has no auth of its own, and IP allowlisting alone doesn't stop a device already inside an allowlisted range. New `rpc_shared_secret` setting gates a nonce-based HMAC-SHA256 handshake on a dedicated auth port before the real RPC connection is admitted. Real mTLS was structurally blocked — upstream llama.cpp's `--rpc` client speaks zero custom handshake — so this is the practical equivalent instead.
- **Durable, exportable audit log** (`audit_log.rs`, new module) — the audit trail was real but reset on every restart with no export path. Now appends to a durable JSONL file in addition to the existing capped live feed, plus a new `Admin`-gated `/api/security/audit-log/export` endpoint (`?format=json|cef`) with real CEF escaping (several existing audit `detail` strings already contain raw `=`, which would otherwise corrupt the field for any real SIEM parser).
- **Grafana dashboard + Prometheus monitoring profile** (`deploy/`, `docker-compose.yml`) — `docker compose up --profile monitoring` now brings up Prometheus scraping the existing `/metrics` endpoint and Grafana pre-wired to it via provisioning, no manual setup click needed.
- **OpenTelemetry tracing** (`otel.rs`, new module) — opt-in via `GHOSTLINK_OTEL_EXPORTER_ENDPOINT` (unset = today's exact console logging). An automatic HTTP root span per request plus three hand-instrumented phase spans in the distributed-inference path. Documents a real architectural limit: traces can't cross the actual `ggml-rpc` TCP hop, the same upstream constraint RPC peer auth hit.
- **Two incidental fixes** found while building the monitoring profile: a malformed `mcp-gateway` stub that broke `docker compose config` for the whole repo, and `ghostlink-api`'s healthcheck/`control-plane`'s backend URL using plain HTTP against a container that (by binding `0.0.0.0`) is forced into HTTPS — which was breaking real chat-completion proxying, not just the health probe.
- A documented, honest investigation confirming continuous rebalancing is **not** wired to the real distributed-inference path (only exists in a synthetic benchmark CLI command) — recorded rather than guessed at, since fixing it is separate, research-adjacent work.

`docs/ROADMAP.md` carries a dated status check for every item, including what's explicitly out of scope and why.

## Test plan

- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p ghost-link` (223 tests) all green after every commit
- [x] RBAC: live role-enforcement walkthrough (Admin/Operator/Viewer), JWT revocation-on-key-delete, last-admin lockout prevention
- [x] RPC peer auth: live handshake against a real running peer — unadmitted/wrong-secret connections rejected, correct secret admits and the proxy forwards
- [x] Audit log: durable file confirmed on disk, survives a process restart, CEF export escaping verified against a stress-test event containing `=` and `|`
- [x] Monitoring: `docker compose config` validated (including the now-fixed `mcp-gateway`/HTTPS issues); Prometheus scrape auth mechanics verified against a real server process
- [x] OTel: real stub OTLP receiver confirmed genuine `application/x-protobuf` POSTs from a live server handling real requests
- [ ] Full `docker compose up --profile monitoring` end-to-end (Docker daemon wasn't running in the dev environment this shipped from — noted in `docs/ROADMAP.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)