### PR TITLE
fix(security): rotate and cap durable audit_log.jsonl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Ghostlink Studio are documented here.
 
 ## [Unreleased]
 
+- **Audit Log Capping, Rotation, and Retention**:
+  - Implemented file capping (`GHOSTLINK_AUDIT_LOG_MAX_BYTES`, default 10MB; `GHOSTLINK_AUDIT_LOG_MAX_LINES`, default disabled) and automatic file rotation (`audit_log.jsonl.1` .. `.N`) for the durable on-disk audit log.
+  - Implemented retention purging (`GHOSTLINK_AUDIT_LOG_MAX_FILES`, default 5 files) to prevent unbounded disk growth.
+  - Added support for `[audit]` configuration table in `ghostlink.toml` (`path`, `max_bytes`, `max_lines`, `max_files`).
+  - Updated `read_all_durable()` and SIEM export endpoints (`GET /api/security/audit-log/export?format=json|cef`) to read across active and retained rotated log files in chronological order.
+
 - **Drain and Restart on Contributor Loss for Serving Path**:
   - Implemented continuous rebalancing / resilience for the real llama-server RPC serving path (InferenceEngine::Native).
   - Added active --rpc target tracking in NativeEngineClient (active_rpc_servers()) and contributor health checking in rpc_cluster::check_active_rpc_peers_healthy.

--- a/crates/ghost-link/src/audit_log.rs
+++ b/crates/ghost-link/src/audit_log.rs
@@ -5,13 +5,13 @@
 //! Security-tab feed exactly as before — fast, restart-reset, capped at
 //! `AUDIT_LOG_CAP`. This module adds what it was missing: an append-only,
 //! on-disk trail (`append_durable`/`read_all_durable`) that survives a
-//! restart and isn't capped, plus a CEF (Common Event Format) export path
-//! for SIEM ingestion, matching `docs/ROADMAP.md`'s Enterprise Trust Track
-//! item #3.
+//! restart, bounded with file rotation and retention controls, plus a CEF
+//! (Common Event Format) export path for SIEM ingestion, matching
+//! `docs/ROADMAP.md`'s Enterprise Trust Track item #3.
 
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// One row for the GUI's Security tab audit log — field names/shape match
 /// what `SecurityTab.tsx` already expects (it predates a real backend for
@@ -30,6 +30,10 @@ pub struct AuditLogEntry {
 
 pub const AUDIT_LOG_CAP: usize = 500;
 
+pub const DEFAULT_AUDIT_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
+pub const DEFAULT_AUDIT_LOG_MAX_LINES: usize = 0; // 0 = disabled
+pub const DEFAULT_AUDIT_LOG_MAX_FILES: usize = 5; // retain 5 rotated files
+
 /// Appends one entry and trims from the front once over `AUDIT_LOG_CAP` —
 /// split out from `record_audit_event` (`main.rs`) so it's unit-testable
 /// against a bare `VecDeque` without needing to construct a full
@@ -47,12 +51,110 @@ fn audit_log_path() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from("audit_log.jsonl"))
 }
 
-/// Appends one entry to the durable, append-only, restart-surviving audit
-/// trail — one JSON object per line (JSONL: trivial to append to, trivial
-/// to `tail`/`grep`, no schema-migration machinery needed). Best-effort:
-/// warns rather than failing the caller's request on a write error, the
-/// same tradeoff every other persistence function in this codebase makes
-/// (`save_settings`, `save_api_keys`, ...).
+fn audit_log_max_bytes() -> u64 {
+    std::env::var("GHOSTLINK_AUDIT_LOG_MAX_BYTES")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_AUDIT_LOG_MAX_BYTES)
+}
+
+fn audit_log_max_lines() -> usize {
+    std::env::var("GHOSTLINK_AUDIT_LOG_MAX_LINES")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_AUDIT_LOG_MAX_LINES)
+}
+
+fn audit_log_max_files() -> usize {
+    std::env::var("GHOSTLINK_AUDIT_LOG_MAX_FILES")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_AUDIT_LOG_MAX_FILES)
+}
+
+fn rotated_path(base_path: &Path, index: usize) -> PathBuf {
+    let mut os_string = base_path.as_os_str().to_os_string();
+    os_string.push(format!(".{index}"));
+    PathBuf::from(os_string)
+}
+
+fn count_file_lines(path: &Path) -> usize {
+    let Ok(file) = std::fs::File::open(path) else {
+        return 0;
+    };
+    std::io::BufReader::new(file).lines().count()
+}
+
+fn should_rotate(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    let file_bytes = meta.len();
+    if file_bytes == 0 {
+        return false;
+    }
+
+    let max_bytes = audit_log_max_bytes();
+    if max_bytes > 0 && file_bytes >= max_bytes {
+        return true;
+    }
+
+    let max_lines = audit_log_max_lines();
+    if max_lines > 0 && count_file_lines(path) >= max_lines {
+        return true;
+    }
+
+    false
+}
+
+fn rotate_audit_log(path: &Path) {
+    let max_files = audit_log_max_files();
+    if max_files == 0 {
+        if path.exists() {
+            let _ = std::fs::remove_file(path);
+        }
+        return;
+    }
+
+    // Shift existing rotated files from max_files - 1 down to 1
+    for i in (1..max_files).rev() {
+        let src = rotated_path(path, i);
+        let dst = rotated_path(path, i + 1);
+        if src.exists() {
+            if dst.exists() {
+                let _ = std::fs::remove_file(&dst);
+            }
+            let _ = std::fs::rename(&src, &dst);
+        }
+    }
+
+    // Move active path to path.1
+    if path.exists() {
+        let dst = rotated_path(path, 1);
+        if dst.exists() {
+            let _ = std::fs::remove_file(&dst);
+        }
+        let _ = std::fs::rename(path, dst);
+    }
+
+    // Purge any excess rotated files beyond max_files
+    let mut excess = max_files + 1;
+    loop {
+        let excess_path = rotated_path(path, excess);
+        if excess_path.exists() {
+            let _ = std::fs::remove_file(&excess_path);
+            excess += 1;
+        } else {
+            break;
+        }
+    }
+}
+
+/// Appends one entry to the durable, restart-surviving audit trail —
+/// one JSON object per line (JSONL). Applies rotation and retention policies
+/// (`GHOSTLINK_AUDIT_LOG_MAX_BYTES`, `GHOSTLINK_AUDIT_LOG_MAX_LINES`,
+/// `GHOSTLINK_AUDIT_LOG_MAX_FILES`). Best-effort: warns rather than failing
+/// the caller's request on a write error.
 pub fn append_durable(entry: &AuditLogEntry) {
     let line = match serde_json::to_string(entry) {
         Ok(l) => l,
@@ -62,6 +164,17 @@ pub fn append_durable(entry: &AuditLogEntry) {
         }
     };
     let path = audit_log_path();
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+    }
+
+    if should_rotate(&path) {
+        rotate_audit_log(&path);
+    }
+
     let result = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -75,14 +188,8 @@ pub fn append_durable(entry: &AuditLogEntry) {
     }
 }
 
-/// Reads the full durable audit trail (not just the capped in-memory live
-/// view). A line that fails to parse (a truncated write, a manual edit, a
-/// future format change) is skipped with a warning rather than failing the
-/// whole read — one bad line shouldn't hide the rest of a real security
-/// trail. No file yet is not an error: an empty trail, not a failure.
-pub fn read_all_durable() -> Vec<AuditLogEntry> {
-    let path = audit_log_path();
-    let file = match std::fs::File::open(&path) {
+fn read_entries_from_file(path: &Path) -> Vec<AuditLogEntry> {
+    let file = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(_) => return Vec::new(),
     };
@@ -93,16 +200,52 @@ pub fn read_all_durable() -> Vec<AuditLogEntry> {
             Ok(l) => match serde_json::from_str::<AuditLogEntry>(&l) {
                 Ok(entry) => Some(entry),
                 Err(err) => {
-                    tracing::warn!("audit_log: skipping unparseable line in durable trail: {err}");
+                    tracing::warn!(
+                        "audit_log: skipping unparseable line in durable trail at {}: {err}",
+                        path.display()
+                    );
                     None
                 }
             },
             Err(err) => {
-                tracing::warn!("audit_log: skipping unreadable line in durable trail: {err}");
+                tracing::warn!(
+                    "audit_log: skipping unreadable line in durable trail at {}: {err}",
+                    path.display()
+                );
                 None
             }
         })
         .collect()
+}
+
+/// Reads the full durable audit trail across active and retained rotated files.
+/// Entries are returned in chronological order (oldest rotated files first, then active file).
+/// Unparseable or unreadable lines are skipped with a warning.
+pub fn read_all_durable() -> Vec<AuditLogEntry> {
+    let path = audit_log_path();
+    let mut files_to_read = Vec::new();
+
+    let max_files = audit_log_max_files();
+    let max_check = max_files.max(100);
+    let mut existing_indices = Vec::new();
+    for k in 1..=max_check {
+        let p = rotated_path(&path, k);
+        if p.exists() {
+            existing_indices.push(k);
+        }
+    }
+    existing_indices.sort_unstable_by(|a, b| b.cmp(a));
+
+    for k in existing_indices {
+        files_to_read.push(rotated_path(&path, k));
+    }
+    files_to_read.push(path);
+
+    let mut all_entries = Vec::new();
+    for file_path in files_to_read {
+        all_entries.extend(read_entries_from_file(&file_path));
+    }
+    all_entries
 }
 
 /// CEF severity (0-10 scale): a successful event is informational,
@@ -288,6 +431,168 @@ mod tests {
         assert!(read_all_durable().is_empty());
 
         std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+    }
+
+    #[test]
+    fn append_durable_rotates_and_retains_by_max_lines() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let temp_dir = std::env::temp_dir();
+        let path = temp_dir.join(format!(
+            "ghostlink-test-audit-rotate-lines-{}.jsonl",
+            std::process::id()
+        ));
+
+        // Clean up any test artifacts
+        let _ = std::fs::remove_file(&path);
+        for i in 1..=10 {
+            let _ = std::fs::remove_file(rotated_path(&path, i));
+        }
+
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_PATH", &path);
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_MAX_LINES", "2");
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_MAX_FILES", "2");
+
+        // Write 6 entries.
+        // Entry 1, 2 -> path (file has 2 lines)
+        // Entry 3 -> triggers rotation! path -> path.1, entry 3 written to path (1 line)
+        // Entry 4 -> path (2 lines)
+        // Entry 5 -> triggers rotation! path.1 -> path.2, path -> path.1, entry 5 written to path (1 line)
+        // Entry 6 -> path (2 lines)
+        for i in 1..=6 {
+            append_durable(&sample(&format!("event-{i}"), "SUCCESS", None));
+        }
+
+        assert!(path.exists(), "active file must exist");
+        assert!(rotated_path(&path, 1).exists(), "path.1 must exist");
+        assert!(rotated_path(&path, 2).exists(), "path.2 must exist");
+        assert!(
+            !rotated_path(&path, 3).exists(),
+            "path.3 must NOT exist because max_files is 2"
+        );
+
+        let all_entries = read_all_durable();
+        // Since entries 1, 2 rotated to path.2 then got purged when entry 5 rotated path.1 -> path.2 and old path.2 was dropped!
+        // Wait, let's trace:
+        // Entry 1, 2 written -> path has [e1, e2]
+        // Entry 3 written -> path had 2 lines >= max_lines(2). Rotates: path -> path.1. path has [e3].
+        // Entry 4 written -> path has [e3, e4] (2 lines).
+        // Entry 5 written -> path had 2 lines >= max_lines(2). Rotates: path.1 -> path.2, path -> path.1. path has [e5].
+        // Entry 6 written -> path has [e5, e6] (2 lines).
+        // Rotated files retained:
+        // path.2 has [e1, e2]
+        // path.1 has [e3, e4]
+        // path has [e5, e6]
+        // Total entries retained = 6!
+        assert_eq!(all_entries.len(), 6);
+        assert_eq!(all_entries[0].event, "event-1");
+        assert_eq!(all_entries[5].event, "event-6");
+
+        // Now append entry 7:
+        // path has 2 lines >= max_lines(2). Rotates:
+        // path.2 (which has [e1, e2]) is purged because max_files=2.
+        // path.1 ([e3, e4]) -> path.2
+        // path ([e5, e6]) -> path.1
+        // path gets [e7].
+        append_durable(&sample("event-7", "SUCCESS", None));
+        let entries_after_7 = read_all_durable();
+        assert_eq!(
+            entries_after_7.len(),
+            5,
+            "e1 and e2 must be purged beyond retention limit"
+        );
+        assert_eq!(entries_after_7[0].event, "event-3");
+        assert_eq!(entries_after_7[4].event, "event-7");
+
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_LINES");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_FILES");
+        let _ = std::fs::remove_file(&path);
+        for i in 1..=10 {
+            let _ = std::fs::remove_file(rotated_path(&path, i));
+        }
+    }
+
+    #[test]
+    fn append_durable_rotates_by_max_bytes() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let temp_dir = std::env::temp_dir();
+        let path = temp_dir.join(format!(
+            "ghostlink-test-audit-rotate-bytes-{}.jsonl",
+            std::process::id()
+        ));
+
+        let _ = std::fs::remove_file(&path);
+        for i in 1..=10 {
+            let _ = std::fs::remove_file(rotated_path(&path, i));
+        }
+
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_PATH", &path);
+        // Each JSON line for sample is ~100 bytes. Set max_bytes = 150.
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_MAX_BYTES", "150");
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_MAX_FILES", "2");
+
+        append_durable(&sample("byte-event-1", "SUCCESS", None));
+        append_durable(&sample("byte-event-2", "SUCCESS", None)); // file size ~200 > 150
+        append_durable(&sample("byte-event-3", "SUCCESS", None)); // triggers rotation!
+
+        assert!(path.exists());
+        assert!(rotated_path(&path, 1).exists());
+
+        let entries = read_all_durable();
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].event, "byte-event-1");
+        assert_eq!(entries[2].event, "byte-event-3");
+
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_BYTES");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_FILES");
+        let _ = std::fs::remove_file(&path);
+        for i in 1..=10 {
+            let _ = std::fs::remove_file(rotated_path(&path, i));
+        }
+    }
+
+    #[test]
+    fn append_durable_purges_excess_rotated_files() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let temp_dir = std::env::temp_dir();
+        let path = temp_dir.join(format!(
+            "ghostlink-test-audit-purge-excess-{}.jsonl",
+            std::process::id()
+        ));
+
+        let _ = std::fs::remove_file(&path);
+        for i in 1..=10 {
+            let _ = std::fs::remove_file(rotated_path(&path, i));
+        }
+
+        // Manually create files .1, .2, .3, .4
+        std::fs::write(&path, "active\n").unwrap();
+        std::fs::write(rotated_path(&path, 1), "rot1\n").unwrap();
+        std::fs::write(rotated_path(&path, 2), "rot2\n").unwrap();
+        std::fs::write(rotated_path(&path, 3), "rot3\n").unwrap();
+        std::fs::write(rotated_path(&path, 4), "rot4\n").unwrap();
+
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_PATH", &path);
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_MAX_LINES", "1");
+        std::env::set_var("GHOSTLINK_AUDIT_LOG_MAX_FILES", "2");
+
+        // Appending will trigger rotation because active file has 1 line >= max_lines 1.
+        append_durable(&sample("purge-trigger", "SUCCESS", None));
+
+        // max_files is 2. Rotated files .1 and .2 should exist. .3 and .4 should be purged!
+        assert!(rotated_path(&path, 1).exists());
+        assert!(rotated_path(&path, 2).exists());
+        assert!(!rotated_path(&path, 3).exists(), ".3 must be purged");
+        assert!(!rotated_path(&path, 4).exists(), ".4 must be purged");
+
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_LINES");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_FILES");
+        let _ = std::fs::remove_file(&path);
+        for i in 1..=10 {
+            let _ = std::fs::remove_file(rotated_path(&path, i));
+        }
     }
 
     #[test]

--- a/crates/ghost-link/src/main.rs
+++ b/crates/ghost-link/src/main.rs
@@ -63,6 +63,7 @@ struct FileConfig {
     discovery: Option<DiscoveryDefaults>,
     tcp: Option<TcpDefaults>,
     gui: Option<GuiDefaults>,
+    audit: Option<AuditDefaults>,
     #[allow(dead_code)]
     #[serde(default)]
     compute: Option<toml::Value>,
@@ -111,6 +112,15 @@ struct TcpDefaults {
 #[serde(deny_unknown_fields)]
 struct GuiDefaults {
     python: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AuditDefaults {
+    path: Option<String>,
+    max_bytes: Option<u64>,
+    max_lines: Option<usize>,
+    max_files: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -336,6 +346,21 @@ fn apply_file_config_to_env(config: &FileConfig) {
             if should_apply_gui_python_override(value) {
                 set_env_if_absent("GHOSTLINK_PYTHON", value.clone());
             }
+        }
+    }
+
+    if let Some(audit) = &config.audit {
+        if let Some(value) = &audit.path {
+            set_env_if_absent("GHOSTLINK_AUDIT_LOG_PATH", value.clone());
+        }
+        if let Some(value) = audit.max_bytes {
+            set_env_if_absent("GHOSTLINK_AUDIT_LOG_MAX_BYTES", value.to_string());
+        }
+        if let Some(value) = audit.max_lines {
+            set_env_if_absent("GHOSTLINK_AUDIT_LOG_MAX_LINES", value.to_string());
+        }
+        if let Some(value) = audit.max_files {
+            set_env_if_absent("GHOSTLINK_AUDIT_LOG_MAX_FILES", value.to_string());
         }
     }
 }
@@ -12490,10 +12515,22 @@ mod tests {
         };
         config.gui = Some(gui);
 
+        let audit = AuditDefaults {
+            path: Some("/tmp/custom_audit.jsonl".to_string()),
+            max_bytes: Some(1048576),
+            max_lines: Some(500),
+            max_files: Some(3),
+        };
+        config.audit = Some(audit);
+
         std::env::remove_var("GHOSTLINK_FLOW_DEFAULT_LOCAL_ID");
         std::env::remove_var("GHOSTLINK_FLOW_DEFAULT_REMOTE_VRAM_GB");
         std::env::remove_var("GHOSTLINK_CLUSTER_START_DEFAULT_NODE_COUNT");
         std::env::remove_var("GHOSTLINK_PYTHON");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_BYTES");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_LINES");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_FILES");
 
         apply_file_config_to_env(&config);
 
@@ -12514,10 +12551,28 @@ mod tests {
             "/usr/bin/python3.11"
         );
 
+        assert_eq!(
+            std::env::var("GHOSTLINK_AUDIT_LOG_PATH").unwrap(),
+            "/tmp/custom_audit.jsonl"
+        );
+        assert_eq!(
+            std::env::var("GHOSTLINK_AUDIT_LOG_MAX_BYTES").unwrap(),
+            "1048576"
+        );
+        assert_eq!(
+            std::env::var("GHOSTLINK_AUDIT_LOG_MAX_LINES").unwrap(),
+            "500"
+        );
+        assert_eq!(std::env::var("GHOSTLINK_AUDIT_LOG_MAX_FILES").unwrap(), "3");
+
         std::env::remove_var("GHOSTLINK_FLOW_DEFAULT_LOCAL_ID");
         std::env::remove_var("GHOSTLINK_FLOW_DEFAULT_REMOTE_VRAM_GB");
         std::env::remove_var("GHOSTLINK_CLUSTER_START_DEFAULT_NODE_COUNT");
         std::env::remove_var("GHOSTLINK_PYTHON");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_PATH");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_BYTES");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_LINES");
+        std::env::remove_var("GHOSTLINK_AUDIT_LOG_MAX_FILES");
     }
 
     #[test]

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -53,16 +53,18 @@ This document summarizes current security assumptions for Ghost-Link runtime and
   cluster's nodes is a manual, opt-in step. This does **not** encrypt the RPC
   byte stream itself (upstream llama.cpp's `--rpc` client leaves no protocol
   slot for that); it is a peer-admission control, not transport encryption.
-- **Durable, append-only audit trail with CEF/JSON export** (since 2.0.0,
+- **Durable, bounded audit trail with CEF/JSON export and rotation** (since 2.0.0,
   `crates/ghost-link/src/audit_log.rs`): every audit event (auth failures,
   JWT refresh, PQC enable, key management, tool-call approve/deny) is written
   as a JSON line to `audit_log.jsonl` (`GHOSTLINK_AUDIT_LOG_PATH` override),
   in addition to the capped in-memory feed the GUI's Security tab reads live.
   `GET /api/security/audit-log/export?format=json|cef` returns the full
-  durable history in JSON or Common Event Format for SIEM ingestion, and is
-  gated `Admin`-only (the live capped feed remains `Viewer`-accessible). The
-  durable file has **no built-in cap, rotation, or retention policy** — plan
-  disk monitoring and log rotation for long-running deployments.
+  retained history across active and rotated files in JSON or Common Event Format
+  for SIEM ingestion, and is gated `Admin`-only (the live capped feed remains
+  `Viewer`-accessible). Active audit log files are automatically capped and rotated
+  (`audit_log.jsonl.1` .. `.N`) based on byte size (`GHOSTLINK_AUDIT_LOG_MAX_BYTES`, default 10MB)
+  or line count (`GHOSTLINK_AUDIT_LOG_MAX_LINES`, default disabled), and retained up to a
+  configurable file limit (`GHOSTLINK_AUDIT_LOG_MAX_FILES`, default 5 files) before purging older archives.
 - **Opt-in OpenTelemetry tracing export** (since 2.0.0, `crates/ghost-link/src/otel.rs`):
   gated entirely on `GHOSTLINK_OTEL_EXPORTER_ENDPOINT` — unset, behavior is
   unchanged from prior releases. When set, HTTP requests and the distributed-
@@ -122,5 +124,3 @@ Future security milestones should include:
   itself — this remains the open gap.
 - Enforced deprecation timeline for legacy CRC32 compatibility mode.
 - Formal threat model review cadence tied to release checkpoints.
-- Retention/rotation policy for the durable audit trail (`audit_log.jsonl`)
-  — it is unbounded and append-only today.

--- a/ghostlink.example.toml
+++ b/ghostlink.example.toml
@@ -101,3 +101,23 @@ request_drain_timeout_secs = 30
 #   GHOSTLINK_LLAMA_SERVER_ARGS="-fa on -b 1024 -ub 512"   # ~8GB VRAM profile
 #   GHOSTLINK_VRAM_GB=8
 #   GHOSTLINK_LLAMA_NGL=40
+
+[audit]
+# Path for the durable audit log JSONL file
+# Overridden by GHOSTLINK_AUDIT_LOG_PATH
+path = "audit_log.jsonl"
+
+# Maximum size in bytes of active audit log file before rotating
+# Default: 10485760 (10 MB). Set to 0 to disable byte-based rotation.
+# Overridden by GHOSTLINK_AUDIT_LOG_MAX_BYTES
+max_bytes = 10485760
+
+# Maximum line count of active audit log file before rotating
+# Default: 0 (disabled). Set to > 0 to rotate when line count reaches limit.
+# Overridden by GHOSTLINK_AUDIT_LOG_MAX_LINES
+max_lines = 0
+
+# Maximum number of rotated audit log files to retain (.1 through .N)
+# Default: 5. Older files beyond this limit are automatically purged.
+# Overridden by GHOSTLINK_AUDIT_LOG_MAX_FILES
+max_files = 5


### PR DESCRIPTION
- **Cap & Rotation**: Implemented file size capping (`GHOSTLINK_AUDIT_LOG_MAX_BYTES`, default 10MB) and line count capping (`GHOSTLINK_AUDIT_LOG_MAX_LINES`, default 0/disabled) for `audit_log.jsonl`. When capped, rotates active file to `audit_log.jsonl.1` .. `.N`.
- **Retention**: Implemented file retention limit (`GHOSTLINK_AUDIT_LOG_MAX_FILES`, default 5 files), automatically purging older rotated files beyond the limit.
- **Export Chronology**: Updated `read_all_durable()` to read retained rotated files in chronological order (oldest rotated files first, then active file) so `GET /api/security/audit-log/export?format=json|cef` exports complete history.
- **TOML Configuration**: Added support for `[audit]` section table in `ghostlink.toml` (`path`, `max_bytes`, `max_lines`, `max_files`) and documented options in `ghostlink.example.toml`.
- **Tests**: Added unit tests in `crates/ghost-link/src/audit_log.rs` (`append_durable_rotates_and_retains_by_max_lines`, `append_durable_rotates_by_max_bytes`, `append_durable_purges_excess_rotated_files`) using temp directories and environment locks, and updated `main.rs` config tests.
- **Docs & Changelog**: Updated `docs/SECURITY_MODEL.md` removing "unbounded" as current state and updated `CHANGELOG.md` under `[Unreleased]`.

---
*PR created automatically by Jules for task [9317621536578545954](https://jules.google.com/task/9317621536578545954) started by @rwilliamspbg-ops*