### PR TITLE
🎨 Palette: Enhance Chat Sidebar Thread Accessibility & Focus States

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal
 
+## 2026-08-20 - [Chat Sidebar Thread Navigation Accessibility & Focus States]
+**Learning:** Non-semantic click containers (such as non-interactive `div` wrappers used for saved thread items in sidebars) completely lock out keyboard navigators, as default Tab traversal skips them entirely. Refactoring item rows to use semantic `<button>` elements for thread selection—complemented by high-contrast `focus-visible:` focus outlines, explicit `aria-label`s, and `group-focus-within:opacity-100` on secondary action triggers (Pin, Rename, Delete)—guarantees keyboard users can focus and interact with every chat thread and action trigger seamlessly.
+**Action:** Always implement listbox and tree item triggers using semantic `<button>` elements with `focus-visible:` focus rings, explicit ARIA labels, and `group-focus-within` visibility for inline action triggers.
+
 ## 2026-08-19 - [Actionable Empty States with Call-To-Action Controls]
 **Learning:** Empty dashboard views (such as Sessions with no active inference runs or Workers with no connected cluster nodes) can leave users stranded if they only display static text instructions. Supporting an optional `action` prop in shared `EmptyState` components provides inline, keyboard-accessible call-to-action buttons (with high-contrast focus rings and contextual icons) that directly guide users to resolution (e.g. switching tabs or opening creation forms).
 **Action:** Always complement empty state messages with actionable CTA buttons when a primary user action (like starting a session or adding a node) can resolve the empty state.

--- a/ghostlink_gui_modern/src/components/ChatTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.test.tsx
@@ -338,5 +338,28 @@ describe('ChatTab', () => {
 
       expect(presetSelect).toHaveValue("concise");
     });
+
+    it("renders keyboard-accessible thread item buttons in sidebar", () => {
+      useAppStore.setState({
+        threads: [
+          { id: "thread-1", title: "Project Architecture", messages: [], createdAt: Date.now(), updatedAt: Date.now() },
+        ],
+        activeThreadId: "thread-1",
+      });
+      const api = createMockApi();
+      render(<ChatTab api={api} />);
+
+      const selectBtn = screen.getByRole("button", { name: "Select thread Project Architecture" });
+      expect(selectBtn).toBeInTheDocument();
+
+      const pinBtn = screen.getByRole("button", { name: "Pin thread Project Architecture" });
+      expect(pinBtn).toBeInTheDocument();
+
+      const renameBtn = screen.getByRole("button", { name: "Rename thread Project Architecture" });
+      expect(renameBtn).toBeInTheDocument();
+
+      const deleteBtn = screen.getByRole("button", { name: "Delete thread Project Architecture" });
+      expect(deleteBtn).toBeInTheDocument();
+    });
   });
 });

--- a/ghostlink_gui_modern/src/components/ChatTab.tsx
+++ b/ghostlink_gui_modern/src/components/ChatTab.tsx
@@ -1347,7 +1347,8 @@ const ThreadSidebarItem: React.FC<ThreadItemProps> = ({
           type="text"
           value={renameInput}
           onChange={(e) => setRenameInput(e.target.value)}
-          className="w-full bg-slate-950 border border-slate-800 rounded px-2 py-1 text-xs text-slate-200 focus:outline-none"
+          aria-label={`Rename thread ${thread.title}`}
+          className="w-full bg-slate-950 border border-slate-800 rounded px-2 py-1 text-xs text-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus
           onKeyDown={(e) => {
@@ -1355,56 +1356,63 @@ const ThreadSidebarItem: React.FC<ThreadItemProps> = ({
             if (e.key === "Escape") onCancelRename();
           }}
         />
-        <button onClick={onSaveRename} className="p-1 text-green-400 hover:text-green-300">
-          <Check size={14} />
+        <button
+          type="button"
+          onClick={onSaveRename}
+          className="p-1 text-green-400 hover:text-green-300 rounded focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+          title="Save title"
+          aria-label="Save thread title"
+        >
+          <Check size={14} aria-hidden="true" />
         </button>
       </div>
     );
   }
 
   return (
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
     <div
-      className={`group flex items-center justify-between px-2.5 py-1.5 rounded-xl text-xs transition cursor-pointer ${
-
-        isActive ? "bg-blue-600/10 text-blue-400 font-semibold" : "text-slate-400 hover:bg-slate-900 hover:text-slate-200"
+      className={`group flex items-center justify-between px-2.5 py-1.5 rounded-xl text-xs transition ${
+        isActive ? "bg-blue-600/10" : "hover:bg-slate-900"
       }`}
-      onClick={onSelect}
     >
-      <div className="flex items-center gap-2 min-w-0">
-        <MessageSquare size={13} className="flex-shrink-0" />
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-label={`Select thread ${thread.title}`}
+        className={`flex items-center gap-2 min-w-0 flex-1 text-left rounded-lg transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none ${
+          isActive ? "text-blue-400 font-semibold" : "text-slate-400 hover:text-slate-200"
+        }`}
+      >
+        <MessageSquare size={13} className="flex-shrink-0" aria-hidden="true" />
         <span className="truncate">{thread.title}</span>
-      </div>
-      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition">
+      </button>
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition">
         <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onTogglePin();
-          }}
-          className="p-1 hover:text-white rounded"
+          type="button"
+          onClick={onTogglePin}
+          className="p-1 text-slate-400 hover:text-white rounded focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
           title={thread.pinned ? "Unpin thread" : "Pin thread"}
+          aria-label={thread.pinned ? `Unpin thread ${thread.title}` : `Pin thread ${thread.title}`}
         >
-          {thread.pinned ? <PinOff size={12} /> : <Pin size={12} />}
+          {thread.pinned ? <PinOff size={12} aria-hidden="true" /> : <Pin size={12} aria-hidden="true" />}
         </button>
         <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onStartRename();
-          }}
-          className="p-1 hover:text-white rounded"
+          type="button"
+          onClick={onStartRename}
+          className="p-1 text-slate-400 hover:text-white rounded focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
           title="Rename thread"
+          aria-label={`Rename thread ${thread.title}`}
         >
-          <Pencil size={12} />
+          <Pencil size={12} aria-hidden="true" />
         </button>
         <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete();
-          }}
-          className="p-1 hover:text-red-400 rounded"
+          type="button"
+          onClick={onDelete}
+          className="p-1 text-slate-400 hover:text-red-400 rounded focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
           title="Delete thread"
+          aria-label={`Delete thread ${thread.title}`}
         >
-          <Trash2 size={12} />
+          <Trash2 size={12} aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/ghostlink_gui_modern/src/components/SecurityTab.tsx
+++ b/ghostlink_gui_modern/src/components/SecurityTab.tsx
@@ -263,6 +263,7 @@ export const SecurityTab: React.FC<{ api: any }> = ({ api }) => {
                   onClick={async () => { const result = await api.getAuditLog(); if (result.entries) setAuditLog(result.entries); }}
                   className="p-2 hover:bg-slate-800 rounded-lg transition text-slate-500 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
                   aria-label="Refresh audit log"
+                  title="Refresh audit log"
                 >
                   <RefreshCw size={14} aria-hidden="true" />
                 </button>


### PR DESCRIPTION
Enhances keyboard accessibility and visual focus feedback in the Chat tab thread sidebar and Security audit log.

- Refactored `ThreadSidebarItem` in `ghostlink_gui_modern/src/components/ChatTab.tsx` from non-semantic `div` elements into semantic, keyboard-accessible `<button>` triggers with high-contrast focus rings (`focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none`) and explicit `aria-label` attributes.
- Added `group-focus-within:opacity-100` to thread action buttons (Pin, Rename, Delete) so action controls become visually apparent when focused via keyboard navigation.
- Added native `title="Refresh audit log"` to the security audit log refresh button in `ghostlink_gui_modern/src/components/SecurityTab.tsx`.
- Added unit test in `ghostlink_gui_modern/src/components/ChatTab.test.tsx` verifying keyboard accessibility and ARIA attributes for thread item buttons.

---
*PR created automatically by Jules for task [1141359988188671272](https://jules.google.com/task/1141359988188671272) started by @rwilliamspbg-ops*