### PR TITLE
🎨 Palette: enhance Toaster dismiss button tooltip and container aria-label

### DIFF
--- a/ghostlink_gui_modern/src/components/Toaster.test.tsx
+++ b/ghostlink_gui_modern/src/components/Toaster.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { Toaster } from './Toaster';
+import { useAppStore } from '../store';
+
+describe('Toaster', () => {
+  beforeEach(() => {
+    act(() => {
+      useAppStore.setState({ toasts: [] });
+    });
+  });
+
+  it('renders nothing when there are no toasts', () => {
+    const { container } = render(<Toaster />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders toast alerts with role="alert" and aria-label on toaster container', () => {
+    act(() => {
+      useAppStore.getState().addToast({ type: 'success', message: 'Model downloaded successfully' });
+    });
+
+    render(<Toaster />);
+
+    const container = screen.getByLabelText('Notifications');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-live', 'polite');
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(screen.getByText('Model downloaded successfully')).toBeInTheDocument();
+  });
+
+  it('renders dismiss button with aria-label and title tooltip', () => {
+    act(() => {
+      useAppStore.getState().addToast({ type: 'error', message: 'Connection failed' });
+    });
+
+    render(<Toaster />);
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss notification' });
+    expect(dismissButton).toBeInTheDocument();
+    expect(dismissButton).toHaveAttribute('title', 'Dismiss notification');
+  });
+
+  it('removes toast when dismiss button is clicked', () => {
+    act(() => {
+      useAppStore.getState().addToast({ type: 'info', message: 'System update available' });
+    });
+
+    render(<Toaster />);
+
+    expect(screen.getByText('System update available')).toBeInTheDocument();
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss notification' });
+    fireEvent.click(dismissButton);
+
+    expect(screen.queryByText('System update available')).not.toBeInTheDocument();
+  });
+});

--- a/ghostlink_gui_modern/src/components/Toaster.tsx
+++ b/ghostlink_gui_modern/src/components/Toaster.tsx
@@ -32,6 +32,7 @@ const ToastItem: React.FC<Toast> = ({ id, type, message }) => {
         onClick={() => removeToast(id)}
         className="text-current opacity-60 hover:opacity-100 transition shrink-0 rounded focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
         aria-label="Dismiss notification"
+        title="Dismiss notification"
       >
         <X size={14} aria-hidden="true" />
       </button>
@@ -47,6 +48,7 @@ export const Toaster: React.FC = () => {
     <div
       className="fixed bottom-24 right-4 z-[90] flex flex-col gap-2 w-full max-w-sm px-4 sm:px-0"
       aria-live="polite"
+      aria-label="Notifications"
     >
       {toasts.map((t) => (
         <ToastItem key={t.id} {...t} />


### PR DESCRIPTION
🎨 Palette: enhance Toaster dismiss button tooltip and container aria-label

💡 What: Added native `title="Dismiss notification"` tooltip to the dismiss button on individual toast notifications and `aria-label="Notifications"` to the parent `Toaster` container. Added a comprehensive test suite in `Toaster.test.tsx`.
🎯 Why: Sighted desktop users benefit from native hover tooltips on icon-only buttons, while screen reader users benefit from explicit ARIA labeling on notification containers.
♿ Accessibility: Added `aria-label="Notifications"` to the toast container and `title` tooltip to the icon-only dismiss button.

---
*PR created automatically by Jules for task [1554992488754930187](https://jules.google.com/task/1554992488754930187) started by @rwilliamspbg-ops*