### PR TITLE
🎨 Palette: Add keyboard focus visible rings to ChatTab session item buttons

### DIFF
--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -1086,7 +1086,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                           <div className="flex items-center gap-1">
                             <button
                               onClick={() => handleLoadSession(s.id)}
-                              className="p-1.5 hover:bg-slate-700 rounded-lg text-slate-400 hover:text-white transition"
+                              className="p-1.5 hover:bg-slate-700 rounded-lg text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                               title="Load"
                               aria-label={`Load session ${s.name || s.id}`}
                             >
@@ -1094,7 +1094,7 @@ export const ChatTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
                             </button>
                             <button
                               onClick={() => handleDeleteSession(s.id)}
-                              className="p-1.5 hover:bg-slate-700 rounded-lg text-slate-400 hover:text-red-400 transition"
+                              className="p-1.5 hover:bg-slate-700 rounded-lg text-slate-400 hover:text-red-400 transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                               title="Delete"
                               aria-label={`Delete session ${s.name || s.id}`}
                             >


### PR DESCRIPTION
Adds explicit focus-visible rings to inline session item buttons in ChatTab to enhance keyboard navigation accessibility.

---
*PR created automatically by Jules for task [14081872990749639687](https://jules.google.com/task/14081872990749639687) started by @rwilliamspbg-ops*