### PR TITLE
🎨 Palette: Add retry action button to ErrorPanel component

### DIFF
--- a/ghostlink_gui_modern/src/components/SessionsTab.tsx
+++ b/ghostlink_gui_modern/src/components/SessionsTab.tsx
@@ -64,7 +64,7 @@ export const SessionsTab: React.FC<{ api: any }> = ({ api }) => {
       <div className="flex-1 overflow-y-auto p-6" tabIndex={0} role="region" aria-label="Sessions">
         <div className="max-w-5xl mx-auto">
           {error ? (
-            <ErrorPanel icon={XCircle} title="Connection Error" message={error} />
+            <ErrorPanel icon={XCircle} title="Connection Error" message={error} onRetry={refreshSessions} />
           ) : sessions.length === 0 ? (
             <EmptyState
               variant="card"

--- a/ghostlink_gui_modern/src/components/StatusViews.test.tsx
+++ b/ghostlink_gui_modern/src/components/StatusViews.test.tsx
@@ -23,6 +23,23 @@ describe('StatusViews', () => {
     expect(screen.getByText('Network timeout occurred.')).toBeInTheDocument();
   });
 
+  it('renders ErrorPanel with retry button and triggers onRetry on click', () => {
+    const handleRetry = vi.fn();
+    render(
+      <ErrorPanel
+        icon={AlertCircle}
+        title="Connection Error"
+        message="Backend unavailable."
+        onRetry={handleRetry}
+      />
+    );
+    const retryBtn = screen.getByRole('button', { name: 'Try Again' });
+    expect(retryBtn).toBeInTheDocument();
+    expect(retryBtn).toHaveClass('focus-visible:ring-2');
+    fireEvent.click(retryBtn);
+    expect(handleRetry).toHaveBeenCalledTimes(1);
+  });
+
   it('renders EmptyState with title and description', () => {
     render(<EmptyState icon={Inbox} title="No items found" description="Try refining your filter." />);
     expect(screen.getByText('No items found')).toBeInTheDocument();

--- a/ghostlink_gui_modern/src/components/StatusViews.tsx
+++ b/ghostlink_gui_modern/src/components/StatusViews.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Loader, type LucideIcon } from 'lucide-react';
+import { Loader, RefreshCw, type LucideIcon } from 'lucide-react';
 
 type IconType = LucideIcon;
 
@@ -71,10 +71,19 @@ interface ErrorPanelProps {
   icon?: IconType;
   title?: string;
   message: string;
+  onRetry?: () => void;
+  retryLabel?: string;
   className?: string;
 }
 
-export const ErrorPanel: React.FC<ErrorPanelProps> = ({ icon: Icon, title = 'Something went wrong', message, className = '' }) => (
+export const ErrorPanel: React.FC<ErrorPanelProps> = ({
+  icon: Icon,
+  title = 'Something went wrong',
+  message,
+  onRetry,
+  retryLabel = 'Try Again',
+  className = '',
+}) => (
   <div
     role="alert"
     aria-live="assertive"
@@ -83,5 +92,14 @@ export const ErrorPanel: React.FC<ErrorPanelProps> = ({ icon: Icon, title = 'Som
     {Icon && <Icon size={48} className="mb-4 opacity-40 text-red-400" aria-hidden="true" />}
     <p className="text-base font-medium text-red-400">{title}</p>
     <p className="text-sm text-slate-500 opacity-80 mt-1 max-w-sm">{message}</p>
+    {onRetry && (
+      <button
+        onClick={onRetry}
+        className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-red-600/20 hover:bg-red-600/30 text-red-300 border border-red-800/60 text-xs font-bold rounded-xl transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+      >
+        <RefreshCw size={14} aria-hidden="true" />
+        {retryLabel}
+      </button>
+    )}
   </div>
 );


### PR DESCRIPTION
🎨 Palette micro-UX enhancement: Adds an inline, keyboard-accessible "Try Again" retry action button to `ErrorPanel` in `StatusViews.tsx` and wires it in `SessionsTab.tsx`, allowing users to quickly recover from error states without hunting for header refresh triggers.

---
*PR created automatically by Jules for task [7493711407474188282](https://jules.google.com/task/7493711407474188282) started by @rwilliamspbg-ops*