### PR TITLE
docs: align version claims and distributed-inference truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Ghostlink Studio are documented here.
 
 ## [Unreleased]
 
+### Documentation & Truth Alignment
+
+- **Version Badge & Development Note**: Clarified that `main` branch development is ahead of the last tagged release (`v2.0.0`) and aligned version badge claims in `README.md`.
+- **Distributed Inference vs Research Pipelines**: Clarified in `README.md` that production OpenAI-compatible endpoints (`/v1/chat/completions`) run via llama.cpp's `ggml-rpc` tensor splitting, while zero-copy SPSC ring buffers and `flow` pipelines serve as transport/latency research components.
+- **Role-Based API Key Access Control Reconciliation**: Updated `README.md`, `docs/SECURITY_MODEL.md`, `docs/ROADMAP.md`, `docs/ENTERPRISE_PLAN.md`, and `docs/API_REFERENCE.md` to precisely distinguish role-based API key access control (`Admin`, `Operator`, `Viewer` roles on API keys in `crates/ghost-link/src/auth.rs`) from full multi-user / multi-tenant RBAC (user identities, team/project scoping, per-resource permissions).
+- **Current Truth Callouts**: Added 'Current truth' callout boxes to `docs/ROADMAP.md` and `docs/BENCHMARKS.md` documenting verified capabilities (30B model capacity split across nodes) vs unproven/in-progress capabilities (usable high tok/s and zero-touch one-command cluster setup).
+
 ## [2.1.0] - 2026-08-18
 
 ### Phase 6: Polish and Consistency Pass (Single Source of Truth, Port Alignment & Command Palette)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Route workloads across CPU, GPU, and NPU resources with explicit scheduling, har
   a request automatically splits across it via llama.cpp's own RPC backend —
   zero-config, no manual `--rpc` flags
 - Hardware-aware placement across mixed compute environments (CPU, GPU, NPU)
-- SPSC ring-buffer transport with spin-wait for sub-microsecond handoff
+- SPSC ring-buffer transport with spin-wait for sub-microsecond handoff (transport and latency research; real distributed inference uses llama.cpp's `ggml-rpc`)
 - TCP and Unix domain socket transport for multi-process pipelines
 - Session-level authentication on transport frames
 - Dynamic system profile watching with auto-tuning cache
@@ -257,8 +257,10 @@ these ran one after another with no shared state between them.
 
 ## Performance
 
-Sub-microsecond core primitives drive Ghostlink's distributed inference fabric. Benchmarks
+Sub-microsecond core primitives drive Ghostlink's transport and latency research layer. Benchmarks
 run on an **Intel i7-14700K (Linux/WSL2)** with `RUSTFLAGS="-C target-cpu=native"`.
+
+*Note: Real distributed LLM inference (`/v1/chat/completions`) uses llama.cpp's `ggml-rpc` tensor splitting. The zero-copy SPSC ring buffers and `flow` pipelines benchmarked below serve as transport and latency research components, and `/v1/chat/completions` does not run on `ghost-link flow`.*
 
 ### Microbenchmarks
 
@@ -400,11 +402,12 @@ cargo run -p ghost-link -- dashboard
 ### API Endpoints
 
 Every route below except `/health` requires `Authorization: Bearer <token>` —
-either the API key printed once at server startup (also saved to
-`api_key.txt`), or a short-lived JWT exchanged for it via
-`POST /api/security/jwt/refresh`. See [docs/API_REFERENCE.md](docs/API_REFERENCE.md)
-for full request/response examples and [docs/openapi.yaml](docs/openapi.yaml)
-for a machine-readable spec.
+either an API key printed once at server startup (saved to `api_key.txt`),
+or a short-lived JWT exchanged for it via `POST /api/security/jwt/refresh`.
+API keys carry role-based access permissions (`Admin`, `Operator`, or `Viewer`)
+for single-operator access control. Full multi-user / multi-tenant RBAC remains an open roadmap item.
+See [docs/API_REFERENCE.md](docs/API_REFERENCE.md) for full request/response examples
+and [docs/openapi.yaml](docs/openapi.yaml) for a machine-readable spec.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -424,6 +427,7 @@ for a machine-readable spec.
 | `/api/inference/chat` | POST | Chat completion |
 | `/api/models/partial` | GET | List interrupted downloads (`.gguf.part` files) |
 | `/api/models/partial/discard` | POST | Delete an interrupted download |
+| `/api/security/keys` | GET / POST / DELETE | Manage API keys and role assignments (`Admin`-gated) |
 | `/api/security/jwt/refresh` | POST | Exchange the API key for a short-lived JWT |
 | `/api/security/pqc/state` | GET | Whether this running server is serving HTTPS/PQC-hybrid TLS |
 | `/api/security/pqc/enable` | POST | Persist `enable_tls: true` (takes effect on next restart) |
@@ -599,6 +603,8 @@ CI enforces the same checks across Ubuntu, Windows, and macOS.
 ## Project Status
 
 Ghostlink is positioned as a launch-ready open-source foundation with a strong demo story and public-facing collateral.
+
+*Note: `main` branch development is ahead of the last tagged release (`v2.0.0`).*
 
 Current strengths:
 - a working local launch path for experimentation and demos,

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -7,7 +7,7 @@ model management and worker discovery) see the table in
 machine-readable spec of the routes documented here, see
 [openapi.yaml](openapi.yaml).
 
-## Authentication
+## Authentication & Key Roles
 
 Every route except `/health` requires a bearer token:
 
@@ -17,12 +17,18 @@ Authorization: Bearer <token>
 
 On first run, the server generates a 256-bit API key, persists it to
 `api_key.txt` (or the path in `GHOSTLINK_API_KEY_PATH`), and prints it once
-to the console — that printout is the only way to learn it, since no API
-response ever returns it. Two kinds of token are accepted:
+to the console — that initial key carries the `Admin` role.
 
+The server enforces **role-based API key access control** (`crates/ghost-link/src/auth.rs`):
+- **`Admin`**: Full system administration. Can manage API keys (`/api/security/keys`), enable PQC TLS, and export audit logs.
+- **`Operator`**: Full operational capability. Can load/unload models, submit inference requests (`/v1/chat/completions`), and edit workspace files.
+- **`Viewer`**: Read-only inspection. Can view health, metrics, cluster status, audit logs, and exchange valid keys for JWTs.
+
+*Note: Role gating applies to API keys for operator access control; full multi-user / multi-tenant RBAC (user accounts, team namespacing, resource isolation) is not implemented.*
+
+Two kinds of token are accepted:
 1. **The raw API key itself** — simplest for a script or `curl`.
-2. **A short-lived JWT** (1 hour, HS256) exchanged for the API key via
-   `POST /api/security/jwt/refresh`.
+2. **A short-lived JWT** (1 hour, HS256) exchanged for a valid key via `POST /api/security/jwt/refresh`.
 
 A request with no token, an expired JWT, or a wrong value gets `401`:
 
@@ -65,6 +71,12 @@ curl http://127.0.0.1:8000/api/security/pqc/state \
   "note": "TLS is not active on this server (plain HTTP) — no key exchange is happening. Enable via POST /api/security/pqc/enable and restart."
 }
 ```
+
+### Key Management (`Admin`-gated)
+
+- `GET /api/security/keys`: List all active API keys (returns ID, name, role, created timestamp, and last 4 chars preview).
+- `POST /api/security/keys`: Create a new key (body: `{"name": "ci-bot", "role": "Operator"}`). Returns newly generated raw key once.
+- `DELETE /api/security/keys/:id`: Revoke a key by ID (immediately invalidating any outstanding JWTs for it). Refuses to delete the last remaining `Admin` key.
 
 ### Audit log
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,5 +1,11 @@
 # Ghostlink Studio - Performance Benchmarks
 
+> [!NOTE]
+> **Current truth (Verified: 2026-08-18)**
+> - **Proven:** Distributed VRAM/RAM capacity splitting across heterogeneous LAN nodes via `ggml-rpc` (e.g., loading and running a 30B-class MoE model split across nodes that individual machines cannot hold alone).
+> - **Unproven / In Progress:** High usable tokens-per-second (tok/s) throughput on network-bound split layers, and a fully automated zero-touch "one-command cluster" setup without manual network/contributor configuration.
+
+
 ## Overview
 
 This document contains performance benchmarks for the Ghostlink Studio system, measuring throughput and latency across different configurations.

--- a/docs/ENTERPRISE_PLAN.md
+++ b/docs/ENTERPRISE_PLAN.md
@@ -106,8 +106,7 @@ ROADMAP.md and SECURITY_MODEL.md already name honestly:
    inference requests. Wiring it to actually record auth failures, admin
    actions, and config changes is cheap relative to its trust payoff —
    prioritize it ahead of most Horizon 2 items.
-2. **RBAC / scoped multi-user API keys** — today's model is effectively
-   single-operator (one API key or JWT per instance). Any team deployment
+2. **Multi-user / multi-tenant RBAC** — today's model is role-based API key access control (`Admin`, `Operator`, `Viewer` roles on API keys in `auth.rs`), but lacks full multi-user identity management or team/project scoping. Any team deployment
    needs per-user scoped keys before it's a credible "team" or "enterprise"
    story, not just a home-lab one.
 3. **mTLS for fabric/node-to-node transport** (SECURITY_MODEL.md Roadmap

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,11 @@
 # Ghostlink: Path to Category Leadership
 
+> [!NOTE]
+> **Current truth (Verified: 2026-08-18)**
+> - **Proven:** Distributed VRAM/RAM capacity splitting across heterogeneous LAN nodes via `ggml-rpc` (e.g., loading and running a 30B-class MoE model split across nodes that individual machines cannot hold alone).
+> - **Unproven / In Progress:** High usable tokens-per-second (tok/s) throughput on network-bound split layers, and a fully automated zero-touch "one-command cluster" setup without manual network/contributor configuration.
+
+
 This is a competitive strategy document, not a task backlog. It answers one
 question: what does Ghostlink need to become the obvious choice instead of
 vLLM, Ollama, LM Studio, llama.cpp server, OpenWebUI, or a Kubernetes-based
@@ -397,7 +403,7 @@ Once Priority Zero is real and provable, these make it hard to copy.
 4. **LoRA / adapter support** in the native engine path — increasingly
    table-stakes, currently absent.
 5. **RBAC + audit logging that's actually populated.** **Status check
-   (2026-08-08): audit logging is done, RBAC is not.**
+   (2026-08-08): audit logging and API key role gating (Admin/Operator/Viewer) are done; full multi-user/multi-tenant RBAC is not.**
    `/api/security/audit-log` used to be hardcoded to always return empty;
    it's now backed by a real in-memory, capped (`AUDIT_LOG_CAP`) log of
    actual security events (failed auth, PQC/JWT actions, tool-call
@@ -481,7 +487,7 @@ speculative gold-plating.
 1. **Scoped API keys / RBAC** — teams/projects namespacing, least-privilege
    MCP tool access, model-level permissions. This *is* Horizon 2 item 5's
    remaining piece, not a new item; sequencing note below. **Status check
-   (2026-08-15): the core (3-role RBAC) shipped.** `auth.rs` now persists a
+   (2026-08-15): the core 3-role API key access control shipped.** `auth.rs` now persists a
    hashed, multi-key store (`api_keys.json`) instead of one shared global
    key — each key carries a role (`Admin`/`Operator`/`Viewer`), checked by
    `main.rs`'s `required_role()` against every route (GET/HEAD default to

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -15,7 +15,7 @@ This document summarizes current security assumptions for Ghost-Link runtime and
 - Versioned discovery-frame authentication using HMAC-SHA256 with timestamp and nonce replay guards.
 - Optional transport auth token controls for TCP flow runs.
 - GUI readiness diagnostics and environment preflight checks.
-- **RBAC with scoped, revocable API keys** (since 2.0.0, `crates/ghost-link/src/auth.rs`):
+- **Role-based API key access control** (since 2.0.0, `crates/ghost-link/src/auth.rs`):
   a persisted, hashed multi-key store (`api_keys.json` — SHA-256 hash + last-4
   preview only, the raw key value is never stored) replaces a single shared
   bearer token. Each key carries a role — `Admin`, `Operator`, or `Viewer` —
@@ -30,7 +30,7 @@ This document summarizes current security assumptions for Ghost-Link runtime and
   `jwt_signing_secret` (`jwt_secret.txt`, `GHOSTLINK_JWT_SECRET_PATH`
   override) rather than the raw API key, and a JWT is only honored while its
   subject key id is still present in the store — revoking a key immediately
-  invalidates any outstanding JWT for it. See [API_REFERENCE.md](API_REFERENCE.md).
+  invalidates any outstanding JWT for it. *Note: this provides role-based API key authorization for operator access control (`Admin`, `Operator`, `Viewer`), but does not provide full multi-user / multi-tenant RBAC (user identities, team/project scoping, per-resource permissions).* See [API_REFERENCE.md](API_REFERENCE.md).
 - **Real bearer-token auth on every API route but `/health`** (since 1.11.0):
   a 256-bit API key generated once on first run, or a short-lived JWT
   (`jsonwebtoken`, HS256) exchanged for it via `POST /api/security/jwt/refresh`.


### PR DESCRIPTION
Align version claims, feature capabilities, and distributed inference reality across documentation to match the underlying codebase.

Summary of corrections:
1. README.md:
   - Kept version badge at v2.0.0 (matching git tag v2.0.0 and Cargo.toml).
   - Added a note in Project Status stating main branch development is ahead of the last tagged release (v2.0.0).
   - Updated feature and performance descriptions to state clearly that real distributed LLM inference (/v1/chat/completions) uses llama.cpp's ggml-rpc, while zero-copy SPSC ring buffers and flow pipelines serve as transport/latency research components.
   - Clarified API endpoint security: API keys carry role-based access control (Admin, Operator, Viewer) for operator access, while full multi-user / multi-tenant RBAC remains a future roadmap item. Added /api/security/keys to the endpoint table.

2. docs/ROADMAP.md & docs/BENCHMARKS.md:
   - Added 'Current truth' callout boxes at the top of both documents (verified 2026-08-18): detailing proven capabilities (30B model capacity splitting across LAN nodes via ggml-rpc) vs unproven/in-progress items (usable high tok/s on network-bound split layers, zero-touch one-command cluster setup).

3. docs/SECURITY_MODEL.md, docs/ROADMAP.md, docs/ENTERPRISE_PLAN.md, docs/API_REFERENCE.md:
   - Reconciled RBAC vs API key role authorization language to describe what auth.rs actually implements (3-role API key permissions: Admin, Operator, Viewer with route-gating) vs missing multi-user / multi-tenant RBAC (user identity, team/project scoping, resource permissions).
   - Documented /api/security/keys (GET/POST/DELETE) and role hierarchy in docs/API_REFERENCE.md.

4. CHANGELOG.md:
   - Added a Documentation & Truth Alignment section under [Unreleased] logging all documentation corrections and the main branch ahead-of-tag note.

---
*PR created automatically by Jules for task [2349261221445870392](https://jules.google.com/task/2349261221445870392) started by @rwilliamspbg-ops*