### PR TITLE
⚡ Bolt: zero-clone single-pass cluster metrics inspection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -110,3 +110,7 @@
 ## 2026-07-02 - [Cluster Health Lock & Clone Overhead Elimination]
 **Learning:** In cluster health calculations, calling multiple helper methods on `ClusterState` (e.g., `active_nodes`, `nodes_snapshot`, `get_metrics`) leads to acquiring the internal metrics mutex multiple times per call and performing numerous expensive deep clones of `NodeMetrics`. Exposing crate-private (`pub(crate)`) access to the underlying metrics map allows acquiring the mutex exactly once and performing a single linear iteration. This bypasses all allocation, cloning, and redundant lock acquisition overhead completely.
 **Action:** Consolidate multiple metrics lookup sweeps into a single-lock, zero-clone traversal. Expose inner collections internally (using `pub(crate)`) when complex multi-metric queries can be performed in a single lock acquisition rather than invoking multiple smaller methods.
+
+## 2026-07-25 - [Single-Pass Closure Mutex Inspection for Cluster Metrics]
+**Learning:** Calling `get_metrics` repeatedly inside loops for $N$ cluster nodes acquires a `Mutex` lock $N$ times and deep-clones `NodeMetrics` (including heap-allocated history vectors like `latency_history_us`). Exposing a `with_metrics<F, R>(&self, f: F) -> R` closure helper on `ClusterState` allows reading metrics for all nodes in a single lock acquisition without any memory allocations or struct cloning.
+**Action:** Use `with_metrics` closure inspection when processing or serializing metrics across multiple cluster nodes instead of calling `get_metrics` per node in a loop.

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -159,13 +159,7 @@ fn bench_cluster(c: &mut Criterion) {
     let snapshot_cluster = ClusterState::new();
     for i in 0..10 {
         let id = format!("node-{i}");
-        snapshot_cluster.register(NodeResources::new(
-            id.clone(),
-            24.0,
-            64.0,
-            "8.9",
-            None,
-        ));
+        snapshot_cluster.register(NodeResources::new(id.clone(), 24.0, 64.0, "8.9", None));
         snapshot_cluster.get_metrics_mut(&id, |m| {
             m.record_latency(1.0);
             m.record_throughput(10.0);

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -158,13 +158,18 @@ fn bench_cluster(c: &mut Criterion) {
     let cluster = ClusterState::new();
     let snapshot_cluster = ClusterState::new();
     for i in 0..10 {
+        let id = format!("node-{i}");
         snapshot_cluster.register(NodeResources::new(
-            format!("node-{i}"),
+            id.clone(),
             24.0,
             64.0,
             "8.9",
             None,
         ));
+        snapshot_cluster.get_metrics_mut(&id, |m| {
+            m.record_latency(1.0);
+            m.record_throughput(10.0);
+        });
     }
 
     let mut group = c.benchmark_group("cluster");
@@ -186,6 +191,15 @@ fn bench_cluster(c: &mut Criterion) {
             black_box(ghostlink_core::planning::calculate_cluster_health(
                 black_box(&snapshot_cluster),
             ))
+        });
+    });
+    group.bench_function("with_metrics_10_nodes", |b| {
+        b.iter(|| {
+            snapshot_cluster.with_metrics(|metrics_map| {
+                for i in 0..10 {
+                    black_box(metrics_map.get(&format!("node-{i}")));
+                }
+            })
         });
     });
     group.finish();

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -2121,74 +2121,74 @@ fn cached_models_scan(
 
 fn build_cluster_topology_json(cluster: &ClusterState) -> serde_json::Value {
     // Optimization: Borrow shared Arc<Vec<NodeResources>> via nodes_snapshot()
-    // instead of nodes(), avoiding deep cloning of NodeResources and heap allocation.
+    // instead of nodes(), and inspect metrics under a single Mutex lock with
+    // with_metrics() to eliminate per-node Mutex lock acquisition and NodeMetrics clones.
     let nodes = cluster.nodes_snapshot();
-    let topology_nodes = nodes
-        .iter()
-        .map(|node| {
-            let metrics = cluster.get_metrics(&node.id);
-            let status = metrics
-                .as_ref()
-                .map(|m| format!("{:?}", m.status))
-                .unwrap_or_else(|| "Unknown".to_string());
-            let latency_us = metrics.as_ref().map(|m| m.avg_latency_us).unwrap_or(0.0);
-            let throughput_gbps = metrics.as_ref().map(|m| m.throughput_gbps).unwrap_or(0.0);
-            let latency_history_us = metrics
-                .as_ref()
-                .map(|m| m.latency_history_us.iter().copied().collect::<Vec<_>>())
-                .unwrap_or_default();
-            let throughput_history_gbps = metrics
-                .as_ref()
-                .map(|m| {
-                    m.throughput_history_gbps
-                        .iter()
-                        .copied()
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            let ip_address = metrics
-                .as_ref()
-                .and_then(|m| m.ip_address)
-                .map(|addr| addr.ip().to_string());
-            let streaming_layers = metrics
-                .as_ref()
-                .and_then(|m| m.streaming_layers)
-                .map(|(start, end)| serde_json::json!({ "start": start, "end": end }));
-
-            serde_json::json!({
-                "id": node.id,
-                "label": node.gpu_name.clone().unwrap_or_else(|| node.id.clone()),
-                "compute_capability": node.compute_capability,
-                "vram_gb": node.vram_gb,
-                "system_memory_gb": node.system_memory_gb,
-                "status": status,
-                "latency_us": latency_us,
-                "throughput_gbps": throughput_gbps,
-                "latency_history_us": latency_history_us,
-                "throughput_history_gbps": throughput_history_gbps,
-                "ip_address": ip_address,
-                "streaming_layers": streaming_layers,
-            })
-        })
-        .collect::<Vec<_>>();
-
-    let edges = if let Some(root) = nodes.first() {
-        nodes
+    let (topology_nodes, edges) = cluster.with_metrics(|metrics_map| {
+        let topology_nodes = nodes
             .iter()
-            .skip(1)
             .map(|node| {
-                let metrics = cluster.get_metrics(&node.id);
+                let metrics = metrics_map.get(&node.id);
+                let status = metrics
+                    .map(|m| format!("{:?}", m.status))
+                    .unwrap_or_else(|| "Unknown".to_string());
+                let latency_us = metrics.map(|m| m.avg_latency_us).unwrap_or(0.0);
+                let throughput_gbps = metrics.map(|m| m.throughput_gbps).unwrap_or(0.0);
+                let latency_history_us = metrics
+                    .map(|m| m.latency_history_us.iter().copied().collect::<Vec<_>>())
+                    .unwrap_or_default();
+                let throughput_history_gbps = metrics
+                    .map(|m| {
+                        m.throughput_history_gbps
+                            .iter()
+                            .copied()
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                let ip_address = metrics
+                    .and_then(|m| m.ip_address)
+                    .map(|addr| addr.ip().to_string());
+                let streaming_layers = metrics
+                    .and_then(|m| m.streaming_layers)
+                    .map(|(start, end)| serde_json::json!({ "start": start, "end": end }));
+
                 serde_json::json!({
-                    "from": root.id,
-                    "to": node.id,
-                    "latency_us": metrics.as_ref().map(|m| m.avg_latency_us).unwrap_or(0.0),
-                    "throughput_gbps": metrics.as_ref().map(|m| m.throughput_gbps).unwrap_or(0.0),
+                    "id": node.id,
+                    "label": node.gpu_name.clone().unwrap_or_else(|| node.id.clone()),
+                    "compute_capability": node.compute_capability,
+                    "vram_gb": node.vram_gb,
+                    "system_memory_gb": node.system_memory_gb,
+                    "status": status,
+                    "latency_us": latency_us,
+                    "throughput_gbps": throughput_gbps,
+                    "latency_history_us": latency_history_us,
+                    "throughput_history_gbps": throughput_history_gbps,
+                    "ip_address": ip_address,
+                    "streaming_layers": streaming_layers,
                 })
             })
-            .collect::<Vec<_>>()
-    } else {
-        Vec::new()
-    };
+            .collect::<Vec<_>>();
+
+        let edges = if let Some(root) = nodes.first() {
+            nodes
+                .iter()
+                .skip(1)
+                .map(|node| {
+                    let metrics = metrics_map.get(&node.id);
+                    serde_json::json!({
+                        "from": root.id,
+                        "to": node.id,
+                        "latency_us": metrics.map(|m| m.avg_latency_us).unwrap_or(0.0),
+                        "throughput_gbps": metrics.map(|m| m.throughput_gbps).unwrap_or(0.0),
+                    })
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
+        (topology_nodes, edges)
+    });
 
     serde_json::json!({
         "summary": {
@@ -5976,31 +5976,33 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         // excluding ourselves and anything already present by id.
         let known_ids: std::collections::HashSet<String> =
             workers.iter().map(|w| w.id.clone()).collect();
-        for node in backend.cluster.nodes() {
-            if node.id == backend.local_node_id || known_ids.contains(&node.id) {
-                continue;
+        let nodes = backend.cluster.nodes_snapshot();
+        backend.cluster.with_metrics(|metrics_map| {
+            for node in nodes.iter() {
+                if node.id == backend.local_node_id || known_ids.contains(&node.id) {
+                    continue;
+                }
+                let metrics = metrics_map.get(&node.id);
+                let host = metrics
+                    .and_then(|m| m.ip_address)
+                    .map(|addr| addr.ip().to_string())
+                    .unwrap_or_else(|| node.id.clone());
+                workers.push(WorkerRecord {
+                    id: node.id.clone(),
+                    host,
+                    // Discovery only tells us the peer's IP (from the UDP reply
+                    // address); the OpenAI-API port isn't part of the discovery
+                    // frame (`rpc_port` is the separate ggml-rpc contribution
+                    // port, not this one), so assume the same default port
+                    // ghost-link listens on everywhere else in this UI.
+                    port: 8003,
+                    status: "Discovered".to_string(),
+                    model: "unknown".to_string(),
+                    threads: 4,
+                    load: 0,
+                });
             }
-            let metrics = backend.cluster.get_metrics(&node.id);
-            let host = metrics
-                .as_ref()
-                .and_then(|m| m.ip_address)
-                .map(|addr| addr.ip().to_string())
-                .unwrap_or_else(|| node.id.clone());
-            workers.push(WorkerRecord {
-                id: node.id.clone(),
-                host,
-                // Discovery only tells us the peer's IP (from the UDP reply
-                // address); the OpenAI-API port isn't part of the discovery
-                // frame (`rpc_port` is the separate ggml-rpc contribution
-                // port, not this one), so assume the same default port
-                // ghost-link listens on everywhere else in this UI.
-                port: 8003,
-                status: "Discovered".to_string(),
-                model: "unknown".to_string(),
-                threads: 4,
-                load: 0,
-            });
-        }
+        });
 
         Json(serde_json::json!({ "workers": workers }))
     }
@@ -6134,8 +6136,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         let (inf, node_count, cluster_vram, uptime_s, backend_name) = {
             let backend = lock_state(&state);
             let cluster = Arc::clone(&backend.cluster);
-            let nodes = cluster.nodes();
-            let node_count = nodes.len();
+            let node_count = cluster.node_count();
             let cluster_vram = cluster.total_vram_gb();
             let inf = backend.inference_metrics.snapshot();
             let uptime_s = backend.started_at.elapsed().as_secs_f32();
@@ -6189,7 +6190,7 @@ fn start_openai_api_server(port: u16, host: &str) -> Result<()> {
         let (inf, node_count, backend_name) = {
             let backend = lock_state(&state);
             let cluster = Arc::clone(&backend.cluster);
-            let node_count = cluster.nodes().len();
+            let node_count = cluster.node_count();
             let inf = backend.inference_metrics.snapshot();
             let backend_name = backend.inference_backend.as_str().to_string();
             (inf, node_count, backend_name)

--- a/crates/ghost-link/src/rpc_cluster.rs
+++ b/crates/ghost-link/src/rpc_cluster.rs
@@ -830,83 +830,85 @@ pub fn discover_rpc_peers(
     local_rpc_build_id: Option<&str>,
 ) -> Vec<RpcPeer> {
     let nodes = cluster.nodes_snapshot();
-    let mut peers: Vec<RpcPeer> = nodes
-        .iter()
-        .filter(|node| node.id != local_node_id)
-        .filter_map(|node| {
-            let rpc_port = node.rpc_port?;
-            let metrics = cluster.get_metrics(&node.id)?;
-            if metrics.status != NodeStatus::Active {
-                return None;
-            }
+    cluster.with_metrics(|metrics_map| {
+        let mut peers: Vec<RpcPeer> = nodes
+            .iter()
+            .filter(|node| node.id != local_node_id)
+            .filter_map(|node| {
+                let rpc_port = node.rpc_port?;
+                let metrics = metrics_map.get(&node.id)?;
+                if metrics.status != NodeStatus::Active {
+                    return None;
+                }
 
-            // Real-time health gate: a peer that's technically `Active` (its
-            // heartbeat hasn't timed out) can still be struggling badly
-            // enough that routing layers to it hurts overall throughput more
-            // than excluding it would. `delivery_ratio` defaults to 1.0 for
-            // a peer with no samples yet, so this never penalizes a
-            // freshly-joined node before it has real data.
-            //
-            // Deliberately NOT also gating on `metrics.avg_latency_us` here:
-            // that field is named as microseconds but is populated with
-            // millisecond-scale values elsewhere in this codebase (e.g.
-            // `record_latency(120.0)`/`record_latency(180.0)` in main.rs),
-            // and `planning::RebalanceTrigger`'s existing `> 15.0` threshold
-            // for it was written for the synthetic pipeline path, not
-            // measured against this real RPC heartbeat path. Copying an
-            // ambiguously-scaled cutoff here risks silently excluding every
-            // real peer (or none) depending on which unit actually applies
-            // — worse than not gating on it at all.
-            if metrics.delivery_ratio < RPC_PEER_MIN_DELIVERY_RATIO {
-                tracing::warn!(
-                    "rpc_cluster: excluding peer '{}' \u{2014} delivery_ratio {:.3} is below the \
-                     {RPC_PEER_MIN_DELIVERY_RATIO} health floor for distributed inference.",
-                    node.id,
-                    metrics.delivery_ratio,
-                );
-                return None;
-            }
-
-            match (local_rpc_build_id, node.rpc_build_id.as_deref()) {
-                (Some(local), Some(peer)) if local != peer => {
+                // Real-time health gate: a peer that's technically `Active` (its
+                // heartbeat hasn't timed out) can still be struggling badly
+                // enough that routing layers to it hurts overall throughput more
+                // than excluding it would. `delivery_ratio` defaults to 1.0 for
+                // a peer with no samples yet, so this never penalizes a
+                // freshly-joined node before it has real data.
+                //
+                // Deliberately NOT also gating on `metrics.avg_latency_us` here:
+                // that field is named as microseconds but is populated with
+                // millisecond-scale values elsewhere in this codebase (e.g.
+                // `record_latency(120.0)`/`record_latency(180.0)` in main.rs),
+                // and `planning::RebalanceTrigger`'s existing `> 15.0` threshold
+                // for it was written for the synthetic pipeline path, not
+                // measured against this real RPC heartbeat path. Copying an
+                // ambiguously-scaled cutoff here risks silently excluding every
+                // real peer (or none) depending on which unit actually applies
+                // — worse than not gating on it at all.
+                if metrics.delivery_ratio < RPC_PEER_MIN_DELIVERY_RATIO {
                     tracing::warn!(
-                        "rpc_cluster: excluding peer '{}' ({peer_addr:?}) \u{2014} llama.cpp \
-                         build mismatch (local: '{local}', peer: '{peer}'). Distributed \
-                         inference is skipping this peer because version-mismatched ggml-rpc \
-                         peers have been confirmed to silently corrupt output for larger models \
-                         while reporting healthy status throughout. Rebuild both nodes at the \
-                         same llama.cpp commit to re-enable this peer.",
+                        "rpc_cluster: excluding peer '{}' \u{2014} delivery_ratio {:.3} is below the \
+                         {RPC_PEER_MIN_DELIVERY_RATIO} health floor for distributed inference.",
                         node.id,
-                        peer_addr = metrics.ip_address,
+                        metrics.delivery_ratio,
                     );
                     return None;
                 }
-                (Some(local), Some(peer)) => {
-                    debug_assert_eq!(local, peer);
-                }
-                _ => {
-                    tracing::warn!(
-                        "rpc_cluster: peer '{}' did not report a verifiable llama.cpp build \
-                         fingerprint (predates version-compatibility checking, or couldn't \
-                         determine its own build id) \u{2014} cannot verify it matches this \
-                         node's build; proceeding anyway.",
-                        node.id
-                    );
-                }
-            }
 
-            let mut addr = metrics.ip_address?;
-            addr.set_port(rpc_port);
-            Some(RpcPeer {
-                node_id: node.id.clone(),
-                addr,
-                vram_gb: node.vram_gb,
-                system_memory_gb: metrics.system_memory_gb,
+                match (local_rpc_build_id, node.rpc_build_id.as_deref()) {
+                    (Some(local), Some(peer)) if local != peer => {
+                        tracing::warn!(
+                            "rpc_cluster: excluding peer '{}' ({peer_addr:?}) \u{2014} llama.cpp \
+                             build mismatch (local: '{local}', peer: '{peer}'). Distributed \
+                             inference is skipping this peer because version-mismatched ggml-rpc \
+                             peers have been confirmed to silently corrupt output for larger models \
+                             while reporting healthy status throughout. Rebuild both nodes at the \
+                             same llama.cpp commit to re-enable this peer.",
+                            node.id,
+                            peer_addr = metrics.ip_address,
+                        );
+                        return None;
+                    }
+                    (Some(local), Some(peer)) => {
+                        debug_assert_eq!(local, peer);
+                    }
+                    _ => {
+                        tracing::warn!(
+                            "rpc_cluster: peer '{}' did not report a verifiable llama.cpp build \
+                             fingerprint (predates version-compatibility checking, or couldn't \
+                             determine its own build id) \u{2014} cannot verify it matches this \
+                             node's build; proceeding anyway.",
+                            node.id
+                        );
+                    }
+                }
+
+                let mut addr = metrics.ip_address?;
+                addr.set_port(rpc_port);
+                Some(RpcPeer {
+                    node_id: node.id.clone(),
+                    addr,
+                    vram_gb: node.vram_gb,
+                    system_memory_gb: metrics.system_memory_gb,
+                })
             })
-        })
-        .collect();
-    peers.sort_by(|a, b| a.node_id.cmp(&b.node_id));
-    peers
+            .collect();
+        peers.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        peers
+    })
 }
 
 /// Computes a `--tensor-split` ratio: the local device first, then each

--- a/crates/ghostlink-core/src/cluster.rs
+++ b/crates/ghostlink-core/src/cluster.rs
@@ -408,6 +408,18 @@ impl ClusterState {
         self.nodes_snapshot.load_full()
     }
 
+    /// Execute a closure with a read lock on the metrics map, avoiding clones and multiple acquisitions.
+    pub fn with_metrics<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&HashMap<String, NodeMetrics>) -> R,
+    {
+        let metrics = self
+            .metrics
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        f(&metrics)
+    }
+
     /// Get metrics for a specific node
     pub fn get_metrics(&self, node_id: &str) -> Option<NodeMetrics> {
         let metrics = self
@@ -648,6 +660,21 @@ mod tests {
         metrics.record_delivery_ratio(0.90);
         // EMA: 0.98 * 0.9 + 0.90 * 0.1 = 0.882 + 0.09 = 0.972
         assert!((metrics.delivery_ratio - 0.972).abs() < 1e-6);
+    }
+
+    #[test]
+    fn with_metrics_allows_single_pass_inspection() {
+        let cluster = ClusterState::new();
+        cluster.register(NodeResources::new("node-a", 24.0, 64.0, "8.9", None));
+        cluster.register(NodeResources::new("node-b", 12.0, 32.0, "8.6", None));
+
+        let total_nodes = cluster.with_metrics(|metrics_map| {
+            assert!(metrics_map.contains_key("node-a"));
+            assert!(metrics_map.contains_key("node-b"));
+            metrics_map.len()
+        });
+
+        assert_eq!(total_nodes, 2);
     }
 
     #[test]


### PR DESCRIPTION
💡 What: Introduced `ClusterState::with_metrics<F, R>(&self, f: F) -> R` in `ghostlink-core` and refactored `discover_rpc_peers`, `build_cluster_topology_json`, and `handle_gui_workers` in `ghost-link` to inspect node metrics under a single lock acquisition without cloning `NodeMetrics`. Also replaced `cluster.nodes().len()` with `cluster.node_count()` in metrics handlers.

🎯 Why: Previously, iterating over nodes to construct topology JSON or discover RPC peers called `cluster.get_metrics(&node.id)` per node, acquiring the metrics `Mutex` $N$ times and deep-cloning `NodeMetrics` (which includes heap-allocated history vectors like `latency_history_us`).

📊 Impact: Reduces Mutex lock acquisitions from $O(N)$ to $O(1)$ and completely eliminates heap allocations / deep-cloning of `NodeMetrics` structs on dashboard, RPC discovery, and metrics polling hot paths.

🔬 Measurement: Added `with_metrics_10_nodes` benchmark to `benches/criterion.rs` and verified that all tests in `ghostlink-core` and `ghost-link` pass.

---
*PR created automatically by Jules for task [10797656794305852590](https://jules.google.com/task/10797656794305852590) started by @rwilliamspbg-ops*