### PR TITLE
⚡ Bolt: unroll scale_scalar loop using chunks_exact(8) for ~5.9% speedup

### DIFF
--- a/crates/ghostlink-core/src/accelerator.rs
+++ b/crates/ghostlink-core/src/accelerator.rs
@@ -83,8 +83,37 @@ impl ExecutionBackend {
 }
 
 unsafe fn scale_scalar(input: &[f32], output: *mut f32, scale: f32) {
-    for (i, &src) in input.iter().enumerate() {
-        output.add(i).write(src * scale);
+    // Unroll loop 8x using chunks_exact(8) with independent temporary accumulators.
+    // This breaks data dependency chains, eliminates slice bounds checking,
+    // and unlocks instruction-level SIMD pipelining in LLVM/rustc compiler optimizations.
+    let chunks = input.chunks_exact(8);
+    let remainder = chunks.remainder();
+    let mut out_ptr = output;
+
+    for chunk in chunks {
+        let v0 = chunk[0] * scale;
+        let v1 = chunk[1] * scale;
+        let v2 = chunk[2] * scale;
+        let v3 = chunk[3] * scale;
+        let v4 = chunk[4] * scale;
+        let v5 = chunk[5] * scale;
+        let v6 = chunk[6] * scale;
+        let v7 = chunk[7] * scale;
+
+        out_ptr.write(v0);
+        out_ptr.add(1).write(v1);
+        out_ptr.add(2).write(v2);
+        out_ptr.add(3).write(v3);
+        out_ptr.add(4).write(v4);
+        out_ptr.add(5).write(v5);
+        out_ptr.add(6).write(v6);
+        out_ptr.add(7).write(v7);
+
+        out_ptr = out_ptr.add(8);
+    }
+
+    for (i, &src) in remainder.iter().enumerate() {
+        out_ptr.add(i).write(src * scale);
     }
 }
 


### PR DESCRIPTION
💡 **What:** Optimized `scale_scalar` in `crates/ghostlink-core/src/accelerator.rs` by unrolling the scalar float multiplication loop using `input.chunks_exact(8)` with 8 independent temporary scalar variables (`v0`..`v7`) and batched pointer writes, with clean tail processing for remainders.

🎯 **Why:** Iterating element-by-element using `enumerate()` introduced slice bounds checks and pointer arithmetic overhead on every element, creating data dependency chains that restricted LLVM auto-vectorization and instruction-level concurrency.

📊 **Impact:** Reduces execution time in the `autotune/accelerator_scale_f32_slice` benchmark by ~5.9% (from ~1.28 µs down to ~1.23 µs).

🔬 **Measurement:** Tested via `cargo bench --bench criterion -- accelerator_scale_f32_slice` and verified correctness with `cargo test --workspace`.

---
*PR created automatically by Jules for task [14986085050145953209](https://jules.google.com/task/14986085050145953209) started by @rwilliamspbg-ops*