### PR TITLE
ci: build ghost-link aarch64 artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,40 @@ jobs:
       - run: cargo test --release -p ghost-link -p ghostlink-core
       - run: cargo clippy --all-targets -- -D warnings
 
+  rust-aarch64:
+    name: Rust (aarch64) - ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - name: Build ghost-link for ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+        run: cargo build --release --target ${{ matrix.target }} -p ghost-link
+      - name: Upload aarch64 binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghost-link-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/ghost-link
+
   go:
     name: Go (control-plane)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Ghostlink Studio are documented here.
 
 ## [Unreleased]
 
+- **aarch64 CI Artifact Cross-Compilation Workflow**: Added a `rust-aarch64` CI matrix job in `.github/workflows/ci.yml` cross-compiling/building `ghost-link` binaries for `aarch64-unknown-linux-gnu` (on `ubuntu-latest` with `gcc-aarch64-linux-gnu`) and `aarch64-apple-darwin` (on `macos-latest`), uploading `ghost-link-aarch64-unknown-linux-gnu` and `ghost-link-aarch64-apple-darwin` binary artifacts on workflow runs. Updated `scripts/install.sh` non-x86_64 refusal message and `README.md` remaining known gaps to clarify that arm64 CI workflow artifacts exist while release installers remain x86_64 until tagged.
+
 ## [2.2.0] - 2026-09-04
 
 - **`rpc_cluster::compute_tensor_split` weighted capacity heuristic**: CPU-only nodes (0 VRAM) now use system RAM scaled by a conservative `CPU_RAM_HAIRCUT` factor (0.5) to receive a proportional tensor split share, enabling CPU-only peers to take real work when needed to fit models while maintaining GPU preference when discrete VRAM is present.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ the `ghost-link` binary, its checksums, and an SBOM are (see
 [`scripts/release_bundle.sh`](scripts/release_bundle.sh)). The one-line
 install gets you the CLI and OpenAI-compatible API server; for the full
 browser GUI, use the build-from-source or Docker paths below. Release
-binaries are also **x86_64/amd64-only** — there's no arm64 build yet, and
+binaries are also **x86_64/amd64-only** — tagged release installers are x86_64-only
+(though arm64 CI workflow artifacts exist on GitHub Actions workflow runs), and
 both scripts detect and refuse non-x86_64 hosts rather than silently
 handing you a binary that won't run.
 
@@ -625,7 +626,7 @@ To publish: tag v2.2.0 and push; do not claim the GitHub Release exists in this 
 - **Zero-Config Developer Launcher**: One-command setup (`launch.sh` / `launch.bat`) manages builds, services, and the Web GUI with built-in Monaco editor and MCP tools.
 
 ### Remaining Known Gaps
-- **arm64 Prebuilt Release Binaries**: Standalone prebuilt release artifacts are currently provided for x86_64; arm64 hosts (e.g. Apple Silicon, ARM Linux) build from source.
+- **arm64 Prebuilt Release Binaries**: Prebuilt arm64 CI workflow artifacts (`aarch64-unknown-linux-gnu` and `aarch64-apple-darwin`) are built and uploaded on GitHub Actions CI runs; tagged release installer downloads remain x86_64-only for now.
 - **GUI & Control Plane Release Packaging**: Prebuilt binaries package the core Rust engine (`ghost-link`); the Go control plane (`control-plane`) and React GUI (`ghostlink_gui_modern`) run via source/launchers.
 - **RPC Byte Stream Unencrypted**: `rpc_shared_secret` authenticates peer admission at the boundary, but the underlying `ggml-rpc` byte stream itself remains plain TCP without transport-layer encryption.
 - **Usable Multi-Node Speed Unproven**: While cross-machine VRAM capacity splitting is verified, high tokens-per-second throughput on network-bound split layers and zero-touch cluster orchestration across arbitrary networks are still in progress (see [docs/BENCHMARKS.md](docs/BENCHMARKS.md)).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,9 +23,8 @@
 #     ubuntu-latest GitHub Actions runner." There is no distro-specific
 #     testing or guarantee beyond that (e.g. it may not run on musl-based
 #     distros like Alpine).
-#   - Only x86_64/amd64 binaries are published as of this writing -- there is
-#     no separate arm64 build for any OS (check the `os:` matrix in
-#     .github/workflows/release-artifacts.yml if that has since changed).
+#   - Tagged release installers are x86_64/amd64-only (arm64 artifact may
+#     exist on CI; release installers are still x86_64 until tagged).
 #     This script refuses to install on non-x86_64 hosts rather than
 #     silently handing you a binary that won't run.
 #
@@ -76,14 +75,14 @@ case "$os_name" in
 esac
 
 # --- Arch detection ----------------------------------------------------------
-# No arm64/aarch64 build exists for any OS today (single-arch matrix, no
-# cross-compilation step) -- warn clearly and refuse rather than install a
-# binary that will not execute.
+# Tagged release installers are x86_64/amd64-only today (arm64 artifact may
+# exist on CI; release installers are still x86_64 until tagged). Warn clearly
+# and refuse rather than install a binary that will not execute.
 arch_name="$(uname -m)"
 case "$arch_name" in
   x86_64 | amd64) : ;;
   *)
-    die "unsupported architecture '${arch_name}'. Ghostlink release binaries are x86_64/amd64-only as of this writing -- there is no arm64/aarch64 build for Linux, macOS, or Windows (check .github/workflows/release-artifacts.yml's build matrix in case this has changed since). Refusing to install a binary that won't run on this machine. On Apple Silicon you may be able to run the x86_64 binary under Rosetta 2 if you have it installed, or build from source: ${GITHUB}#quick-start"
+    die "unsupported architecture '${arch_name}'. Ghostlink release binaries are x86_64/amd64-only as of this writing (arm64 artifact may exist on CI; release installers are still x86_64 until tagged). Refusing to install a binary that won't run on this machine. On Apple Silicon you may be able to run the x86_64 binary under Rosetta 2 if you have it installed, or build from source: ${GITHUB}#quick-start"
     ;;
 esac
 


### PR DESCRIPTION
### Summary

This PR adds a CI job to build `ghost-link` binaries for `aarch64` architectures and upload them as workflow artifacts.

- **Runners**: `ubuntu-latest` (Linux x86_64 cross-compiling to aarch64) and `macos-latest` (macOS native/cross-compiling to Apple Silicon).
- **Target Triples**:
  - `aarch64-unknown-linux-gnu` (built on `ubuntu-latest` with `gcc-aarch64-linux-gnu` and `g++-aarch64-linux-gnu`)
  - `aarch64-apple-darwin` (built on `macos-latest` with Xcode clang)
- **Artifact Upload**: Artifacts are uploaded via `actions/upload-artifact@v4` with names `ghost-link-aarch64-unknown-linux-gnu` and `ghost-link-aarch64-apple-darwin` located at `target/<target>/release/ghost-link`.
- **`install.sh` Refusal**: Updated `scripts/install.sh` refusal message on non-x86_64 hosts to explicitly inform users: `"arm64 artifact may exist on CI; release installers are still x86_64 until tagged."` without attempting to download non-existent release assets.
- **Documentation**: Updated `README.md` and `CHANGELOG.md` to document arm64 CI workflow artifact availability accurately.

---
*PR created automatically by Jules for task [3866070063149701555](https://jules.google.com/task/3866070063149701555) started by @rwilliamspbg-ops*