### PR TITLE
🎨 Palette: Command Palette Modal Focus Trapping & Cyclic Keyboard Navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal
 
+## 2026-08-18 - [Command Palette Modal Focus Trapping & Cyclic Tab Navigation]
+**Learning:** Combobox search inputs inside modal overlays (like the global Command Palette) can inadvertently release keyboard focus to invisible background DOM elements when users press `Tab`. Intercepting `Tab` / `Shift+Tab` keydown events on the search input to cycle option highlights modulo the filtered length keeps keyboard focus firmly contained within the modal dialogue while providing intuitive cyclic option navigation.
+**Action:** Always intercept `Tab` and `Shift+Tab` on modal combobox search inputs to cycle option highlights safely and trap focus within `role="dialog"` overlays.
+
 ## 2026-08-16 - [Command Palette Keyboard Navigation Auto-Scrolling]
 **Learning:** Scrollable option listboxes in modal overlays (such as the global Command Palette) leave keyboard users navigating blind if the highlighted option moves outside the visible container bounds. Adding a scroll effect linked to the active highlight index (`element.scrollIntoView({ block: 'nearest' })`) ensures the selected option always remains visible as users navigate using arrow keys.
 **Action:** Always attach auto-scroll behavior (`scrollIntoView({ block: 'nearest' })`) to keyboard-navigated listbox overlays so active options stay in view.

--- a/ghostlink_gui_modern/src/components/CommandPalette.test.tsx
+++ b/ghostlink_gui_modern/src/components/CommandPalette.test.tsx
@@ -32,4 +32,28 @@ describe('CommandPalette', () => {
 
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });
+
+  it('cycles through commands with Tab and Shift+Tab key navigation', () => {
+    render(<CommandPalette />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('open-command-palette'));
+    });
+
+    const searchInput = screen.getByRole('combobox', { name: 'Search commands' });
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    // Tab moves highlight to next option
+    fireEvent.keyDown(searchInput, { key: 'Tab' });
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+
+    // Shift+Tab cycles back to previous option
+    fireEvent.keyDown(searchInput, { key: 'Tab', shiftKey: true });
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    // Shift+Tab at first option wraps around to last option
+    fireEvent.keyDown(searchInput, { key: 'Tab', shiftKey: true });
+    expect(options[options.length - 1]).toHaveAttribute('aria-selected', 'true');
+  });
 });

--- a/ghostlink_gui_modern/src/components/CommandPalette.tsx
+++ b/ghostlink_gui_modern/src/components/CommandPalette.tsx
@@ -153,12 +153,13 @@ export const CommandPalette: React.FC = () => {
   };
 
   const handleInputKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown') {
+    if (filtered.length === 0) return;
+    if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey)) {
       e.preventDefault();
-      setHighlight((h) => Math.min(h + 1, filtered.length - 1));
-    } else if (e.key === 'ArrowUp') {
+      setHighlight((h) => (h + 1) % filtered.length);
+    } else if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey)) {
       e.preventDefault();
-      setHighlight((h) => Math.max(h - 1, 0));
+      setHighlight((h) => (h - 1 + filtered.length) % filtered.length);
     } else if (e.key === 'Enter') {
       e.preventDefault();
       const cmd = filtered[highlight];


### PR DESCRIPTION
Enhances keyboard navigation and focus trapping in `CommandPalette.tsx` by handling `Tab` and `Shift+Tab` keydown events on the search input to cyclically iterate through filtered commands without losing focus from the modal overlay dialog. Includes corresponding unit test coverage in `CommandPalette.test.tsx`.

---
*PR created automatically by Jules for task [6259742543523366003](https://jules.google.com/task/6259742543523366003) started by @rwilliamspbg-ops*