### PR TITLE
🎨 Palette: Add accessible loading states to Refresh sessions button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-09-06 - Link Form Descriptions and Warnings via `aria-describedby`
 **Learning:** Screen reader users navigating through complex settings forms via Tab focus do not automatically hear field descriptions or inline warning banners unless the input elements explicitly reference them using `aria-describedby` and `aria-labelledby`.
 **Action:** In multi-field form components with helper text, generate deterministic IDs (e.g. `${fieldId}-desc`, `${fieldId}-warning`) and attach `aria-describedby` to `input`, `select`, and `radiogroup` containers.
+
+## 2026-09-06 - Actionable Loading States on Icon-Only Async Buttons
+**Learning:** Icon-only action buttons triggering asynchronous state updates (such as Refresh controls) need explicit `disabled={loading}` and `aria-busy={loading}` along with dynamic `aria-label` updates (`Refreshing...` vs `Refresh...`) to communicate status to screen readers and prevent accidental duplicate network requests.
+**Action:** Always combine visual spinner animations on icon-only refresh buttons with `disabled={loading}`, `aria-busy={loading}`, `disabled:opacity-50`, and a dynamic `aria-label`.

--- a/ghostlink_gui_modern/src/components/SessionsTab.test.tsx
+++ b/ghostlink_gui_modern/src/components/SessionsTab.test.tsx
@@ -41,9 +41,11 @@ describe('SessionsTab', () => {
       expect(screen.getByText('mistral-7b')).toBeInTheDocument();
     });
 
-    // Check tooltip/title on Refresh button
+    // Check tooltip/title and accessibility on Refresh button
     const refreshBtn = screen.getByRole('button', { name: /refresh sessions/i });
     expect(refreshBtn).toHaveAttribute('title', 'Refresh sessions');
+    expect(refreshBtn).not.toBeDisabled();
+    expect(refreshBtn).toHaveAttribute('aria-busy', 'false');
 
     // Check tooltip/title on Cancel session buttons
     const cancelBtn1 = screen.getByRole('button', { name: /cancel session session-1/i });
@@ -133,5 +135,28 @@ describe('SessionsTab', () => {
     fireEvent.click(screen.getByRole('button', { name: /delete saved session saved-1/i }));
 
     await waitFor(() => expect(api.deleteSession).toHaveBeenCalledWith('saved-1'));
+  });
+
+  it('shows loading state and disables refresh button during refresh', async () => {
+    let resolveGetSessions: (val: any) => void = () => {};
+    const pendingPromise = new Promise((resolve) => {
+      resolveGetSessions = resolve;
+    });
+
+    const api = {
+      getSessions: vi.fn().mockImplementation(() => pendingPromise),
+    };
+
+    render(<SessionsTab api={api} />);
+
+    const refreshBtn = screen.getByRole('button', { name: /refreshing sessions\.\.\./i });
+    expect(refreshBtn).toBeDisabled();
+    expect(refreshBtn).toHaveAttribute('aria-busy', 'true');
+
+    resolveGetSessions({ sessions: [] });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /refresh sessions/i })).not.toBeDisabled();
+    });
   });
 });

--- a/ghostlink_gui_modern/src/components/SessionsTab.tsx
+++ b/ghostlink_gui_modern/src/components/SessionsTab.tsx
@@ -86,9 +86,11 @@ export const SessionsTab: React.FC<{ api: any }> = ({ api }) => {
         <h2 className="text-xl font-bold text-white">Active Sessions</h2>
         <button
           onClick={refreshSessions}
-          aria-label="Refresh sessions"
+          disabled={loading}
+          aria-busy={loading}
+          aria-label={loading ? 'Refreshing sessions...' : 'Refresh sessions'}
           title="Refresh sessions"
-          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+          className="p-2 rounded-lg hover:bg-slate-900 text-slate-400 hover:text-white transition disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
         >
           <RefreshCw size={18} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
         </button>


### PR DESCRIPTION
This PR improves accessibility and loading feedback on the Refresh sessions button in `SessionsTab.tsx`.

💡 **What:** Added `disabled={loading}`, `aria-busy={loading}`, `disabled:opacity-50`, and a dynamic `aria-label` ('Refreshing sessions...' vs 'Refresh sessions') to the Refresh sessions button.
🎯 **Why:** Prevents duplicate network requests during slow fetches and provides explicit screen reader announcements during async session loading.
♿ **Accessibility:** Screen readers are informed when session refreshing is in progress, and the button cannot be accidentally re-triggered while loading.

---
*PR created automatically by Jules for task [9889024859649319257](https://jules.google.com/task/9889024859649319257) started by @rwilliamspbg-ops*