### PR TITLE
🎨 Palette: Add CSV export toast feedback and sidebar toggle tooltips

### DIFF
--- a/ghostlink_gui_modern/src/App.tsx
+++ b/ghostlink_gui_modern/src/App.tsx
@@ -404,6 +404,7 @@ function App() {
             <button
                 ref={sidebarOpenButtonRef}
                 onClick={() => setSidebarOpen(true)}
+                title="Open sidebar"
                 aria-label="Open sidebar"
                 aria-expanded={false}
                 aria-controls="primary-sidebar"
@@ -416,6 +417,7 @@ function App() {
         {sidebarOpen && (
             <button
                 onClick={() => setSidebarOpen(false)}
+                title="Collapse sidebar"
                 aria-label="Collapse sidebar"
                 aria-expanded={true}
                 aria-controls="primary-sidebar"

--- a/ghostlink_gui_modern/src/components/MetricsTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/MetricsTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MetricsTab } from './MetricsTab';
 import { useAppStore } from '../store';
 
@@ -155,5 +155,26 @@ describe('MetricsTab', () => {
     });
     rerender(<MetricsTab api={api} />);
     expect(screen.getByLabelText('Export metrics history as CSV')).toBeDisabled();
+  });
+
+  it('triggers a toast notification upon CSV export', () => {
+    const addToastSpy = vi.fn();
+    useAppStore.setState({
+      addToast: addToastSpy,
+    });
+    const api = createMockApi();
+    render(<MetricsTab api={api} />);
+
+    // Mock URL.createObjectURL and URL.revokeObjectURL for jsdom environment
+    window.URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+    window.URL.revokeObjectURL = vi.fn();
+
+    const exportBtn = screen.getByLabelText('Export metrics history as CSV');
+    fireEvent.click(exportBtn);
+
+    expect(addToastSpy).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'Exported 3 metrics samples to CSV.',
+    });
   });
 });

--- a/ghostlink_gui_modern/src/components/MetricsTab.tsx
+++ b/ghostlink_gui_modern/src/components/MetricsTab.tsx
@@ -25,7 +25,7 @@ interface BackendStatus {
 }
 
 export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
-  const { metrics, setMetrics, metricsHistory, workers } = useAppStore();
+  const { metrics, setMetrics, metricsHistory, workers, addToast } = useAppStore();
   const [loading, setLoading] = React.useState(false);
   const [history, setHistory] = React.useState<MetricsHistoryPoint[]>([]);
 
@@ -106,6 +106,7 @@ export const MetricsTab: React.FC<{ api: any }> = React.memo(({ api }) => {
     a.download = `ghostlink-metrics-${new Date().toISOString().replace(/[:.]/g, '-')}.csv`;
     a.click();
     URL.revokeObjectURL(url);
+    addToast({ type: 'success', message: `Exported ${metricsHistory.length} metrics samples to CSV.` });
   };
 
   const throughputHistory = useMemo(() => metricsHistory.map((m) => m.throughput ?? 0), [metricsHistory]);


### PR DESCRIPTION
Adds feedback when exporting metrics history to CSV via a toast notification, and adds hover title tooltips to the sidebar open and collapse buttons.

---
*PR created automatically by Jules for task [220604482203502723](https://jules.google.com/task/220604482203502723) started by @rwilliamspbg-ops*