### PR TITLE
🎨 Palette: Add ARIA labels and focus ring to HealthPanel recovery form

### DIFF
--- a/ghostlink_gui_modern/src/components/HealthPanel.tsx
+++ b/ghostlink_gui_modern/src/components/HealthPanel.tsx
@@ -223,11 +223,15 @@ export const HealthPanel: React.FC<HealthPanelProps> = ({ api, onNavigateToTab }
               placeholder="Paste Bearer API key..."
               value={inputApiKey}
               onChange={(e) => setInputApiKey(e.target.value)}
-              className="flex-1 px-3 py-2 bg-slate-950 border border-slate-800 rounded-lg text-xs text-slate-200 font-mono focus:outline-none focus:border-amber-500"
+              aria-label="Recovery API key input"
+              title="Enter Bearer API key for HTTP 401 recovery"
+              className="flex-1 px-3 py-2 bg-slate-950 border border-slate-800 rounded-lg text-xs text-slate-200 font-mono focus:outline-none focus:border-amber-500 focus-visible:ring-2 focus-visible:ring-amber-500"
             />
             <button
               type="submit"
-              className="px-4 py-2 bg-amber-600 hover:bg-amber-500 text-white rounded-lg text-xs font-bold transition focus-visible:ring-2 focus-visible:ring-amber-500"
+              aria-label="Apply recovery API key"
+              title="Apply recovery API key"
+              className="px-4 py-2 bg-amber-600 hover:bg-amber-500 text-white rounded-lg text-xs font-bold transition focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:outline-none"
             >
               Apply Key
             </button>

--- a/ghostlink_gui_modern/src/components/SecurityTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/SecurityTab.test.tsx
@@ -86,4 +86,22 @@ describe('SecurityTab', () => {
     expect(writeTextMock).toHaveBeenCalledWith('a.b.c');
     expect(await screen.findByRole('button', { name: /copied token/i })).toBeInTheDocument();
   });
+
+  it('renders recovery API key form with proper ARIA labels when health check returns 401', async () => {
+    const api = createMockApi({
+      getHealth: vi.fn().mockResolvedValue({ success: false, error: '401' }),
+      getModels: vi.fn().mockResolvedValue({ error: '401' }),
+      getInferenceEngines: vi.fn().mockRejectedValue({ response: { status: 401 } }),
+    });
+
+    render(<SecurityTab api={api} />);
+
+    const recoveryInput = await screen.findByLabelText(/recovery api key input/i);
+    const applyButton = screen.getByRole('button', { name: /apply recovery api key/i });
+
+    expect(recoveryInput).toBeInTheDocument();
+    expect(recoveryInput).toHaveAttribute('title', 'Enter Bearer API key for HTTP 401 recovery');
+    expect(applyButton).toBeInTheDocument();
+    expect(applyButton).toHaveAttribute('title', 'Apply recovery API key');
+  });
 });


### PR DESCRIPTION
Added ARIA labels, title tooltips, and focus-visible ring styling to the HTTP 401 recovery form controls in HealthPanel.tsx. Added unit test coverage in SecurityTab.test.tsx verifying the accessibility properties.

---
*PR created automatically by Jules for task [528820193596376951](https://jules.google.com/task/528820193596376951) started by @rwilliamspbg-ops*