### PR TITLE
🎨 Palette: enhance Refresh button accessibility and loading state in ModelsTab

### DIFF
--- a/ghostlink_gui_modern/src/components/ModelsTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.test.tsx
@@ -28,6 +28,7 @@ function createMockApi(engine: 'ollama' | 'vllm' | 'native' = 'ollama'): Ghostli
   vi.spyOn(api, 'loadModel').mockResolvedValue({ success: true, data: {} });
   vi.spyOn(api, 'unloadModel').mockResolvedValue({ success: true, data: {} });
   vi.spyOn(api, 'deleteModel').mockResolvedValue({ success: true, data: {} });
+  vi.spyOn(api, 'listPartialDownloads').mockResolvedValue({ partials: [] });
   vi.spyOn(api, 'searchHuggingFace').mockResolvedValue({ models: [{ id: 'test/model', name: 'Test Model', downloads: 1000, likes: 50 }] });
   vi.spyOn(api, 'getRuntimes').mockResolvedValue({
     available_runtimes: [{ runtime: 'cpu', memory_gb: 16, is_primary: true, is_available: true }],
@@ -190,5 +191,34 @@ describe('ModelsTab', () => {
     expect(screen.queryByTitle('Delete from Ollama')).not.toBeInTheDocument();
     expect(screen.queryByTitle('View Modelfile')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Unload' })).not.toBeInTheDocument();
+  });
+
+  it('disables Refresh button and sets aria-busy while loading models', async () => {
+    const api = createMockApi();
+    let resolveGetModels: (val: any) => void;
+    vi.spyOn(api, 'getModels').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGetModels = resolve;
+        })
+    );
+
+    render(<ModelsTab api={api} />);
+
+    const refreshBtn = screen.getByRole('button', { name: /refresh/i });
+    expect(refreshBtn).toBeDisabled();
+    expect(refreshBtn).toHaveAttribute('aria-busy', 'true');
+    expect(refreshBtn).toHaveAttribute('aria-label', 'Refreshing models...');
+
+    resolveGetModels!({
+      models: [],
+      current_model: 'none',
+    });
+
+    await waitFor(() => {
+      expect(refreshBtn).not.toBeDisabled();
+      expect(refreshBtn).toHaveAttribute('aria-busy', 'false');
+      expect(refreshBtn).toHaveAttribute('aria-label', 'Refresh models');
+    });
   });
 });

--- a/ghostlink_gui_modern/src/components/ModelsTab.tsx
+++ b/ghostlink_gui_modern/src/components/ModelsTab.tsx
@@ -572,9 +572,12 @@ export const ModelsTab: React.FC<{ api: GhostlinkAPI }> = ({ api }) => {
           )}
           <button
             onClick={refreshModels}
-            className="flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-blue-600 text-white rounded-xl text-xs font-bold transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none group-hover:shadow-lg group-hover:shadow-blue-500/20"
+            disabled={loading}
+            aria-busy={loading}
+            aria-label={loading ? 'Refreshing models...' : 'Refresh models'}
+            className="flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-blue-600 text-white rounded-xl text-xs font-bold transition disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none group-hover:shadow-lg group-hover:shadow-blue-500/20"
           >
-            <RefreshCw size={16} aria-hidden="true" /> Refresh
+            <RefreshCw size={16} className={loading ? 'animate-spin' : ''} aria-hidden="true" /> Refresh
           </button>
         </div>
       </div>


### PR DESCRIPTION
Enhances the Refresh models button in `ModelsTab.tsx` with active loading feedback, dynamic ARIA labels, aria-busy status, icon spin animation, disabled states, and corresponding unit test coverage.

---
*PR created automatically by Jules for task [15622497386789590391](https://jules.google.com/task/15622497386789590391) started by @rwilliamspbg-ops*