### PR TITLE
🎨 Palette: Enhance HealthPanel Re-probe button accessibility and ARIA states

### DIFF
--- a/ghostlink_gui_modern/src/components/HealthPanel.tsx
+++ b/ghostlink_gui_modern/src/components/HealthPanel.tsx
@@ -120,10 +120,12 @@ export const HealthPanel: React.FC<HealthPanelProps> = ({ api, onNavigateToTab }
         <button
           onClick={runProbes}
           disabled={probing}
+          aria-label={probing ? 'Probing system health...' : 'Re-run health probes'}
+          aria-busy={probing}
           className="flex items-center gap-2 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 text-slate-300 hover:text-white rounded-lg text-xs font-bold transition disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
           title="Re-run health probes"
         >
-          <RefreshCw size={14} className={probing ? 'animate-spin' : ''} />
+          <RefreshCw size={14} className={probing ? 'animate-spin' : ''} aria-hidden="true" />
           {probing ? 'Probing...' : 'Re-probe'}
         </button>
       </div>

--- a/ghostlink_gui_modern/src/components/StatusViews.test.tsx
+++ b/ghostlink_gui_modern/src/components/StatusViews.test.tsx
@@ -2,8 +2,24 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { AlertCircle, Inbox, Plus } from 'lucide-react';
 import { EmptyState, ErrorPanel, LoadingState } from './StatusViews';
+import { HealthPanel } from './HealthPanel';
 
 describe('StatusViews', () => {
+  it('renders HealthPanel with accessible Re-probe button attributes', async () => {
+    const mockApi = {
+      getHealth: vi.fn().mockResolvedValue({ success: true }),
+      getModels: vi.fn().mockResolvedValue({ models: [], current_model: 'llama-3' }),
+      getInferenceEngines: vi.fn().mockResolvedValue({ engines: [] }),
+      setApiKey: vi.fn(),
+    };
+
+    render(<HealthPanel api={mockApi as any} />);
+
+    const reprobeButton = await screen.findByRole('button', { name: /re-run health probes/i });
+    expect(reprobeButton).toBeInTheDocument();
+    expect(reprobeButton).toHaveAttribute('aria-label', 'Re-run health probes');
+    expect(reprobeButton).toHaveAttribute('aria-busy', 'false');
+  });
   it('renders LoadingState with correct ARIA attributes and motion-safe spin class', () => {
     render(<LoadingState label="Fetching models..." />);
     const statusEl = screen.getByRole('status');


### PR DESCRIPTION
Enhances the HealthPanel Re-probe trigger button in `ghostlink_gui_modern/src/components/HealthPanel.tsx` with dynamic `aria-label` attributes (`Probing system health...` when probing vs `Re-run health probes`), explicit `aria-busy={probing}`, and `aria-hidden="true"` on the internal SVG spinner icon. Also adds unit test assertions in `StatusViews.test.tsx` to verify these accessibility attributes.

---
*PR created automatically by Jules for task [5414982428206431545](https://jules.google.com/task/5414982428206431545) started by @rwilliamspbg-ops*