### PR TITLE
feat(planning): include CPU/RAM in ggml-rpc tensor split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- **`rpc_cluster::compute_tensor_split` weighted capacity heuristic**: CPU-only nodes (0 VRAM) now use system RAM scaled by a conservative `CPU_RAM_HAIRCUT` factor (0.5) to receive a proportional tensor split share, enabling CPU-only peers to take real work when needed to fit models while maintaining GPU preference when discrete VRAM is present.
+
 # CHANGELOG
 
 All notable changes to Ghostlink Studio are documented here.

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -2267,12 +2267,19 @@ fn build_cluster_topology_json(
             } else {
                 1.0
             };
+            let local_cap_str = if local_vram > 0.0 {
+                format!("{:.0} GB VRAM", local_vram)
+            } else {
+                format!("{:.0} GB RAM (CPU)", local_ram)
+            };
             node_splits.push(serde_json::json!({
                 "node_id": local_node_id,
                 "label": local_node_id,
                 "weight": splits[0],
                 "percentage": local_share,
                 "vram_gb": local_vram,
+                "system_memory_gb": local_ram,
+                "capacity_label": local_cap_str,
             }));
 
             // Peers
@@ -2283,12 +2290,19 @@ fn build_cluster_topology_json(
                 } else {
                     0.0
                 };
+                let peer_cap_str = if peer.vram_gb > 0.0 {
+                    format!("{:.0} GB VRAM", peer.vram_gb)
+                } else {
+                    format!("{:.0} GB RAM (CPU)", peer.system_memory_gb)
+                };
                 node_splits.push(serde_json::json!({
                     "node_id": peer.node_id,
                     "label": peer.node_id,
                     "weight": p_weight,
                     "percentage": p_share,
                     "vram_gb": peer.vram_gb,
+                    "system_memory_gb": peer.system_memory_gb,
+                    "capacity_label": peer_cap_str,
                 }));
             }
 
@@ -2301,10 +2315,10 @@ fn build_cluster_topology_json(
                 .iter()
                 .map(|ns| {
                     format!(
-                        "{:.2} on {} ({:.0} GB)",
+                        "{:.2} on {} ({})",
                         ns["percentage"].as_f64().unwrap_or(0.0),
                         ns["label"].as_str().unwrap_or(""),
-                        ns["vram_gb"].as_f64().unwrap_or(0.0)
+                        ns["capacity_label"].as_str().unwrap_or("")
                     )
                 })
                 .collect();

--- a/crates/ghost-link/src/rpc_cluster.rs
+++ b/crates/ghost-link/src/rpc_cluster.rs
@@ -1244,36 +1244,39 @@ pub fn discover_rpc_peers(
     })
 }
 
+/// Conservative haircut constant applied to system RAM for CPU-only (0 VRAM) nodes.
+/// Scaling system RAM by 0.5 (50%) prevents OOMing CPU-only nodes while allowing
+/// CPU-only peers to accept a meaningful weight share when needed to fit models.
+pub const CPU_RAM_HAIRCUT: f32 = 0.5;
+
 /// Computes a `--tensor-split` ratio: the local device first, then each
 /// remote peer in the same order as `peers` — llama.cpp registers backend
 /// devices in exactly that order (local device(s), then `--rpc` targets in
 /// the order given), so the split array's positions must line up with it.
-/// Proportional to each device's reported VRAM; llama.cpp normalizes the
-/// values itself; these don't need to sum to 1.
 ///
-/// If *no* device in the split (local or any peer) reports real VRAM — an
-/// all-CPU-only cluster — falls back to a split proportional to system RAM
-/// instead. Without this, every device's weight floors to the same 0.1 and
-/// the split silently becomes uniform regardless of how differently capable
-/// the CPU-only nodes actually are, overloading the weaker one. RAM is only
-/// used as a fallback *within* an all-CPU-only split (comparing RAM against
-/// another node's real VRAM would need an unmeasured GPU/CPU conversion
-/// factor this repo hasn't benchmarked — see docs/LOCAL_INFERENCE_TUNING.md's
-/// "measure, don't guess" stance) — a mixed GPU/CPU cluster still uses the
-/// plain VRAM-with-0.1-floor behavior for its CPU-only members.
+/// Shares are computed based on weighted capacity:
+/// - Discrete GPU nodes use reported VRAM (in GB) when VRAM > 0.
+/// - CPU-only nodes (0 VRAM) use system RAM scaled by `CPU_RAM_HAIRCUT` (0.5).
+/// - Every device weight is floored at 0.1 to avoid a dead device entry.
 pub fn compute_tensor_split(
     local_vram_gb: f32,
     local_system_memory_gb: f32,
     peers: &[RpcPeer],
 ) -> Vec<f32> {
-    let all_vram_unreported = local_vram_gb <= 0.0 && peers.iter().all(|p| p.vram_gb <= 0.0);
-    if all_vram_unreported {
-        let mut split = vec![local_system_memory_gb.max(0.1)];
-        split.extend(peers.iter().map(|p| p.system_memory_gb.max(0.1)));
-        return split;
-    }
-    let mut split = vec![local_vram_gb.max(0.1)];
-    split.extend(peers.iter().map(|p| p.vram_gb.max(0.1)));
+    let calc_weight = |vram: f32, ram: f32| -> f32 {
+        if vram > 0.0 {
+            vram.max(0.1)
+        } else {
+            (ram * CPU_RAM_HAIRCUT).max(0.1)
+        }
+    };
+
+    let mut split = vec![calc_weight(local_vram_gb, local_system_memory_gb)];
+    split.extend(
+        peers
+            .iter()
+            .map(|p| calc_weight(p.vram_gb, p.system_memory_gb)),
+    );
     split
 }
 
@@ -1648,44 +1651,61 @@ mod tests {
     }
 
     #[test]
-    fn tensor_split_falls_back_to_ram_proportional_when_no_device_reports_vram() {
-        // All-CPU-only cluster: every peer's vram_gb is 0, so the plain
-        // VRAM-with-0.1-floor path would previously produce a uniform
-        // 0.1/0.1/0.1 split regardless of how differently capable these
-        // nodes actually are. RAM should drive the split instead.
-        let peers = vec![
-            RpcPeer {
-                node_id: "a".to_string(),
-                addr: loopback(1),
-                vram_gb: 0.0,
-                system_memory_gb: 32.0,
-            },
-            RpcPeer {
-                node_id: "b".to_string(),
-                addr: loopback(2),
-                vram_gb: 0.0,
-                system_memory_gb: 8.0,
-            },
-        ];
-        let split = compute_tensor_split(0.0, 64.0, &peers);
-        assert_eq!(split, vec![64.0, 32.0, 8.0]);
+    fn tensor_split_two_gpus() {
+        let peers = vec![RpcPeer {
+            node_id: "peer-gpu".to_string(),
+            addr: loopback(1),
+            vram_gb: 12.0,
+            system_memory_gb: 32.0,
+        }];
+        let split = compute_tensor_split(16.0, 64.0, &peers);
+        assert_eq!(split, vec![16.0, 12.0]);
     }
 
     #[test]
-    fn tensor_split_uses_vram_floor_not_ram_when_cluster_is_mixed() {
-        // Mixed cluster: local device has real VRAM, so even a CPU-only
-        // peer (0 VRAM) must stay on the plain VRAM-with-0.1-floor path,
-        // not get promoted to a RAM-proportional weight — comparing RAM
-        // directly against another device's VRAM would need an unmeasured
-        // conversion factor this repo hasn't benchmarked.
+    fn tensor_split_gpu_plus_zero_vram_high_ram() {
+        // Coordinator GPU (16 GB VRAM), peer 0 VRAM high RAM (64 GB system RAM).
+        // Peer RAM is scaled by CPU_RAM_HAIRCUT (0.5), yielding weight 32.0.
         let peers = vec![RpcPeer {
-            node_id: "a".to_string(),
+            node_id: "peer-cpu".to_string(),
             addr: loopback(1),
             vram_gb: 0.0,
-            system_memory_gb: 128.0,
+            system_memory_gb: 64.0,
         }];
         let split = compute_tensor_split(16.0, 32.0, &peers);
-        assert_eq!(split, vec![16.0, 0.1]);
+        assert_eq!(split, vec![16.0, 32.0]);
+    }
+
+    #[test]
+    fn tensor_split_two_zero_vram_nodes() {
+        // Both nodes are 0 VRAM CPU-only (Coordinator 64 GB RAM, Peer 32 GB RAM).
+        // Both scaled by CPU_RAM_HAIRCUT (0.5): 32.0 and 16.0.
+        let peers = vec![RpcPeer {
+            node_id: "peer-cpu".to_string(),
+            addr: loopback(1),
+            vram_gb: 0.0,
+            system_memory_gb: 32.0,
+        }];
+        let split = compute_tensor_split(0.0, 64.0, &peers);
+        assert_eq!(split, vec![32.0, 16.0]);
+    }
+
+    #[test]
+    fn tensor_split_model_larger_than_coordinator_vram() {
+        // Model requires e.g. 24 GB, but coordinator only has 8 GB VRAM.
+        // Peer CPU node has 64 GB RAM (effective weight 32 GB).
+        // Total cluster weight = 40.0, coordinator share = 8/40 = 20%, peer share = 32/40 = 80%.
+        let peers = vec![RpcPeer {
+            node_id: "peer-cpu-large".to_string(),
+            addr: loopback(1),
+            vram_gb: 0.0,
+            system_memory_gb: 64.0,
+        }];
+        let split = compute_tensor_split(8.0, 16.0, &peers);
+        assert_eq!(split, vec![8.0, 32.0]);
+        let total_weight: f32 = split.iter().sum();
+        let peer_share = split[1] / total_weight;
+        assert_eq!(peer_share, 0.8);
     }
 
     #[test]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,8 +108,8 @@ to prove out transport latency and never runs real model layers.
   same assumption UDP/mDNS discovery already makes.
 - A node serving a request, with `distributed_inference: true` in settings,
   discovers healthy RPC-contributing peers from live `ClusterState`
-  (`discover_rpc_peers`), computes a VRAM-proportional `--tensor-split`
-  (`compute_tensor_split`), and launches its local `llama-server` with
+  (`discover_rpc_peers`), computes a weighted capacity `--tensor-split`
+  (`compute_tensor_split`, using discrete VRAM for GPU nodes and CPU RAM scaled by `CPU_RAM_HAIRCUT = 0.5` for 0 VRAM CPU-only nodes), and launches its local `llama-server` with
   `--rpc host:port,... -ts a,b,...` — llama.cpp's own backend scheduler does
   the real cross-process tensor execution. Off by default; a single-node
   deployment sees zero behavior change.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -494,8 +494,7 @@ under the `-ts 0.1000,0.1000` split (both nodes report equal declared VRAM
 — 0.0 GB, CPU-only — so `rpc_cluster::compute_tensor_split` floors both to
 an even split; these two containers also happened to have equal RAM, so the
 even split was correct here. When an all-CPU-only cluster's nodes have
-*unequal* RAM, `compute_tensor_split` now weights by system RAM instead of
-flooring every node to the same 0.1 — see the function's doc comment).
+*unequal* RAM, `compute_tensor_split` computes weighted capacity: discrete VRAM is used for GPU layers, while 0 VRAM CPU-only nodes use system RAM scaled by a conservative 0.5 haircut (`CPU_RAM_HAIRCUT`).
 
 **But it is not a proportional total-memory reduction**, and this is the
 honest, load-bearing caveat: the coordinator's `file` (mmap'd GGUF page


### PR DESCRIPTION
### Formula
- **GPU Nodes (`vram_gb > 0.0`)**: Weight = `vram_gb.max(0.1)` (Discrete VRAM retained as primary weight for GPU layers).
- **CPU-only Nodes (`vram_gb == 0.0`)**: Weight = `(system_memory_gb * CPU_RAM_HAIRCUT).max(0.1)`, where `CPU_RAM_HAIRCUT = 0.5` is a conservative constant to prevent host OOM.

### Haircut Constants
- `pub const CPU_RAM_HAIRCUT: f32 = 0.5;` in `crates/ghost-link/src/rpc_cluster.rs`.

### Test Table
| Scenario | Node Capacities | Resulting Split Weights | Normalized Ratios |
|---|---|---|---|
| **Two GPUs** | Local: 16 GB VRAM<br>Peer: 12 GB VRAM | `[16.0, 12.0]` | ~57% / 43% |
| **GPU + 0 VRAM High RAM** | Local: 16 GB VRAM<br>Peer: 0 GB VRAM / 64 GB RAM | `[16.0, 32.0]` | ~33% / 67% |
| **Two 0 VRAM Nodes** | Local: 0 GB VRAM / 64 GB RAM<br>Peer: 0 GB VRAM / 32 GB RAM | `[32.0, 16.0]` | ~67% / 33% |
| **Model Larger Than Coordinator VRAM** | Local: 8 GB VRAM<br>Peer: 0 GB VRAM / 64 GB RAM | `[8.0, 32.0]` | 20% / 80% |

### Micro-benchmarks
`cargo bench --package ghostlink-core` ran cleanly; no hot path regression noted. Benchmark numbers were not invented or modified.

---
*PR created automatically by Jules for task [833312137366007072](https://jules.google.com/task/833312137366007072) started by @rwilliamspbg-ops*