### PR TITLE
🔒 Fix overly permissive CORS policy in control-plane gateway

### DIFF
--- a/control-plane/main.go
+++ b/control-plane/main.go
@@ -53,19 +53,66 @@ func requireControlPlaneAuth(w http.ResponseWriter, r *http.Request, expectedTok
 	return true
 }
 
-// corsMiddleware mirrors ghost-link's tower_http::cors::CorsLayer::permissive()
-// — the GUI calls this gateway's absolute URL cross-origin (a different port
-// than the Vite dev server), exactly like it already does to ghost-link
-// directly today, so the same permissive stance is needed here too.
+func getAllowedOrigins() []string {
+	raw := os.Getenv("GHOSTLINK_ALLOWED_ORIGINS")
+	if raw == "" {
+		return []string{"*"}
+	}
+	parts := strings.Split(raw, ",")
+	var origins []string
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			origins = append(origins, trimmed)
+		}
+	}
+	if len(origins) == 0 {
+		return []string{"*"}
+	}
+	return origins
+}
+
 func corsMiddleware(next http.Handler) http.Handler {
+	allowedOrigins := getAllowedOrigins()
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "*")
+		origin := r.Header.Get("Origin")
+
+		var allowOrigin string
+		allowAll := false
+
+		for _, o := range allowedOrigins {
+			if o == "*" {
+				allowAll = true
+				break
+			}
+			if origin != "" && strings.EqualFold(o, origin) {
+				allowOrigin = origin
+				break
+			}
+		}
+
+		if allowAll {
+			allowOrigin = "*"
+		}
+
+		if allowOrigin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+			if allowOrigin != "*" {
+				w.Header().Add("Vary", "Origin")
+			}
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "*")
+		}
+
 		if r.Method == http.MethodOptions {
+			if allowOrigin == "" && origin != "" {
+				http.Error(w, "CORS origin not allowed", http.StatusForbidden)
+				return
+			}
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/control-plane/main_test.go
+++ b/control-plane/main_test.go
@@ -78,6 +78,8 @@ func TestWorkersProxiesToBackend(t *testing.T) {
 }
 
 func TestCORSHeaders(t *testing.T) {
+	os.Unsetenv("GHOSTLINK_ALLOWED_ORIGINS")
+
 	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "", "")
 
 	req := httptest.NewRequest("OPTIONS", "/api/models", nil)
@@ -89,6 +91,56 @@ func TestCORSHeaders(t *testing.T) {
 	}
 	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
 		t.Errorf("expected permissive CORS origin, got %q", got)
+	}
+}
+
+func TestCORSAllowedOriginsConfig(t *testing.T) {
+	if err := os.Setenv("GHOSTLINK_ALLOWED_ORIGINS", "http://localhost:5173, http://localhost:3000"); err != nil {
+		t.Fatalf("set env: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Unsetenv("GHOSTLINK_ALLOWED_ORIGINS")
+	})
+
+	handler := buildHandler("http://127.0.0.1:19999", 1000, time.Second, "", "")
+
+	// 1. Allowed origin OPTIONS request
+	req1 := httptest.NewRequest("OPTIONS", "/api/models", nil)
+	req1.Header.Set("Origin", "http://localhost:5173")
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for allowed origin preflight, got %d", w1.Code)
+	}
+	if got := w1.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Errorf("expected Access-Control-Allow-Origin=http://localhost:5173, got %q", got)
+	}
+	if got := w1.Header().Get("Vary"); got != "Origin" {
+		t.Errorf("expected Vary header=Origin, got %q", got)
+	}
+
+	// 2. Disallowed origin OPTIONS request
+	req2 := httptest.NewRequest("OPTIONS", "/api/models", nil)
+	req2.Header.Set("Origin", "http://malicious-site.com")
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 Forbidden for disallowed origin preflight, got %d", w2.Code)
+	}
+	if got := w2.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected empty Access-Control-Allow-Origin for disallowed origin, got %q", got)
+	}
+
+	// 3. Disallowed origin GET request
+	req3 := httptest.NewRequest("GET", "/health", nil)
+	req3.Header.Set("Origin", "http://malicious-site.com")
+	w3 := httptest.NewRecorder()
+	handler.ServeHTTP(w3, req3)
+
+	if got := w3.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected empty Access-Control-Allow-Origin for disallowed GET origin, got %q", got)
 	}
 }
 


### PR DESCRIPTION
🎯 **What:** 
Fixed overly permissive CORS policy in `control-plane/main.go` by adding dynamic origin validation against the `GHOSTLINK_ALLOWED_ORIGINS` environment variable.

⚠️ **Risk:** 
Setting `Access-Control-Allow-Origin: *` unconditionally allowed any malicious origin to perform cross-origin requests and read responses from control-plane endpoints in web browsers.

🛡️ **Solution:** 
1. Added `getAllowedOrigins()` to read comma-separated origins from `GHOSTLINK_ALLOWED_ORIGINS` (defaulting to `*` if empty/unset to preserve existing local dev setup).
2. Updated `corsMiddleware` to inspect incoming `Origin` request headers and match against allowed origins:
   - Sets `Access-Control-Allow-Origin` to the exact request origin and appends `Vary: Origin` if matched.
   - Preserves wildcard `*` support if configured or fallback default.
   - Blocks disallowed origin `OPTIONS` preflight requests with `403 Forbidden` and omits `Access-Control-Allow-Origin` headers for unauthorized origins.
3. Added comprehensive unit tests in `control-plane/main_test.go` covering default wildcard behavior, allowed origin validation, `Vary` header insertion, and disallowed origin rejection.

---
*PR created automatically by Jules for task [7295962448823698358](https://jules.google.com/task/7295962448823698358) started by @rwilliamspbg-ops*