### PR TITLE
🎨 Palette: Improve modal dialog accessibility in WorkersTab

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal
 
+## 2026-09-05 - [Modal Dialog ARIA Attributes & Close Button Labels]
+**Learning:** Modal overlay dialogs without explicit `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` fail to communicate dialog boundaries to screen reader users. Additionally, icon-only close triggers (`✕`) require explicit `aria-label="Close dialog"` and `title="Close dialog"` so screen readers and mouse hover tooltips explicitly announce their purpose.
+**Action:** Always annotate custom modal dialog containers with `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`, and ensure icon-only close triggers have explicit ARIA labels and native title attributes.
+
 ## 2026-08-20 - [Chat Sidebar Thread Navigation Accessibility & Focus States]
 **Learning:** Non-semantic click containers (such as non-interactive `div` wrappers used for saved thread items in sidebars) completely lock out keyboard navigators, as default Tab traversal skips them entirely. Refactoring item rows to use semantic `<button>` elements for thread selection—complemented by high-contrast `focus-visible:` focus outlines, explicit `aria-label`s, and `group-focus-within:opacity-100` on secondary action triggers (Pin, Rename, Delete)—guarantees keyboard users can focus and interact with every chat thread and action trigger seamlessly.
 **Action:** Always implement listbox and tree item triggers using semantic `<button>` elements with `focus-visible:` focus rings, explicit ARIA labels, and `group-focus-within` visibility for inline action triggers.

--- a/ghostlink_gui_modern/src/components/WorkersTab.tsx
+++ b/ghostlink_gui_modern/src/components/WorkersTab.tsx
@@ -636,14 +636,21 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
       {/* How to Join Modal */}
       {showHowToJoin && (
         <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-          <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 max-w-lg w-full space-y-6 shadow-2xl">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="how-to-join-title"
+            className="bg-slate-900 border border-slate-800 rounded-3xl p-6 max-w-lg w-full space-y-6 shadow-2xl"
+          >
             <div className="flex items-center justify-between pb-4 border-b border-slate-800">
-              <h3 className="text-base font-bold text-slate-100 flex items-center gap-2">
+              <h3 id="how-to-join-title" className="text-base font-bold text-slate-100 flex items-center gap-2">
                 <Network className="text-blue-400" size={20} />
                 How to join a second machine
               </h3>
               <button
                 onClick={() => setShowHowToJoin(false)}
+                aria-label="Close dialog"
+                title="Close dialog"
                 className="text-slate-400 hover:text-white p-1 rounded-lg focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
               >
                 ✕
@@ -690,10 +697,15 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
       {/* Contribute Warning Modal */}
       {showContributeWarning && (
         <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-          <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 max-w-md w-full space-y-5 shadow-2xl">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="contribute-warning-title"
+            className="bg-slate-900 border border-slate-800 rounded-3xl p-6 max-w-md w-full space-y-5 shadow-2xl"
+          >
             <div className="flex items-center gap-3 text-amber-400">
               <AlertTriangle size={24} />
-              <h3 className="text-base font-bold text-slate-100">LAN Security Warning</h3>
+              <h3 id="contribute-warning-title" className="text-base font-bold text-slate-100">LAN Security Warning</h3>
             </div>
 
             <p className="text-xs text-slate-300 leading-relaxed">
@@ -724,16 +736,21 @@ export const WorkersTab: React.FC<{ api: any }> = ({ api }) => {
         <div className="fixed inset-0 bg-slate-950/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
           <form
             onSubmit={handleAddWorkerSubmit}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="add-worker-title"
             className="bg-slate-900 border border-slate-800 rounded-3xl p-6 max-w-md w-full space-y-5 shadow-2xl"
           >
             <div className="flex items-center justify-between pb-3 border-b border-slate-800">
-              <h3 className="text-base font-bold text-slate-100 flex items-center gap-2">
+              <h3 id="add-worker-title" className="text-base font-bold text-slate-100 flex items-center gap-2">
                 <Plus className="text-blue-400" size={20} />
                 Add Worker Manually
               </h3>
               <button
                 type="button"
                 onClick={() => setShowAddForm(false)}
+                aria-label="Close dialog"
+                title="Close dialog"
                 className="text-slate-400 hover:text-white p-1 rounded-lg focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
               >
                 ✕


### PR DESCRIPTION
💡 What: Added explicit ARIA dialog semantics (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`) and clear `aria-label="Close dialog"` / `title="Close dialog"` attributes to modal containers and close buttons in `WorkersTab.tsx`.

🎯 Why: Custom modal overlays without ARIA metadata fail to establish proper accessibility boundaries for screen readers. Icon-only close buttons (`✕`) lacked descriptive screen-reader labels and hover tooltips.

📸 Screenshots/Media: Visual verification recorded and verified via Playwright screenshot and video.

♿ Accessibility:
- Annotated modal overlays with `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`.
- Added explicit `aria-label="Close dialog"` and `title="Close dialog"` to icon-only `✕` close buttons.

---
*PR created automatically by Jules for task [2353788791116468866](https://jules.google.com/task/2353788791116468866) started by @rwilliamspbg-ops*