### PR TITLE
🎨 Palette: MCP Tab actionable empty state and modal focus trap

### DIFF
--- a/ghostlink_gui_modern/src/components/McpTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/McpTab.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { McpTab } from './McpTab';
+import { useAppStore } from '../store';
+
+function createMockApi() {
+  return {
+    listMcpServers: vi.fn().mockResolvedValue({
+      servers: [],
+    }),
+    toggleMcpServer: vi.fn().mockResolvedValue({ success: true, servers: [] }),
+    deleteMcpServer: vi.fn().mockResolvedValue({ success: true, servers: [] }),
+    createMcpServer: vi.fn().mockResolvedValue({ success: true, servers: [] }),
+    updateMcpServer: vi.fn().mockResolvedValue({ success: true, servers: [] }),
+  };
+}
+
+describe('McpTab', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      mcpServers: [],
+      setMcpServers: (servers) => useAppStore.setState({ mcpServers: servers }),
+      addToast: vi.fn(),
+    } as any);
+  });
+
+  it('renders empty state with CTA button that opens the modal', async () => {
+    const api = createMockApi();
+    render(<McpTab api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No MCP servers configured')).toBeInTheDocument();
+    });
+
+    const addButtons = screen.getAllByRole('button', { name: /Add Server/i });
+    expect(addButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(addButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Add MCP Server' })).toBeInTheDocument();
+    });
+  });
+
+  it('traps focus inside the dialog when Tab key is pressed', async () => {
+    const api = createMockApi();
+    render(<McpTab api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No MCP servers configured')).toBeInTheDocument();
+    });
+
+    const addButton = screen.getAllByRole('button', { name: /Add Server/i })[0];
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Add MCP Server' })).toBeInTheDocument();
+    });
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+
+    cancelButton.focus();
+    expect(document.activeElement).toBe(cancelButton);
+
+    // Tab from last focusable item (Save button) should cycle back to first (Close button)
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    saveButton.focus();
+    expect(document.activeElement).toBe(saveButton);
+
+    fireEvent.keyDown(document.activeElement!, { key: 'Tab', shiftKey: false });
+    expect(document.activeElement).toBe(closeButton);
+
+    // Shift+Tab from first focusable item (Close button) should cycle back to last (Save button)
+    fireEvent.keyDown(document.activeElement!, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(saveButton);
+  });
+
+  it('restores focus to trigger button when modal is closed', async () => {
+    const api = createMockApi();
+    render(<McpTab api={api} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No MCP servers configured')).toBeInTheDocument();
+    });
+
+    const addButton = screen.getAllByRole('button', { name: /Add Server/i })[0];
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Add MCP Server' })).toBeInTheDocument();
+    });
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(addButton);
+    });
+  });
+});

--- a/ghostlink_gui_modern/src/components/McpTab.tsx
+++ b/ghostlink_gui_modern/src/components/McpTab.tsx
@@ -69,6 +69,7 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   const [saving, setSaving] = useState(false);
   const editorCloseRef = useRef<HTMLButtonElement>(null);
   const editorTriggerRef = useRef<HTMLElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const refresh = async () => {
     setLoading(true);
@@ -151,7 +152,30 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
   useEffect(() => {
     if (editorTarget === null) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeEditor();
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeEditor();
+        return;
+      }
+      if (e.key === 'Tab') {
+        const dialog = dialogRef.current;
+        if (!dialog) return;
+        const focusables = Array.from(
+          dialog.querySelectorAll<HTMLElement>(
+            'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+          )
+        );
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
     };
     document.addEventListener('keydown', handleKey);
     editorCloseRef.current?.focus();
@@ -253,6 +277,11 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
               icon={Plug}
               title="No MCP servers configured"
               description="Click Add Server above, or hand-edit mcp_servers.toml and refresh."
+              action={{
+                label: 'Add Server',
+                onClick: (e) => openCreateEditor(e.currentTarget as HTMLElement),
+                icon: Plus,
+              }}
             />
           )}
 
@@ -360,6 +389,7 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={closeEditor}>
           {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- onClick here only stops the backdrop's close-on-click from firing when clicking inside the dialog, it's not a control */}
           <div
+            ref={dialogRef}
             role="dialog"
             aria-modal="true"
             aria-labelledby="mcp-editor-title"

--- a/ghostlink_gui_modern/src/components/McpTab.tsx
+++ b/ghostlink_gui_modern/src/components/McpTab.tsx
@@ -125,8 +125,8 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
     setDeleting(null);
   };
 
-  const openCreateEditor = (trigger: HTMLElement) => {
-    editorTriggerRef.current = trigger;
+  const openCreateEditor = (trigger?: HTMLElement | null) => {
+    editorTriggerRef.current = trigger || null;
     setForm(EMPTY_FORM);
     setEnvText('');
     setArgsText('');
@@ -279,7 +279,7 @@ export const McpTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
               description="Click Add Server above, or hand-edit mcp_servers.toml and refresh."
               action={{
                 label: 'Add Server',
-                onClick: (e) => openCreateEditor(e.currentTarget as HTMLElement),
+                onClick: () => openCreateEditor(),
                 icon: Plus,
               }}
             />


### PR DESCRIPTION
Added an actionable 'Add Server' CTA button to the empty state view in McpTab.tsx when no MCP servers are configured, and implemented keyboard focus trapping and focus restoration in the MCP Server editor modal dialog. Added unit tests in McpTab.test.tsx.

---
*PR created automatically by Jules for task [9685441800164827158](https://jules.google.com/task/9685441800164827158) started by @rwilliamspbg-ops*